### PR TITLE
100/trading page widget

### DIFF
--- a/src/components/DepositWidget/Row.tsx
+++ b/src/components/DepositWidget/Row.tsx
@@ -216,7 +216,7 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
     <>
       <TokenTr data-address={address} className={className} data-address-mainnet={addressMainnet}>
         <td>
-          <TokenImg image={image} name={name} />
+          <TokenImg src={image} alt={name} />
         </td>
         <td>{name}</td>
         <td title={formatAmountFull(exchangeBalanceTotal, decimals)}>{formatAmount(exchangeBalanceTotal, decimals)}</td>

--- a/src/components/DepositWidget/Row.tsx
+++ b/src/components/DepositWidget/Row.tsx
@@ -5,7 +5,6 @@ import { faSpinner, faCheck, faClock, faPlus, faMinus } from '@fortawesome/free-
 import { toast } from 'react-toastify'
 
 import { TokenBalanceDetails, Receipt, TxOptionalParams } from 'types'
-import unknownTokenImg from 'img/unknown-token.png'
 import { formatAmount, formatAmountFull } from 'utils'
 import { useEnableTokens } from 'hooks/useEnableToken'
 import Form from './Form'
@@ -16,12 +15,9 @@ import { depositApi } from 'api'
 import { useHighlight } from 'hooks/useHighlight'
 import { TxNotification } from 'components/TxNotification'
 import { useWalletConnection } from 'hooks/useWalletConnection'
+import TokenImg from 'components/TokenImg'
 
 const TokenTr = styled.tr`
-  img {
-    width: 30px;
-    height: 30px;
-  }
 
   &.highlight {
     background-color: #fdffc1;
@@ -56,11 +52,6 @@ const ClaimLink = styled.a`
 
 export interface RowProps {
   tokenBalances: TokenBalanceDetails
-}
-
-function _loadFallbackTokenImage(event: React.SyntheticEvent<HTMLImageElement>): void {
-  const image = event.currentTarget
-  image.src = unknownTokenImg
 }
 
 const txOptionalParams: TxOptionalParams = {
@@ -225,7 +216,7 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
     <>
       <TokenTr data-address={address} className={className} data-address-mainnet={addressMainnet}>
         <td>
-          <img src={image} alt={name} onError={_loadFallbackTokenImage} />
+          <TokenImg image={image} name={name} />
         </td>
         <td>{name}</td>
         <td title={formatAmountFull(exchangeBalanceTotal, decimals)}>{formatAmount(exchangeBalanceTotal, decimals)}</td>

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -4,13 +4,9 @@ import styled from 'styled-components'
 import { Row } from './Row'
 import { useTokenBalances } from 'hooks/useTokenBalances'
 import ErrorMsg from 'components/ErrorMsg'
-import { depositApi } from 'api'
-import { EtherscanLink } from 'components/EtherscanLink'
+import Widget from 'components/layout/Widget'
 
 const Wrapper = styled.section`
-  overflow-x: auto;
-  font-size: 0.85rem;
-  padding-bottom: 4em;
   table {
     width: 100%;
     border-collapse: collapse;
@@ -61,57 +57,45 @@ const Wrapper = styled.section`
   }
 `
 
-const LinkWrapper = styled.div`
-  a {
-    text-align: right;
-    margin-bottom: 3em;
-    display: block;
-  }
-`
-
 const DepositWidget: React.FC = () => {
   const { balances, error } = useTokenBalances()
-  const contractAddress = depositApi.getContractAddress()
 
   if (balances === undefined) {
     // Loading: Do not show the widget
     return <></>
   }
-  const contractLink = (
-    <EtherscanLink type="contract" identifier={contractAddress} label={<small>View verified contract</small>} />
-  )
-
   return (
-    <Wrapper className="widget">
-      {contractLink && <LinkWrapper>{contractLink}</LinkWrapper>}
-      {error ? (
-        <ErrorMsg title="oops..." message="Something happened while loading the balances" />
-      ) : (
-        <table>
-          <thead>
-            <tr>
-              <th colSpan={2}>Token</th>
-              <th>
-                Exchange
-                <br />
-                wallet
-              </th>
-              <th>
-                Pending
-                <br />
-                withdrawals
-              </th>
-              <th>Wallet</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {balances &&
-              balances.map(tokenBalances => <Row key={tokenBalances.addressMainnet} tokenBalances={tokenBalances} />)}
-          </tbody>
-        </table>
-      )}
-    </Wrapper>
+    <Widget>
+      <Wrapper>
+        {error ? (
+          <ErrorMsg title="oops..." message="Something happened while loading the balances" />
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th colSpan={2}>Token</th>
+                <th>
+                  Exchange
+                  <br />
+                  wallet
+                </th>
+                <th>
+                  Pending
+                  <br />
+                  withdrawals
+                </th>
+                <th>Wallet</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {balances &&
+                balances.map(tokenBalances => <Row key={tokenBalances.addressMainnet} tokenBalances={tokenBalances} />)}
+            </tbody>
+          </table>
+        )}
+      </Wrapper>
+    </Widget>
   )
 }
 

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -62,7 +62,7 @@ const DepositWidget: React.FC = () => {
 
   if (balances === undefined) {
     // Loading: Do not show the widget
-    return <></>
+    return null
   }
   return (
     <Widget>

--- a/src/components/EtherscanLink.tsx
+++ b/src/components/EtherscanLink.tsx
@@ -9,6 +9,7 @@ export interface EtherscanLinkProps {
   type: EtherscanLinkType
   identifier: string
   label?: string | ReactElement | void
+  className?: string // to allow subclassing styles with styled-components
 }
 
 function getEtherscanDomainPrefix(networkId: Network): string {
@@ -28,7 +29,7 @@ function getEtherscanDomainSuffix(type: EtherscanLinkType, identifier: string): 
   }
 }
 
-export const EtherscanLink: React.FC<EtherscanLinkProps> = ({ type, identifier, label }) => {
+export const EtherscanLink: React.FC<EtherscanLinkProps> = ({ type, identifier, label, className }) => {
   const { networkId } = useWalletConnection()
 
   if (!networkId) {
@@ -40,7 +41,7 @@ export const EtherscanLink: React.FC<EtherscanLinkProps> = ({ type, identifier, 
     identifier,
   )}`
   return (
-    <a href={href} target="_blank" rel="noopener noreferrer">
+    <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
       {label ? label : abbreviateString(identifier, 6, 4)}
     </a>
   )

--- a/src/components/TokenImg.tsx
+++ b/src/components/TokenImg.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import unknownTokenImg from 'img/unknown-token.png'
+
+const Wrapper = styled.img`
+  width: 30px;
+  height: 30px;
+`
+
+interface Props {
+  image: string
+  name: string
+  // required to be able to apply custom styles
+  // see https://www.styled-components.com/docs/basics#styling-any-component
+  className?: string
+}
+
+function _loadFallbackTokenImage(event: React.SyntheticEvent<HTMLImageElement>): void {
+  const image = event.currentTarget
+  image.src = unknownTokenImg
+}
+
+const TokenImg: React.FC<Props> = ({ image, name, className }: Props) => {
+  return <Wrapper src={image} alt={name} className={className} onError={_loadFallbackTokenImage} />
+}
+
+export default TokenImg

--- a/src/components/TokenImg.tsx
+++ b/src/components/TokenImg.tsx
@@ -3,26 +3,12 @@ import styled from 'styled-components'
 
 import unknownTokenImg from 'img/unknown-token.png'
 
-const Wrapper = styled.img`
-  width: 30px;
-  height: 30px;
-`
-
-interface Props {
-  image: string
-  name: string
-  // required to be able to apply custom styles
-  // see https://www.styled-components.com/docs/basics#styling-any-component
-  className?: string
-}
-
 function _loadFallbackTokenImage(event: React.SyntheticEvent<HTMLImageElement>): void {
   const image = event.currentTarget
   image.src = unknownTokenImg
 }
 
-const TokenImg: React.FC<Props> = ({ image, name, className }: Props) => {
-  return <Wrapper src={image} alt={name} className={className} onError={_loadFallbackTokenImage} />
-}
-
-export default TokenImg
+export default styled.img.attrs(() => ({ onError: _loadFallbackTokenImage }))`
+  width: 30px;
+  height: 30px;
+`

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -58,7 +58,7 @@ const TokenRow: React.FC<Props> = ({ selectLabel, tokenDetails: { name, image } 
 
   return (
     <Wrapper>
-      <TokenImgWrapper name={name} image={image} />
+      <TokenImgWrapper alt={name} src={image} />
       <SelectBox>
         <label htmlFor={selectId}>{selectLabel}</label>
         <select name="tokenSelector" id={selectId}>

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -54,7 +54,7 @@ interface Props {
 }
 
 const TokenRow: React.FC<Props> = ({ selectLabel, tokenDetails: { name, image } }: Props) => {
-  const selectId = selectLabel.replace(/[^a-zA-Z]+/g, '')
+  const selectId = selectLabel.replace(/[^a-zA-Z]/g, '')
 
   return (
     <Wrapper>

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import TokenImg from 'components/TokenImg'
+import { TokenDetails } from 'types'
+import { Link } from 'react-router-dom'
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+`
+
+const TokenImgWrapper = styled(TokenImg)`
+  margin-right: 1em;
+  width: 50px;
+  height: 50px;
+`
+
+const SelectBox = styled.div`
+  margin: 0 1em 0 1em;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+
+  label {
+    text-transform: uppercase;
+  }
+`
+
+const InputBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  flex-grow: 1;
+  margin-left: 1em;
+
+  input {
+    margin: 0 0 0.5em 0;
+  }
+`
+
+const WalletDetail = styled.div`
+  font-size: 0.75em;
+
+  .success {
+    color: green;
+  }
+`
+
+interface Props {
+  tokenDetails: TokenDetails
+  selectLabel: string
+}
+
+const TokenRow: React.FC<Props> = ({ selectLabel, tokenDetails: { name, image } }: Props) => {
+  const selectId = selectLabel.replace(/[^a-zA-Z]+/g, '')
+
+  return (
+    <Wrapper>
+      <TokenImgWrapper name={name} image={image} />
+      <SelectBox>
+        <label htmlFor={selectId}>{selectLabel}</label>
+        <select name="tokenSelector" id={selectId}>
+          <option value="DAI">DAI</option>
+        </select>
+      </SelectBox>
+      <InputBox>
+        <input type="text" placeholder="0" />
+        <WalletDetail>
+          <strong>
+            <Link to="/deposit">Exchange wallet:</Link>
+          </strong>{' '}
+          <span className="success">312312.33</span>
+        </WalletDetail>
+        <WalletDetail>
+          <strong>Wallet:</strong> 444.33
+        </WalletDetail>
+      </InputBox>
+    </Wrapper>
+  )
+}
+
+export default TokenRow

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -11,10 +11,7 @@ import { faExchangeAlt, faPaperPlane } from '@fortawesome/free-solid-svg-icons'
 
 function _getTokenDetails(symbol: string, networkId: number): TokenDetails {
   const _networkId = networkId ? networkId : Network.Mainnet // fallback to mainnet
-  return tokenListApi
-    .getTokens(_networkId)
-    .filter(tokenDetails => tokenDetails.symbol == symbol)
-    .reduce((_, tokenDetails) => tokenDetails)
+  return tokenListApi.getTokens(_networkId).find(tokenDetails => tokenDetails.symbol == symbol)
 }
 
 const IconWrapper = styled.a`

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -1,9 +1,49 @@
 import React from 'react'
 import styled from 'styled-components'
+
 import Widget from 'components/layout/Widget'
+import { useWalletConnection } from 'hooks/useWalletConnection'
+import { Network, TokenDetails } from 'types'
+import { tokenListApi } from 'api'
+import TokenRow from './TokenRow'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faExchangeAlt, faPaperPlane } from '@fortawesome/free-solid-svg-icons'
+
+function _getTokenDetails(symbol: string, networkId: number): TokenDetails {
+  const _networkId = networkId ? networkId : Network.Mainnet // fallback to mainnet
+  return tokenListApi
+    .getTokens(_networkId)
+    .filter(tokenDetails => tokenDetails.symbol == symbol)
+    .reduce((_, tokenDetails) => tokenDetails)
+}
+
+const IconWrapper = styled.a`
+  margin: -1em 0 1.5em 0.75em;
+  width: 2em;
+`
+
+const SubmitButton = styled.button`
+  margin: 2em 0 0 0;
+  line-height: 2;
+`
 
 const TradeWidget: React.FC = () => {
-  return <Widget></Widget>
+  const { networkId } = useWalletConnection()
+  const DAI = _getTokenDetails('DAI', networkId)
+  const USDC = _getTokenDetails('USDC', networkId)
+
+  return (
+    <Widget>
+      <TokenRow tokenDetails={DAI} selectLabel="pay with" />
+      <IconWrapper>
+        <FontAwesomeIcon icon={faExchangeAlt} rotation={90} size="2x" />
+      </IconWrapper>
+      <TokenRow tokenDetails={USDC} selectLabel="receive" />
+      <SubmitButton>
+        <FontAwesomeIcon icon={faPaperPlane} size="lg" /> Send limit offer
+      </SubmitButton>
+    </Widget>
+  )
 }
 
 export default TradeWidget

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -37,7 +37,7 @@ const TradeWidget: React.FC = () => {
       </IconWrapper>
       <TokenRow tokenDetails={USDC} selectLabel="receive" />
       <SubmitButton>
-        <FontAwesomeIcon icon={faPaperPlane} size="lg" /> Send limit offer
+        <FontAwesomeIcon icon={faPaperPlane} size="lg" /> Send limit order
       </SubmitButton>
     </Widget>
   )

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import styled from 'styled-components'
+import Widget from 'components/layout/Widget'
+
+const TradeWidget: React.FC = () => {
+  return <Widget></Widget>
+}
+
+export default TradeWidget

--- a/src/components/layout/GlobalStyles.ts
+++ b/src/components/layout/GlobalStyles.ts
@@ -146,27 +146,18 @@ const GlobalStyles = createGlobalStyle`
     }
   }
 
-  .widget,
+  //TODO: extract into a Page component
   .page {
     background-color: white;
     margin: -3rem auto 3rem auto;
-    box-shadow: 1px 1px #e8e8e8;    
+    box-shadow: 1px 1px #e8e8e8;
     min-height: 25rem;
+    padding: 2rem 10vw 2rem 10vw;
+    width: 95vw;
 
     @media (max-width: 768px) {
       margin: auto;
     }
-  }
-
-  .widget {
-    padding: 2em;
-    border-radius: 10px;
-    min-width: 58vw;
-  }
-
-  .page {
-    padding: 2rem 10vw 2rem 10vw;
-    width: 95vw;
   }
 
 `

--- a/src/components/layout/Widget.tsx
+++ b/src/components/layout/Widget.tsx
@@ -22,24 +22,22 @@ const Wrapper = styled.section`
   flex-direction: column;
 `
 
-const LinkWrapper = styled.div`
-  a {
-    text-align: right;
-    margin-bottom: 3em;
-    display: block;
-  }
+const LinkWrapper = styled(EtherscanLink)`
+  text-align: right;
+  margin-bottom: 3em;
+  display: block;
 `
 
 const Widget: React.FC = ({ children }) => {
   const contractAddress = depositApi.getContractAddress()
 
   const contractLink = (
-    <EtherscanLink type="contract" identifier={contractAddress} label={<small>View verified contract</small>} />
+    <LinkWrapper type="contract" identifier={contractAddress} label={<small>View verified contract</small>} />
   )
 
   return (
     <Wrapper>
-      {contractLink && <LinkWrapper>{contractLink}</LinkWrapper>}
+      {contractLink && contractLink}
       {children}
     </Wrapper>
   )

--- a/src/components/layout/Widget.tsx
+++ b/src/components/layout/Widget.tsx
@@ -17,6 +17,9 @@ const Wrapper = styled.section`
   margin: -3rem auto 3rem auto;
   box-shadow: 1px 1px #e8e8e8;
   min-height: 25rem;
+
+  display: flex;
+  flex-direction: column;
 `
 
 const LinkWrapper = styled.div`

--- a/src/components/layout/Widget.tsx
+++ b/src/components/layout/Widget.tsx
@@ -7,6 +7,16 @@ const Wrapper = styled.section`
   overflow-x: auto;
   font-size: 0.85rem;
   padding-bottom: 4em;
+  padding: 2em;
+  border-radius: 10px;
+  min-width: 58vw;
+
+  //TODO: 4 lines bellow duplicated from "page" css.
+  //extract into a common "section" component
+  background-color: white;
+  margin: -3rem auto 3rem auto;
+  box-shadow: 1px 1px #e8e8e8;
+  min-height: 25rem;
 `
 
 const LinkWrapper = styled.div`
@@ -25,7 +35,7 @@ const Widget: React.FC = ({ children }) => {
   )
 
   return (
-    <Wrapper className="widget">
+    <Wrapper>
       {contractLink && <LinkWrapper>{contractLink}</LinkWrapper>}
       {children}
     </Wrapper>

--- a/src/components/layout/Widget.tsx
+++ b/src/components/layout/Widget.tsx
@@ -31,13 +31,9 @@ const LinkWrapper = styled(EtherscanLink)`
 const Widget: React.FC = ({ children }) => {
   const contractAddress = depositApi.getContractAddress()
 
-  const contractLink = (
-    <LinkWrapper type="contract" identifier={contractAddress} label={<small>View verified contract</small>} />
-  )
-
   return (
     <Wrapper>
-      {contractLink && contractLink}
+      <LinkWrapper type="contract" identifier={contractAddress} label={<small>View verified contract</small>} />
       {children}
     </Wrapper>
   )

--- a/src/components/layout/Widget.tsx
+++ b/src/components/layout/Widget.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import styled from 'styled-components'
+import { depositApi } from 'api'
+import { EtherscanLink } from 'components/EtherscanLink'
+
+const Wrapper = styled.section`
+  overflow-x: auto;
+  font-size: 0.85rem;
+  padding-bottom: 4em;
+`
+
+const LinkWrapper = styled.div`
+  a {
+    text-align: right;
+    margin-bottom: 3em;
+    display: block;
+  }
+`
+
+const Widget: React.FC = ({ children }) => {
+  const contractAddress = depositApi.getContractAddress()
+
+  const contractLink = (
+    <EtherscanLink type="contract" identifier={contractAddress} label={<small>View verified contract</small>} />
+  )
+
+  return (
+    <Wrapper className="widget">
+      {contractLink && <LinkWrapper>{contractLink}</LinkWrapper>}
+      {children}
+    </Wrapper>
+  )
+}
+
+export default Widget

--- a/src/pages/Trade.tsx
+++ b/src/pages/Trade.tsx
@@ -1,15 +1,1 @@
-import React from 'react'
-
-const Trade: React.FC = () => (
-  <div className="page">
-    <h1>Trade</h1>
-    <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-      magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-      Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
-    </p>
-  </div>
-)
-
-export default Trade
+export { default } from 'components/TradeWidget'


### PR DESCRIPTION
Closes #100 

Implements the basic Trade widget layout:

- [x] Refactoring out a base `Widget` component
  - Moved global `.widget` styles into `Widget` component
  - Made `Widget` `display: flex`
- [x] Refactored out `TokenImg` component
- [x] Implemented basic `TradeWdiget`

![trade-widget](https://user-images.githubusercontent.com/43217/67131474-a7532a80-f1b9-11e9-8782-ea89575dee57.png)

---

Not part of this PR:
- Implement button actions
- Interact with user wallet
- Interact with contract
- Show notifications 