### PR TITLE
Change check for enabled tokens

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -7,7 +7,9 @@ export const TWO = new BN(2)
 export const TEN = new BN(10)
 
 // Max allowance value for ERC20 approve
-export const ALLOWANCE_VALUE = new BN(2).pow(new BN(256)).sub(ONE) // 115792089237316195423570985008687907853269984665640564039457584007913129639935
+export const ALLOWANCE_MAX_VALUE = new BN(2).pow(new BN(256)).sub(ONE) // 115792089237316195423570985008687907853269984665640564039457584007913129639935
+// Arbitrarily big number for checking if the token is enabled
+export const ALLOWANCE_FOR_ENABLED_TOKEN = new BN(2).pow(new BN(128)) // 340282366920938463463374607431768211456
 
 // Model constants
 export const FEE_DENOMINATOR = 1000 // Fee is 1/fee_denominator i.e. 1/1000 = 0.1%

--- a/src/hooks/useEnableToken.ts
+++ b/src/hooks/useEnableToken.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { erc20Api, depositApi, walletApi } from 'api'
 import { TokenBalanceDetails, TxOptionalParams, TxResult } from 'types'
-import { ALLOWANCE_VALUE } from 'const'
+import { ALLOWANCE_MAX_VALUE } from 'const'
 import assert from 'assert'
 
 interface Params {
@@ -43,7 +43,7 @@ export const useEnableTokens = (params: Params): Result => {
       tokenAddress,
       userAddress,
       contractAddress,
-      ALLOWANCE_VALUE,
+      ALLOWANCE_MAX_VALUE,
       params.txOptionalParams,
     )
 

--- a/src/hooks/useTokenBalances.ts
+++ b/src/hooks/useTokenBalances.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { TokenBalanceDetails, TokenDetails } from 'types'
 import { tokenListApi, walletApi, erc20Api, depositApi } from 'api'
-import { ALLOWANCE_VALUE } from 'const'
+import { ALLOWANCE_FOR_ENABLED_TOKEN } from 'const'
 
 interface UseTokenBalanceResult {
   balances: TokenBalanceDetails[] | undefined
@@ -40,7 +40,7 @@ async function fetchBalancesForToken(
     withdrawingBalance,
     withdrawable: withdrawingBalance.isZero() ? false : withdrawBatchId < currentBachId,
     walletBalance,
-    enabled: allowance.eq(ALLOWANCE_VALUE),
+    enabled: allowance.gt(ALLOWANCE_FOR_ENABLED_TOKEN),
   }
 }
 

--- a/test/data/erc20Allowances.ts
+++ b/test/data/erc20Allowances.ts
@@ -1,4 +1,4 @@
-import { ZERO, ALLOWANCE_VALUE } from 'const'
+import { ZERO, ALLOWANCE_MAX_VALUE } from 'const'
 import { USER_1, TOKEN_1, CONTRACT, TOKEN_2, TOKEN_3, TOKEN_4, TOKEN_5, TOKEN_6, TOKEN_7 } from './basic'
 import BN from 'bn.js'
 
@@ -11,7 +11,7 @@ export default {
       [CONTRACT]: new BN('500000'), // 0.5, USDT: decimals=6
     },
     [TOKEN_3]: {
-      [CONTRACT]: ALLOWANCE_VALUE, // MAX, TUSD: decimals=18
+      [CONTRACT]: ALLOWANCE_MAX_VALUE, // MAX, TUSD: decimals=18
     },
     [TOKEN_4]: {
       [CONTRACT]: new BN('1000000'), // 1, USDC: decimals=6
@@ -20,7 +20,7 @@ export default {
       [CONTRACT]: new BN('1000000000000000000'), // 1, PAX: decimals=18
     },
     [TOKEN_6]: {
-      [CONTRACT]: ALLOWANCE_VALUE, // MAX, GUSD: decimals=2
+      [CONTRACT]: ALLOWANCE_MAX_VALUE, // MAX, GUSD: decimals=2
     },
     [TOKEN_7]: {
       [CONTRACT]: ZERO, // 0, DAI: decimals=18

--- a/test/data/erc20Balances.ts
+++ b/test/data/erc20Balances.ts
@@ -1,5 +1,5 @@
 import BN from 'bn.js'
-import { ZERO, ALLOWANCE_VALUE } from 'const'
+import { ZERO, ALLOWANCE_MAX_VALUE } from 'const'
 import { USER_1, TOKEN_1, TOKEN_2, TOKEN_3, TOKEN_4, TOKEN_5, TOKEN_6, TOKEN_7, CONTRACT } from './basic'
 
 export default {
@@ -14,12 +14,12 @@ export default {
   },
   [CONTRACT]: {
     // Set contract tokens to max for performing mock withdraws
-    [TOKEN_1]: ALLOWANCE_VALUE,
-    [TOKEN_2]: ALLOWANCE_VALUE,
-    [TOKEN_3]: ALLOWANCE_VALUE,
-    [TOKEN_4]: ALLOWANCE_VALUE,
-    [TOKEN_5]: ALLOWANCE_VALUE,
-    [TOKEN_6]: ALLOWANCE_VALUE,
-    [TOKEN_7]: ALLOWANCE_VALUE,
+    [TOKEN_1]: ALLOWANCE_MAX_VALUE,
+    [TOKEN_2]: ALLOWANCE_MAX_VALUE,
+    [TOKEN_3]: ALLOWANCE_MAX_VALUE,
+    [TOKEN_4]: ALLOWANCE_MAX_VALUE,
+    [TOKEN_5]: ALLOWANCE_MAX_VALUE,
+    [TOKEN_6]: ALLOWANCE_MAX_VALUE,
+    [TOKEN_7]: ALLOWANCE_MAX_VALUE,
   },
 }

--- a/test/utils/formatAmount.spec.ts
+++ b/test/utils/formatAmount.spec.ts
@@ -1,4 +1,4 @@
-import { ZERO, ONE, ALLOWANCE_VALUE } from 'const'
+import { ZERO, ONE, ALLOWANCE_MAX_VALUE } from 'const'
 import { formatAmount, toWei } from 'utils'
 import BN from 'bn.js'
 
@@ -178,7 +178,7 @@ describe('Big amounts', () => {
   // TODO: Define what for arbitrarily big amounts
   test('uint max value', async () => {
     const expected = '115,792,089,237,316,195,423,570,985,008,687,907,853,269,984,665,640,564,039,457.584'
-    expect(formatAmount(new BN(new BN(ALLOWANCE_VALUE)))).toEqual(expected)
+    expect(formatAmount(new BN(new BN(ALLOWANCE_MAX_VALUE)))).toEqual(expected)
   })
 })
 

--- a/test/utils/formatAmountFull.spec.ts
+++ b/test/utils/formatAmountFull.spec.ts
@@ -1,4 +1,4 @@
-import { ZERO, ONE, ALLOWANCE_VALUE } from 'const'
+import { ZERO, ONE, ALLOWANCE_MAX_VALUE } from 'const'
 import { formatAmountFull, toWei } from 'utils'
 import BN from 'bn.js'
 
@@ -83,6 +83,6 @@ describe('Big amounts', () => {
   test('uint max value', async () => {
     const expected =
       '115,792,089,237,316,195,423,570,985,008,687,907,853,269,984,665,640,564,039,457.584007913129639935'
-    expect(formatAmountFull(new BN(new BN(ALLOWANCE_VALUE)))).toEqual(expected)
+    expect(formatAmountFull(new BN(new BN(ALLOWANCE_MAX_VALUE)))).toEqual(expected)
   })
 })

--- a/test/utils/parseAmount.spec.ts
+++ b/test/utils/parseAmount.spec.ts
@@ -1,6 +1,6 @@
 import { toWei, parseAmount } from 'utils'
 import BN from 'bn.js'
-import { ONE, ZERO, ALLOWANCE_VALUE } from 'const'
+import { ONE, ZERO, ALLOWANCE_MAX_VALUE } from 'const'
 
 describe('Integer amounts', () => {
   test('0 wei', async () => {
@@ -93,6 +93,6 @@ describe('Big amounts', () => {
   // TODO: Define what for arbitrarily big amounts
   test('uint max value', async () => {
     const input = '115792089237316195423570985008687907853269984665640564039457.584007913129639935'
-    expect(parseAmount(input)).toEqual(new BN(new BN(ALLOWANCE_VALUE)))
+    expect(parseAmount(input)).toEqual(new BN(new BN(ALLOWANCE_MAX_VALUE)))
   })
 })


### PR DESCRIPTION
Address one of the problems mentioned in #106 

- When enabling the tokens we set the maximun amount. That's a huge number `2**256-1`
- When checking if the token is enabled, we relax the conditin, but still an arbitrarily huge number that is much smaller than the max: It uses `2**128`