### PR TITLE
Connect/Disconnect wallet and provide Wallet info

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import 'types'
 import { hot } from 'react-hot-loader/root'
 import React from 'react'
 import GlobalStyles from './components/layout/GlobalStyles'
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
+import { BrowserRouter as Router, Route, Switch, RouteProps, Redirect } from 'react-router-dom'
 
 // Toast notifications
 import { toast } from 'react-toastify'
@@ -18,6 +18,31 @@ import Deposit from 'pages/Deposit'
 import Trade from 'pages/Trade'
 import SourceCode from 'pages/SourceCode'
 import NotFound from 'pages/NotFound'
+import ConnectWallet from 'pages/ConnectWallet'
+import { walletApi } from 'api'
+
+const PrivateRoute: React.FC<RouteProps> = (props: RouteProps) => {
+  const isConnected = walletApi.isConnected()
+
+  const { component: Component, ...rest } = props
+  return (
+    <Route
+      {...rest}
+      render={(props: any): React.ReactNode =>
+        isConnected ? (
+          <Component {...props} />
+        ) : (
+          <Redirect
+            to={{
+              pathname: '/connect-wallet',
+              state: { from: props.location },
+            }}
+          />
+        )
+      }
+    />
+  )
+}
 
 toast.configure({ position: toast.POSITION.BOTTOM_RIGHT, closeOnClick: false })
 
@@ -30,8 +55,9 @@ const App: React.FC = () => (
         <Switch>
           <Route path="/" exact component={Trade} />
           <Route path="/about" exact component={About} />
-          <Route path="/deposit" exact component={Deposit} />
+          <PrivateRoute path="/deposit" exact component={Deposit} />
           <Route path="/source-code" exact component={SourceCode} />
+          <Route path="/connect-wallet" exact component={ConnectWallet} />
           <Route component={NotFound} />
         </Switch>
       </Layout>

--- a/src/api/wallet/WalletApiMock.ts
+++ b/src/api/wallet/WalletApiMock.ts
@@ -1,4 +1,4 @@
-import { WalletApi, Network } from 'types'
+import { WalletApi, Network, WalletInfo } from 'types'
 import BN from 'bn.js'
 import assert from 'assert'
 
@@ -11,22 +11,24 @@ import { USER_1 } from '../../../test/data'
 export class WalletApiMock implements WalletApi {
   private _connected = false
   private _balance = toWei(new BN(2.75), 'ether')
+  private _listeners: ((walletInfo: WalletInfo) => void)[] = []
 
   public isConnected(): boolean {
     return this._connected
   }
 
   public async connect(): Promise<void> {
-    // TODO: Uncomment after doing login
-    // await wait()
+    await wait(500)
     this._connected = true
     log('[WalletApiMock] Connected')
+    await this._notifyListeners()
   }
 
   public async disconnect(): Promise<void> {
-    await wait()
+    await wait(500)
     this._connected = false
     log('[WalletApiMock] Disconnected')
+    await this._notifyListeners()
   }
 
   public async getAddress(): Promise<string> {
@@ -45,6 +47,23 @@ export class WalletApiMock implements WalletApi {
     assert(this._connected, 'The wallet is not connected')
 
     return Network.Rinkeby
+  }
+
+  public addOnChangeWalletInfo(callback: (walletInfo: WalletInfo) => void): void {
+    this._listeners.push(callback)
+  }
+
+  public removeOnChangeWalletInfo(callback: (walletInfo: WalletInfo) => void): void {
+    this._listeners = this._listeners.filter(c => c !== callback)
+  }
+
+  private async _notifyListeners(): Promise<void> {
+    const walletInfo: WalletInfo = {
+      isConnected: this._connected,
+      userAddress: this._connected ? await this.getAddress() : undefined,
+      networkId: this._connected ? await this.getNetworkId() : undefined,
+    }
+    this._listeners.forEach(listener => listener(walletInfo))
   }
 }
 

--- a/src/api/wallet/WalletApiMock.ts
+++ b/src/api/wallet/WalletApiMock.ts
@@ -60,7 +60,6 @@ export class WalletApiMock implements WalletApi {
 
   public removeOnChangeWalletInfo(callback: (walletInfo: WalletInfo) => void): void {
     this._listeners = this._listeners.filter(c => c !== callback)
-    console.log('removeOnChangeWalletInfo', this._listeners.length)
   }
 
   private _getWalletInfo(): WalletInfo {

--- a/src/api/wallet/WalletApiMock.ts
+++ b/src/api/wallet/WalletApiMock.ts
@@ -70,7 +70,7 @@ export class WalletApiMock implements WalletApi {
     }
   }
 
-  private async _notifyListeners(): Promise<void> {
+  private _notifyListeners(): void {
     const walletInfo: WalletInfo = this._getWalletInfo()
     this._listeners.forEach(listener => listener(walletInfo))
   }

--- a/src/api/wallet/WalletApiMock.ts
+++ b/src/api/wallet/WalletApiMock.ts
@@ -1,9 +1,11 @@
-import { WalletApi, Network, WalletInfo } from 'types'
+import { WalletApi, Network, WalletInfo, Command } from 'types'
 import BN from 'bn.js'
 import assert from 'assert'
 
 import { log, wait, toWei } from 'utils'
 import { USER_1 } from '../../../test/data'
+
+type OnChangeWalletInfo = (walletInfo: WalletInfo) => void
 
 /**
  * Basic implementation of Wallet API
@@ -51,14 +53,16 @@ export class WalletApiMock implements WalletApi {
     return this._networkId
   }
 
-  public addOnChangeWalletInfo(callback: (walletInfo: WalletInfo) => void, trigger?: boolean): void {
+  public addOnChangeWalletInfo(callback: OnChangeWalletInfo, trigger?: boolean): Command {
     this._listeners.push(callback)
     if (trigger) {
       callback(this._getWalletInfo())
     }
+
+    return (): void => this.removeOnChangeWalletInfo(callback)
   }
 
-  public removeOnChangeWalletInfo(callback: (walletInfo: WalletInfo) => void): void {
+  public removeOnChangeWalletInfo(callback: OnChangeWalletInfo): void {
     this._listeners = this._listeners.filter(c => c !== callback)
   }
 

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -60,8 +60,7 @@ const Wrapper = styled.section`
 const DepositWidget: React.FC = () => {
   const { balances, error } = useTokenBalances()
   const contractAddress = depositApi.getContractAddress()
-
-  if (!balances) {
+  if (balances === undefined) {
     // Loading: Do not show the widget
     return <></>
   }

--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -6,25 +6,13 @@ import { toast } from 'react-toastify'
 
 import { walletApi } from 'api'
 import { useWalletConnection } from 'hooks/useWalletConnection'
+import { withRouter, RouteComponentProps } from 'react-router'
 
-const Wrapper = styled.a`
-  padding: 1rem;
-  margin: 1rem;
-  border: 2px solid #ff5097;
-  color: #ff5097;
-  vertical-align: middle;
-  text-decoration: none;
-  min-width: 16em;
-  text-align: center;
+interface WalletProps extends RouteComponentProps {
+  className: string
+}
 
-  &:hover {
-    color: white;
-    border-color: white;
-    cursor: pointer;
-  }
-`
-
-const Wallet: React.FC = () => {
+const Wallet: React.FC<RouteComponentProps> = (props: WalletProps) => {
   const { isConnected, userAddress } = useWalletConnection()
   const [loadingLabel, setLoadingLabel] = useState()
 
@@ -49,25 +37,52 @@ const Wallet: React.FC = () => {
       toast.error('Error disconnecting wallet')
     } finally {
       setLoadingLabel(undefined)
+      props.history.push('/')
     }
   }
 
+  let onClick, content
   if (loadingLabel) {
-    return (
-      <Wrapper>
+    content = (
+      <>
         <FontAwesomeIcon icon={faSpinner} />
         {' ' + loadingLabel}
-      </Wrapper>
+      </>
+    )
+  } else if (isConnected) {
+    onClick = disconnectWallet
+    content = (
+      <>
+        {userAddress.substr(0, 9)}...{userAddress.substr(35, userAddress.length)} &nbsp;<small>(disconnect)</small>
+      </>
     )
   } else {
-    return isConnected ? (
-      <Wrapper onClick={disconnectWallet}>
-        {userAddress.substr(0, 9)}...{userAddress.substr(35, userAddress.length)} &nbsp;<small>(disconnect)</small>
-      </Wrapper>
-    ) : (
-      <Wrapper onClick={connectWallet}>Connect to Wallet</Wrapper>
-    )
+    onClick = connectWallet
+    content = <>Connect to Wallet</>
   }
+
+  return (
+    <a onClick={onClick} className={props.className}>
+      {content}
+    </a>
+  )
 }
 
-export default Wallet
+export default styled(withRouter(Wallet))`
+  padding: 1rem;
+  margin: 1rem;
+  border: 2px solid #ff5097;
+  color: #ff5097;
+  vertical-align: middle;
+  text-decoration: none;
+  min-width: 16em;
+  text-align: center;
+
+  &:hover {
+    color: #ff5097;
+  }
+
+  &:hover {
+    background-color: #ffe3ee;
+  }
+`

--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
+import { walletApi } from 'api'
 
 const Wrapper = styled.a`
   padding: 1rem;
@@ -14,14 +15,21 @@ const Wrapper = styled.a`
     cursor: pointer;
   }
 `
-function connectWallet(): void {
-  alert('TODO: Connect to Wallet')
-}
 
-const Wallet: React.FC = () => (
-  <Wrapper className="connect-wallet" onClick={connectWallet}>
-    Connect to Wallet
-  </Wrapper>
-)
+const Wallet: React.FC = () => {
+  const [connected, setIsConnected] = useState(walletApi.isConnected())
+
+  const connectWallet = async (): Promise<void> => {
+    try {
+      console.log('[Wallet] Connect')
+      await walletApi.connect()
+      setIsConnected(true)
+    } catch (error) {
+      console.log('Login error', error)
+    }
+  }
+
+  return connected ? <span>Connected!</span> : <Wrapper onClick={connectWallet}>Connect to Wallet</Wrapper>
+}
 
 export default Wallet

--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -58,7 +58,7 @@ const Wallet: React.FC<RouteComponentProps> = (props: WalletProps) => {
     )
   } else {
     onClick = connectWallet
-    content = <>Connect to Wallet</>
+    content = 'Connect to Wallet'
   }
 
   return (

--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import { walletApi } from 'api'
+import { useWalletConnection } from 'hooks/useWalletConnection'
 
 const Wrapper = styled.a`
   padding: 1rem;
@@ -17,13 +18,12 @@ const Wrapper = styled.a`
 `
 
 const Wallet: React.FC = () => {
-  const [connected, setIsConnected] = useState(walletApi.isConnected())
+  const { walletInfo } = useWalletConnection()
 
   const connectWallet = async (): Promise<void> => {
     try {
       console.log('[Wallet] Connect')
       await walletApi.connect()
-      setIsConnected(true)
     } catch (error) {
       // TODO: Handle error
       console.log('Connect Wallet error', error)
@@ -34,16 +34,15 @@ const Wallet: React.FC = () => {
     try {
       console.log('[Wallet] Disconnect')
       await walletApi.disconnect()
-      setIsConnected(false)
     } catch (error) {
       // TODO: Handle error
       console.log('Disconnect Wallet error', error)
     }
   }
 
-  return connected ? (
+  return walletInfo.isConnected ? (
     <Wrapper onClick={disconnectWallet}>
-      Connected!&nbsp;<small>(disconnect)</small>
+      {walletInfo.userAddress}!&nbsp;<small>(disconnect)</small>
     </Wrapper>
   ) : (
     <Wrapper onClick={connectWallet}>Connect to Wallet</Wrapper>

--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -25,11 +25,29 @@ const Wallet: React.FC = () => {
       await walletApi.connect()
       setIsConnected(true)
     } catch (error) {
-      console.log('Login error', error)
+      // TODO: Handle error
+      console.log('Connect Wallet error', error)
     }
   }
 
-  return connected ? <span>Connected!</span> : <Wrapper onClick={connectWallet}>Connect to Wallet</Wrapper>
+  const disconnectWallet = async (): Promise<void> => {
+    try {
+      console.log('[Wallet] Disconnect')
+      await walletApi.disconnect()
+      setIsConnected(false)
+    } catch (error) {
+      // TODO: Handle error
+      console.log('Disconnect Wallet error', error)
+    }
+  }
+
+  return connected ? (
+    <Wrapper onClick={disconnectWallet}>
+      Connected!&nbsp;<small>(disconnect)</small>
+    </Wrapper>
+  ) : (
+    <Wrapper onClick={connectWallet}>Connect to Wallet</Wrapper>
+  )
 }
 
 export default Wallet

--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -7,6 +7,7 @@ import { toast } from 'react-toastify'
 import { walletApi } from 'api'
 import { useWalletConnection } from 'hooks/useWalletConnection'
 import { withRouter, RouteComponentProps } from 'react-router'
+import { abbreviateString } from 'utils'
 
 interface WalletProps extends RouteComponentProps {
   className: string
@@ -53,7 +54,7 @@ const Wallet: React.FC<RouteComponentProps> = (props: WalletProps) => {
     onClick = disconnectWallet
     content = (
       <>
-        {userAddress.substr(0, 9)}...{userAddress.substr(35, userAddress.length)} &nbsp;<small>(disconnect)</small>
+        {abbreviateString(userAddress, 10, 5)} &nbsp;<small>(disconnect)</small>
       </>
     )
   } else {

--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const Wrapper = styled.a`
+  padding: 1rem;
+  margin: 1rem;
+  border: 2px solid #ff5097;
+  color: #ff5097;
+  vertical-align: middle;
+
+  &:hover {
+    color: white;
+    border-color: white;
+    cursor: pointer;
+  }
+`
+function connectWallet(): void {
+  alert('TODO: Connect to Wallet')
+}
+
+const Wallet: React.FC = () => (
+  <Wrapper className="connect-wallet" onClick={connectWallet}>
+    Connect to Wallet
+  </Wrapper>
+)
+
+export default Wallet

--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -1,5 +1,9 @@
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faSpinner } from '@fortawesome/free-solid-svg-icons'
+import { toast } from 'react-toastify'
+
 import { walletApi } from 'api'
 import { useWalletConnection } from 'hooks/useWalletConnection'
 
@@ -9,6 +13,9 @@ const Wrapper = styled.a`
   border: 2px solid #ff5097;
   color: #ff5097;
   vertical-align: middle;
+  text-decoration: none;
+  min-width: 16em;
+  text-align: center;
 
   &:hover {
     color: white;
@@ -18,35 +25,49 @@ const Wrapper = styled.a`
 `
 
 const Wallet: React.FC = () => {
-  const { walletInfo } = useWalletConnection()
+  const { isConnected, userAddress } = useWalletConnection()
+  const [loadingLabel, setLoadingLabel] = useState()
 
   const connectWallet = async (): Promise<void> => {
     try {
-      console.log('[Wallet] Connect')
+      setLoadingLabel('Connecting...')
       await walletApi.connect()
+      toast.success('Wallet connected')
     } catch (error) {
-      // TODO: Handle error
-      console.log('Connect Wallet error', error)
+      toast.error('Error connecting wallet')
+    } finally {
+      setLoadingLabel(undefined)
     }
   }
 
   const disconnectWallet = async (): Promise<void> => {
     try {
-      console.log('[Wallet] Disconnect')
+      setLoadingLabel('Disconnecting...')
       await walletApi.disconnect()
+      toast.info('Wallet disconnected')
     } catch (error) {
-      // TODO: Handle error
-      console.log('Disconnect Wallet error', error)
+      toast.error('Error disconnecting wallet')
+    } finally {
+      setLoadingLabel(undefined)
     }
   }
 
-  return walletInfo.isConnected ? (
-    <Wrapper onClick={disconnectWallet}>
-      {walletInfo.userAddress}!&nbsp;<small>(disconnect)</small>
-    </Wrapper>
-  ) : (
-    <Wrapper onClick={connectWallet}>Connect to Wallet</Wrapper>
-  )
+  if (loadingLabel) {
+    return (
+      <Wrapper>
+        <FontAwesomeIcon icon={faSpinner} />
+        {' ' + loadingLabel}
+      </Wrapper>
+    )
+  } else {
+    return isConnected ? (
+      <Wrapper onClick={disconnectWallet}>
+        {userAddress.substr(0, 9)}...{userAddress.substr(35, userAddress.length)} &nbsp;<small>(disconnect)</small>
+      </Wrapper>
+    ) : (
+      <Wrapper onClick={connectWallet}>Connect to Wallet</Wrapper>
+    )
+  }
 }
 
 export default Wallet

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -36,16 +36,13 @@ const Wrapper = styled.header`
     border: 2px solid #ff5097;
     color: #ff5097;
     vertical-align: middle;
+    font-size: 1.2em;
 
     &:hover {
       color: white;
       border-color: white;
       cursor: pointer;
     }
-  }
-
-  .logo {
-    font-size: 1.2em;
   }
 
   .header-title {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -62,6 +62,15 @@ const Wrapper = styled.header`
     margin-top: 0;
     color: #e0aacf;
   }
+
+  a${Wallet} {
+    &:hover {
+      color: white;
+      border-color: white;
+      cursor: pointer;
+      background-color: inherit;
+    }
+  }
 `
 
 const Header: React.FC = () => (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { rem } from 'polished'
 import { Link } from 'react-router-dom'
+import Wallet from 'components/Wallet'
 
 const Wrapper = styled.header`
   color: #ffffff;
@@ -29,8 +30,7 @@ const Wrapper = styled.header`
     }
   }
 
-  .logo,
-  .connect-wallet {
+  .logo {
     padding: 1rem;
     margin: 1rem;
     border: 2px solid #ff5097;
@@ -64,10 +64,6 @@ const Wrapper = styled.header`
   }
 `
 
-function connectWallet(): void {
-  alert('TODO: Connect to Wallet')
-}
-
 const Header: React.FC = () => (
   <Wrapper>
     <nav>
@@ -82,9 +78,7 @@ const Header: React.FC = () => (
           <Link to="/deposit">Deposit</Link>
         </li>
       </ul>
-      <a className="connect-wallet" onClick={connectWallet}>
-        Connect to Wallet
-      </a>
+      <Wallet />
     </nav>
     <div className="header-title">
       <h1>Swap stable coins</h1>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -63,7 +63,7 @@ const Wrapper = styled.header`
     color: #e0aacf;
   }
 
-  a${Wallet} {
+  ${Wallet} {
     &:hover {
       color: white;
       border-color: white;

--- a/src/hooks/useEnableToken.ts
+++ b/src/hooks/useEnableToken.ts
@@ -33,9 +33,10 @@ export const useEnableTokens = (params: Params): Result => {
     assert(!enabled, 'The token was already enabled')
 
     setEnabling(true)
+
     // TODO: Review after implementing connect wallet.
     //   Probably some APIs should have an implicit user and it should be login aware
-    walletApi.connect()
+    // walletApi.connect()
 
     // Set the allowance
     const userAddress = await walletApi.getAddress()

--- a/src/hooks/useTokenBalances.ts
+++ b/src/hooks/useTokenBalances.ts
@@ -46,7 +46,7 @@ async function fetchBalancesForToken(
 
 async function _getBalances(): Promise<TokenBalanceDetails[]> {
   // TODO: Remove connect once login is done
-  await walletApi.connect()
+  // await walletApi.connect()
 
   const [userAddress, networkId] = await Promise.all([walletApi.getAddress(), walletApi.getNetworkId()])
   const contractAddress = depositApi.getContractAddress()
@@ -66,7 +66,7 @@ export const useTokenBalances = (): UseTokenBalanceResult => {
       .then(balances => setBalances(balances))
       .catch(error => {
         console.error('Error loading balances', error)
-        setError(error)
+        setError(true)
       })
 
     return function cleanUp(): void {

--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -1,16 +1,12 @@
 import { walletApi } from 'api'
 import { useState, useEffect } from 'react'
-import { WalletInfo } from 'types'
+import { WalletInfo, Command } from 'types'
 
 export const useWalletConnection = (): WalletInfo => {
   const [walletInfo, setWalletInfo] = useState<WalletInfo>({ isConnected: false })
 
-  useEffect((): (() => void) => {
-    walletApi.addOnChangeWalletInfo(setWalletInfo, true)
-
-    return function cleanup(): void {
-      walletApi.removeOnChangeWalletInfo(setWalletInfo)
-    }
+  useEffect((): Command => {
+    return walletApi.addOnChangeWalletInfo(setWalletInfo, true)
   }, [])
   return walletInfo
 }

--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -1,0 +1,16 @@
+import { walletApi } from 'api'
+import { useState, useEffect } from 'react'
+import { WalletInfo } from 'types'
+
+export const useWalletConnection = (): WalletInfo => {
+  const [walletInfo, setWalletInfo] = useState<WalletInfo>({ isConnected: false })
+
+  useEffect((): (() => void) => {
+    walletApi.addOnChangeWalletInfo(setWalletInfo, true)
+
+    return function cleanup(): void {
+      walletApi.removeOnChangeWalletInfo(setWalletInfo)
+    }
+  }, [])
+  return walletInfo
+}

--- a/src/pages/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faWallet } from '@fortawesome/free-solid-svg-icons'
+
+import Wallet from 'components/Wallet'
+import { useWalletConnection } from 'hooks/useWalletConnection'
+import { Redirect } from 'react-router'
+import { History } from 'history'
+import styled from 'styled-components'
+
+type ConnectWalletProps = History<{ from: string }>
+const Wrapper = styled.div`
+  text-align: center;
+  p {
+    padding: 0.85em;
+    color: var(--color-text-secondary);
+  }
+`
+
+const IconWallet = styled(FontAwesomeIcon)`
+  color: #a882d8;
+`
+
+const ConnectWallet: React.FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
+  const { from } = props.location.state || { from: { pathname: '/' } }
+  const { isConnected } = useWalletConnection()
+  if (isConnected) {
+    return <Redirect to={from} />
+  }
+
+  return (
+    <Wrapper className="widget">
+      <IconWallet icon={faWallet} size="6x" />
+      <h1>Connect Wallet</h1>
+      <p>Please connect your wallet first</p>
+      <Wallet />
+    </Wrapper>
+  )
+}
+
+export default ConnectWallet

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ import BN from 'bn.js'
 
 import 'global'
 
+export type Command = () => void
+
 export enum Network {
   Mainnet = 1,
   Rinkeby = 4,
@@ -95,7 +97,7 @@ export interface WalletApi {
   getAddress(): Promise<string>
   getBalance(): Promise<BN>
   getNetworkId(): Promise<number>
-  addOnChangeWalletInfo(callback: (walletInfo: WalletInfo) => void, trigger?: boolean): void
+  addOnChangeWalletInfo(callback: (walletInfo: WalletInfo) => void, trigger?: boolean): Command
   removeOnChangeWalletInfo(callback: (walletInfo: WalletInfo) => void): void
 }
 
@@ -125,5 +127,3 @@ export interface Erc20Api {
     txOptionalParams?: TxOptionalParams,
   ): Promise<TxResult<boolean>>
 }
-
-export type Command = (x: void) => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,3 +125,5 @@ export interface Erc20Api {
     txOptionalParams?: TxOptionalParams,
   ): Promise<TxResult<boolean>>
 }
+
+export type Command = (x: void) => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,12 @@ export interface DepositApi {
   withdraw(userAddress: string, tokenAddress: string, txOptionalParams?: TxOptionalParams): Promise<TxResult<void>>
 }
 
+export interface WalletInfo {
+  isConnected: boolean
+  userAddress?: string
+  networkId?: number
+}
+
 export interface WalletApi {
   isConnected(): boolean
   connect(): Promise<void>
@@ -89,6 +95,8 @@ export interface WalletApi {
   getAddress(): Promise<string>
   getBalance(): Promise<BN>
   getNetworkId(): Promise<number>
+  addOnChangeWalletInfo(callback: (walletInfo: WalletInfo) => void): void
+  removeOnChangeWalletInfo(callback: (walletInfo: WalletInfo) => void): void
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,7 +95,7 @@ export interface WalletApi {
   getAddress(): Promise<string>
   getBalance(): Promise<BN>
   getNetworkId(): Promise<number>
-  addOnChangeWalletInfo(callback: (walletInfo: WalletInfo) => void): void
+  addOnChangeWalletInfo(callback: (walletInfo: WalletInfo) => void, trigger?: boolean): void
   removeOnChangeWalletInfo(callback: (walletInfo: WalletInfo) => void): void
 }
 


### PR DESCRIPTION
This PR allows to connect and disconnect a wallet, provides a simple hook with the wallet information, and allows to protect pages that require a connected wallet.

Apologies cause the PR is a big bigger than expected. All the changes are related, I hope that with the explanations it's a bit clear all the changes involved.

Includes:
- [X] Provides a hook that can be easily used to received the connected wallet info and keep the components updated on every wallet change: `useWalletConnection.tsx`
- [X] subscribe/desubscribe functions in WalletApi to notify any change in the wallet information
- [X] Extracted and createad a component our of the "Connect Wallet" button from the Header. It's called `Wallet.tsx`
- [X] The `Wallet` detects if the user is connected or not and depending on that, it will:
  * [X] Show "Connect Wallet" button that triggers the connect attempt
  * [X] Show uses address and a "Disconnect Wallet" button that triggers the disconnect attempt
- [X] When the user is connecting/disconnecting it shows a loading state and the right label in the button
- [X] `ConnectWallet.tsx`: New page that will ask you to connect. It would be the equivalent to a login page.
- [X] Define `PrivateRoute` for protecting the pages that require a connected wallet. This way the deposit page can assume there's a connected wallet and doesn't need to add any validation. For the trade page, the approach will be different since we ask the user to connect only when the user tries to trade.

**Out of the scope of the PR**
- It doesn't style a lot the wallet information (#89 )
- It doesn't implement the Web3 implementation. Only connects using the mock. (#81 )
- It doesn't remove the `TODOS` in the paces where there was a `// TODO: Review after implementing connect wallet.` because this will be handled in a separate PR (#105)
- I think it's convenient to do a autoconnect for the mock implementation, so we don't need to connect for quick testing and on every reload. This will be handled in a separate PR too (#93 )

**Test**
- https://pr83--dexreact.review.gnosisdev.com
