### PR TITLE
Simplify imports for test

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
       "^.+\\.tsx?$": "ts-jest"
     },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
+    "moduleDirectories": [
+      "node_modules",
+      "src"
+    ],
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/test/components/DepositWidget.components.test.tsx
+++ b/test/components/DepositWidget.components.test.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import { render } from 'enzyme'
 
-import { Row } from '../../src/components/DepositWidget/Row'
-import { TokenBalanceDetails } from '../../src/types'
+import { TokenBalanceDetails } from 'types'
+import { Row } from 'components/DepositWidget/Row'
 
 describe('<Row /> with deposit and withdraw', () => {
   const tokenBalanceDetails: TokenBalanceDetails = {

--- a/test/components/DepositWidget.functions.test.ts
+++ b/test/components/DepositWidget.functions.test.ts
@@ -1,4 +1,4 @@
-import { getButtonText, ButtonTypes } from '../../src/components/DepositWidget/Row'
+import { getButtonText, ButtonTypes } from 'components/DepositWidget/Row'
 
 describe('Get text for buttons', () => {
   test('Deposit', () => {


### PR DESCRIPTION
- [X] Allows Jest to resolve dependencies relative to the `src` dir (same as web) so you don't need to provide always the relative path
- [X] Use absolute path for importing components in tests:

![image](https://user-images.githubusercontent.com/2352112/64791673-588df180-d578-11e9-83e2-10a63ca2ddea.png)

*Test:*
```bash
yarn test
```