### PR TITLE
101/trading widget form

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react": "^16.8.6",
     "react-copy-to-clipboard": "^5.0.1",
     "react-dom": "^16.8.6",
+    "react-hook-form": "^3.26.2",
     "react-hot-loader": "^4.12.10",
     "react-router-dom": "^5.0.1",
     "react-select": "^3.0.8",

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -72,8 +72,9 @@ const WalletDetail = styled.div`
 
   &.error,
   &.warning {
-    text-align: right;
+    margin: 0 0 1em 0;
   }
+
   &.error {
     color: red;
   }
@@ -215,6 +216,7 @@ const TokenRow: React.FC<Props> = ({
             },
           })}
         />
+        {errorOrWarning}
         <WalletDetail>
           <strong>
             <Link to="/deposit">Exchange wallet:</Link>
@@ -226,7 +228,6 @@ const TokenRow: React.FC<Props> = ({
         <WalletDetail>
           <strong>Wallet:</strong> {displayBalance(balance, 'walletBalance')}
         </WalletDetail>
-        {errorOrWarning}
       </InputBox>
     </Wrapper>
   )

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -148,7 +148,7 @@ const TokenRow: React.FC<Props> = ({
 }) => {
   const options = useMemo(() => tokens.map(token => ({ token, value: token.symbol, label: token.name })), [tokens])
 
-  const { register, errors } = useFormContext()
+  const { register, errors, setValue } = useFormContext()
 
   const maxRef = useRef(getMax(balance, token))
   useEffect(() => {
@@ -192,7 +192,9 @@ const TokenRow: React.FC<Props> = ({
           <strong>
             <Link to="/deposit">Exchange wallet:</Link>
           </strong>{' '}
-          <span className="success">{displayBalance(balance, 'exchangeBalance')}</span>
+          <a className="success" onClick={(): void => setValue(inputId, maxRef.current)}>
+            {displayBalance(balance, 'exchangeBalance')}
+          </a>
         </WalletDetail>
         <WalletDetail>
           <strong>Wallet:</strong> {displayBalance(balance, 'walletBalance')}

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -51,6 +51,10 @@ const InputBox = styled.div`
   input {
     margin: 0 0 0.5em 0;
     width: 100%;
+
+    &.error {
+      box-shadow: 0 0 3px #cc0000;
+    }
   }
 `
 
@@ -59,6 +63,12 @@ const WalletDetail = styled.div`
 
   .success {
     color: green;
+    text-decoration: none;
+  }
+
+  &.error {
+    text-align: right;
+    color: red;
   }
 `
 

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -77,7 +77,7 @@ const TradeWidget: React.FC = () => {
   return (
     <WrappedWidget>
       <FormContext {...methods}>
-        <WrapperForm onSubmit={methods.handleSubmit(data => console.log('data', data))} noValidate>
+        <WrapperForm onSubmit={methods.handleSubmit(data => console.log('data', data))}>
           <TokenRow
             token={sellToken}
             tokens={tokens}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -1,19 +1,25 @@
 import React, { useState, useMemo } from 'react'
+import { faExchangeAlt, faPaperPlane } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import styled from 'styled-components'
+import useForm, { FormContext } from 'react-hook-form'
 
-import Widget from 'components/layout/Widget'
-import { useWalletConnection } from 'hooks/useWalletConnection'
 import { Network, TokenDetails } from 'types'
 import { tokenListApi } from 'api'
-import TokenRow from './TokenRow'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faExchangeAlt, faPaperPlane } from '@fortawesome/free-solid-svg-icons'
 import { getToken } from 'utils'
 import { useTokenBalances } from 'hooks/useTokenBalances'
+import { useWalletConnection } from 'hooks/useWalletConnection'
+import TokenRow from './TokenRow'
+import Widget from 'components/layout/Widget'
 
 const WrappedWidget = styled(Widget)`
   overflow-x: visible;
   min-width: 0;
+`
+
+const WrapperForm = styled.form`
+  display: flex;
+  flex-direction: column;
 `
 
 const IconWrapper = styled.a`
@@ -42,6 +48,10 @@ const TradeWidget: React.FC = () => {
     receiveToken.symbol,
   ])
 
+  const methods = useForm({ mode: 'onBlur' })
+  const sellTokenId = 'sellToken'
+  const receiveTokenId = 'receiveToken'
+
   const swapTokens = (): void => {
     setSellToken(receiveToken)
     setReceiveToken(sellToken)
@@ -62,26 +72,33 @@ const TradeWidget: React.FC = () => {
 
   return (
     <WrappedWidget>
-      <TokenRow
-        token={sellToken}
-        tokens={tokens}
-        balance={sellTokenBalance}
-        selectLabel="sell"
-        onSelectChange={onSelectChangeFactory(setSellToken, receiveToken)}
-      />
-      <IconWrapper onClick={swapTokens}>
-        <FontAwesomeIcon icon={faExchangeAlt} rotation={90} size="2x" />
-      </IconWrapper>
-      <TokenRow
-        token={receiveToken}
-        tokens={tokens}
-        balance={receiveTokenBalance}
-        selectLabel="receive"
-        onSelectChange={onSelectChangeFactory(setReceiveToken, sellToken)}
-      />
-      <SubmitButton>
-        <FontAwesomeIcon icon={faPaperPlane} size="lg" /> Send limit order
-      </SubmitButton>
+      <FormContext {...methods}>
+        <WrapperForm onSubmit={methods.handleSubmit(data => console.log('data', data))} noValidate>
+          <TokenRow
+            token={sellToken}
+            tokens={tokens}
+            balance={sellTokenBalance}
+            selectLabel="sell"
+            onSelectChange={onSelectChangeFactory(setSellToken, receiveToken)}
+            inputId={sellTokenId}
+            validateMaxAmount
+          />
+          <IconWrapper onClick={swapTokens}>
+            <FontAwesomeIcon icon={faExchangeAlt} rotation={90} size="2x" />
+          </IconWrapper>
+          <TokenRow
+            token={receiveToken}
+            tokens={tokens}
+            balance={receiveTokenBalance}
+            selectLabel="receive"
+            onSelectChange={onSelectChangeFactory(setReceiveToken, sellToken)}
+            inputId={receiveTokenId}
+          />
+          <SubmitButton type="submit">
+            <FontAwesomeIcon icon={faPaperPlane} size="lg" /> Send limit order
+          </SubmitButton>
+        </WrapperForm>
+      </FormContext>
     </WrappedWidget>
   )
 }

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -30,6 +30,10 @@ const IconWrapper = styled.a`
 const SubmitButton = styled.button`
   margin: 2em 0 0 0;
   line-height: 2;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
 `
 
 const TradeWidget: React.FC = () => {
@@ -94,7 +98,7 @@ const TradeWidget: React.FC = () => {
             onSelectChange={onSelectChangeFactory(setReceiveToken, sellToken)}
             inputId={receiveTokenId}
           />
-          <SubmitButton type="submit">
+          <SubmitButton type="submit" disabled={!methods.formState.isValid}>
             <FontAwesomeIcon icon={faPaperPlane} size="lg" /> Send limit order
           </SubmitButton>
         </WrapperForm>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2845,9 +2845,9 @@ copy-to-clipboard@^3:
     toggle-selection "^1.0.6"
 
 core-js-compat@^3.1.1:
-  version "3.3.5"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.3.5.tgz#7abf70778b73dc74aa99d4075aefcd99b76f2c3a"
-  integrity sha512-44ZORuapx0MUht0MUk0p9lcQPh7n/LDXehimTmjCs0CYblpKZcqVd5w0OQDUDq5OQjEbazWObHDQJWvvHYPNTg==
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.3.6.tgz#70c30dbeb582626efe9ecd6f49daa9ff4aeb136c"
+  integrity sha512-YnwZG/+0/f7Pf6Lr3jxtVAFjtGBW9lsLYcqrxhYJai1GfvrP8DEyEpnNzj/FRQfIkOOfk1j5tTBvPBLWVVJm4A==
   dependencies:
     browserslist "^4.7.2"
     semver "^6.3.0"
@@ -7963,9 +7963,9 @@ performance-now@^2.1.0:
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
 picomatch@^2.0.5:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
-  integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.1.0.tgz#0fd042f568d08b1ad9ff2d3ec0f0bfb3cb80e177"
+  integrity sha512-uhnEDzAbrcJ8R3g2fANnSuXZMBtkpSjxTTgn2LeSiQlfmq72enQJWdQllXW24MBLYnA1SBD2vfvx2o0Zw3Ielw==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -8473,6 +8473,11 @@ react-error-overlay@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.3.tgz#c378c4b0a21e88b2e159a3e62b2f531fd63bf60d"
   integrity sha512-bOUvMWFQVk5oz8Ded9Xb7WVdEi3QGLC8tH7HmYP0Fdp4Bn3qw0tRFmr5TW6mvahzvmrK4a6bqWGfCevBflP+Xw==
+
+react-hook-form@^3.26.2:
+  version "3.26.4"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-3.26.4.tgz#535c2b8862a4aa899fea454b01480e7e0c3e377f"
+  integrity sha512-n+BkcojpwO5swWOjdN+UoOPStN5nZnWqyZ8xLYL/Pq1/c3Ng4HsNjooVATg9O3Eff5RgBg+m9tYjZcKZqHMMGg==
 
 react-hot-loader@^4.12.10:
   version "4.12.15"
@@ -11024,9 +11029,9 @@ webpack-bundle-analyzer@^3.4.1:
     ws "^6.0.0"
 
 webpack-cli@^3.3.8:
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.9.tgz#79c27e71f94b7fe324d594ab64a8e396b9daa91a"
-  integrity sha512-xwnSxWl8nZtBl/AFJCOn9pG7s5CYUYdZxmmukv+fAHLcBIHM36dImfpQg3WfShZXeArkWlf6QRw24Klcsv8a5A==
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.10.tgz#17b279267e9b4fb549023fae170da8e6e766da13"
+  integrity sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==
   dependencies:
     chalk "2.4.2"
     cross-spawn "6.0.5"


### PR DESCRIPTION
 Closes #101 

Contains changes from #161 and #164. 
Recommend reviewing them first.
Once they are merged there will be less code to review.

---

### Note:
Styling is very basic. I welcome suggestions to how better display the error messages:

---

- [x] Using `react-hook-form`
- [x] Making total exchange amount clickable and filling the input with its value
- [x] Validating a float number > 0 is provided
- [x] Displaying warning when sell token amount is > exchange wallet balance for given token
- [x] Disabling the submit button when form is not valid

![token-selector-validation](https://user-images.githubusercontent.com/43217/68142012-7fff9b80-fee3-11e9-827f-06c7ee883b59.png)

## Testing

- [x] `yarn test && yarn build`
- [x] visually tested in the browser