### PR TITLE
105/review use wallet info

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,33 +9,50 @@ import { tokenList, exchangeBalanceStates, erc20Balances, erc20Allowances } from
 const isMock = process.env.MOCK === 'true'
 
 function createWalletApi(): WalletApi {
+  let walletApi
   if (isMock) {
-    return new WalletApiMock()
+    walletApi = new WalletApiMock()
+    window['walletApi'] = walletApi // register for convenience
   } else {
     // TODO: Add actual implementation
     throw new Error('Not implemented yet. Only mock implementation available')
   }
+  return walletApi
 }
 
 function createTokenListApi(): TokenList {
+  let tokenListApi
   if (isMock) {
-    return new TokenListApiMock(tokenList)
+    tokenListApi = new TokenListApiMock(tokenList)
+    window['tokenListApi'] = tokenListApi // register for convenience
   } else {
-    return new TokenListApiImpl([Network.Mainnet, Network.Rinkeby])
+    tokenListApi = new TokenListApiImpl([Network.Mainnet, Network.Rinkeby])
   }
+  return tokenListApi
 }
 
 function createErc20Api(): Erc20Api {
-  return new Erc20ApiMock({ balances: erc20Balances, allowances: erc20Allowances })
-}
-
-function createDepositApi(erc20Api: Erc20Api): DepositApi {
+  let erc20Api
   if (isMock) {
-    return new DepositApiMock(exchangeBalanceStates, erc20Api)
+    erc20Api = new Erc20ApiMock({ balances: erc20Balances, allowances: erc20Allowances })
+    window['erc20Api'] = erc20Api // register for convenience
   } else {
     // TODO: Add actual implementation
     throw new Error('Not implemented yet. Only mock implementation available')
   }
+  return erc20Api
+}
+
+function createDepositApi(erc20Api: Erc20Api): DepositApi {
+  let depositApi
+  if (isMock) {
+    depositApi = new DepositApiMock(exchangeBalanceStates, erc20Api)
+    window['depositApi'] = depositApi // register for convenience
+  } else {
+    // TODO: Add actual implementation
+    throw new Error('Not implemented yet. Only mock implementation available')
+  }
+  return depositApi
 }
 
 // Build APIs

--- a/src/api/wallet/WalletApiMock.ts
+++ b/src/api/wallet/WalletApiMock.ts
@@ -3,7 +3,7 @@ import BN from 'bn.js'
 import assert from 'assert'
 
 import { log, wait, toWei } from 'utils'
-import { USER_1 } from '../../../test/data'
+import { USER_1, USER_2 } from '../../../test/data'
 
 type OnChangeWalletInfo = (walletInfo: WalletInfo) => void
 
@@ -65,6 +65,21 @@ export class WalletApiMock implements WalletApi {
   public removeOnChangeWalletInfo(callback: OnChangeWalletInfo): void {
     this._listeners = this._listeners.filter(c => c !== callback)
   }
+
+  /* ****************      Test functions      **************** */
+  // Functions created just for simulate some cases
+
+  public changeUser(): void {
+    this._user = this._user === USER_1 ? USER_2 : USER_1
+    this._notifyListeners()
+  }
+
+  public changeNetwork(): void {
+    this._networkId = this._networkId === Network.Rinkeby ? Network.Mainnet : Network.Rinkeby
+    this._notifyListeners()
+  }
+
+  /* ****************      Private Functions      **************** */
 
   private _getWalletInfo(): WalletInfo {
     return {

--- a/src/hooks/useEnableToken.ts
+++ b/src/hooks/useEnableToken.ts
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef } from 'react'
-import { erc20Api, depositApi, walletApi } from 'api'
+import { erc20Api, depositApi } from 'api'
 import { TokenBalanceDetails, TxOptionalParams, TxResult } from 'types'
 import { ALLOWANCE_MAX_VALUE } from 'const'
 import assert from 'assert'
+import { useWalletConnection } from './useWalletConnection'
 
 interface Params {
   tokenBalances: TokenBalanceDetails
@@ -16,6 +17,7 @@ interface Result {
 }
 
 export const useEnableTokens = (params: Params): Result => {
+  const { userAddress, isConnected } = useWalletConnection()
   const { enabled: enabledInitial, address: tokenAddress } = params.tokenBalances
   const [enabled, setEnabled] = useState(enabledInitial)
   const [enabling, setEnabling] = useState(false)
@@ -29,15 +31,11 @@ export const useEnableTokens = (params: Params): Result => {
 
   async function enableToken(): Promise<TxResult<boolean>> {
     assert(!enabled, 'The token was already enabled')
+    assert(isConnected, "There's no connected wallet")
 
     setEnabling(true)
 
-    // TODO: Review after implementing connect wallet.
-    //   Probably some APIs should have an implicit user and it should be login aware
-    // walletApi.connect()
-
     // Set the allowance
-    const userAddress = await walletApi.getAddress()
     const contractAddress = depositApi.getContractAddress()
     const result = await erc20Api.approve(
       tokenAddress,

--- a/src/hooks/useTokenBalances.ts
+++ b/src/hooks/useTokenBalances.ts
@@ -9,7 +9,6 @@ interface UseTokenBalanceResult {
   error: boolean
 }
 
-// TODO: move to utils? Pretty independent function at this point
 async function fetchBalancesForToken(
   token: TokenDetails,
   userAddress: string,

--- a/src/hooks/useTokenBalances.ts
+++ b/src/hooks/useTokenBalances.ts
@@ -3,6 +3,7 @@ import { TokenBalanceDetails, TokenDetails, WalletInfo } from 'types'
 import { tokenListApi, erc20Api, depositApi } from 'api'
 import { ALLOWANCE_FOR_ENABLED_TOKEN } from 'const'
 import { useWalletConnection } from './useWalletConnection'
+import { formatAmount } from 'utils'
 
 interface UseTokenBalanceResult {
   balances: TokenBalanceDetails[] | undefined
@@ -46,6 +47,7 @@ async function fetchBalancesForToken(
 
 async function _getBalances(walletInfo: WalletInfo): Promise<TokenBalanceDetails[]> {
   const { userAddress, networkId } = walletInfo
+  console.log('[useTokenBalances] getBalances for %s in network %s', userAddress, networkId)
   if (!userAddress || !networkId) {
     return null
   }
@@ -65,7 +67,14 @@ export const useTokenBalances = (): UseTokenBalanceResult => {
 
   useEffect(() => {
     _getBalances(walletInfo)
-      .then(balances => setBalances(balances))
+      .then(balances => {
+        // TODO: Remove after testing!
+        console.log(
+          '[useTokenBalances] Wallet balances',
+          balances ? balances.map(b => formatAmount(b.walletBalance)) : null,
+        )
+        setBalances(balances)
+      })
       .catch(error => {
         console.error('Error loading balances', error)
         setError(true)

--- a/src/hooks/useTokenBalances.ts
+++ b/src/hooks/useTokenBalances.ts
@@ -68,7 +68,6 @@ export const useTokenBalances = (): UseTokenBalanceResult => {
   useEffect(() => {
     _getBalances(walletInfo)
       .then(balances => {
-        // TODO: Remove after testing!
         console.log(
           '[useTokenBalances] Wallet balances',
           balances ? balances.map(b => formatAmount(b.walletBalance)) : null,

--- a/src/hooks/useTokenBalances.ts
+++ b/src/hooks/useTokenBalances.ts
@@ -45,7 +45,7 @@ async function fetchBalancesForToken(
   }
 }
 
-async function _getBalances(walletInfo: WalletInfo): Promise<TokenBalanceDetails[]> {
+async function _getBalances(walletInfo: WalletInfo): Promise<TokenBalanceDetails[] | null> {
   const { userAddress, networkId } = walletInfo
   console.log('[useTokenBalances] getBalances for %s in network %s', userAddress, networkId)
   if (!userAddress || !networkId) {
@@ -61,7 +61,7 @@ async function _getBalances(walletInfo: WalletInfo): Promise<TokenBalanceDetails
 
 export const useTokenBalances = (): UseTokenBalanceResult => {
   const walletInfo = useWalletConnection()
-  const [balances, setBalances] = useState<TokenBalanceDetails[] | undefined>(null)
+  const [balances, setBalances] = useState<TokenBalanceDetails[] | null>(null)
   const [error, setError] = useState(false)
   const mounted = useRef(true)
 

--- a/src/hooks/useWithdrawTokens.ts
+++ b/src/hooks/useWithdrawTokens.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef } from 'react'
 import { TxResult, TokenBalanceDetails, TxOptionalParams } from 'types'
 import assert from 'assert'
-import { depositApi, walletApi } from 'api'
+import { depositApi } from 'api'
+import { useWalletConnection } from './useWalletConnection'
 
 interface Params {
   tokenBalances: TokenBalanceDetails
@@ -14,6 +15,7 @@ interface Result {
 }
 
 export const useWithdrawTokens = (params: Params): Result => {
+  const { userAddress, isConnected } = useWalletConnection()
   const {
     tokenBalances: { enabled, address: tokenAddress, claimable },
   } = params
@@ -29,14 +31,11 @@ export const useWithdrawTokens = (params: Params): Result => {
   async function withdraw(): Promise<TxResult<void>> {
     assert(enabled, 'Token not enabled')
     assert(claimable, 'Withdraw not ready')
+    assert(isConnected, "There's no connected wallet")
 
     setWithdrawing(true)
 
     try {
-      // TODO: Remove connect once login is done
-      await walletApi.connect()
-
-      const userAddress = await walletApi.getAddress()
       return await depositApi.withdraw(userAddress, tokenAddress, params.txOptionalParams)
     } finally {
       if (mounted.current) {


### PR DESCRIPTION
Closes #105 

This PR research how to keep the components updated always with the info about the wallet (address, network, etc..)

Initially I thought it was a bad idea making hooks depend on other hooks, but after some thought I think it might be fine. Think that hooks already depended on basic hooks (they make use of `useState`)

This way, every hook that needs some info from the wallet can use the `useWalletConnection` hook, so it can be updated automatically.

This PR has a small surprise I think it's very useful. It exposes the mock services in the `window` object making it very convenient to use them from the console in development time.

Further more, it includes two new methods in the `WalletApiMock` implementation that allows to simulate a change in the user's wallet account and a change in the `networkId`

**Test**
Just play with the console using the mock as it suggest the following picture:
https://pr117--dexreact.review.gnosisdev.com

![image](https://user-images.githubusercontent.com/2352112/66149713-faeb4300-e613-11e9-97db-213bb684d027.png)

