### PR TITLE
Displaying order details when both inputs are filled

### DIFF
--- a/src/components/TradeWidget/OrderDetails.tsx
+++ b/src/components/TradeWidget/OrderDetails.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import styled from 'styled-components'
+import { useFormContext } from 'react-hook-form'
+
+import { TokenDetails } from 'types'
+import { FEE_PERCENTAGE } from 'const'
+
+const Wrapper = styled.dl`
+  margin: 2em 0 0 0;
+  font-size: 0.8em;
+`
+
+const Dd = styled.dd`
+  font-weight: bold;
+  margin: 0;
+`
+
+const Dt = styled.dt`
+  margin-left: 4em;
+`
+
+const Highlight = styled.span`
+  font-weight: bold;
+  color: #367be0;
+`
+
+// TODO: move to utils?
+function calculatePrice(sellAmount: number, receiveAmount: number): number {
+  return sellAmount > 0 ? receiveAmount / sellAmount : 0
+}
+
+interface Props {
+  sellTokenId: string
+  sellToken: TokenDetails
+  receiveTokenId: string
+  receiveToken: TokenDetails
+}
+
+const OrderDetails: React.FC<Props> = ({ sellTokenId, sellToken, receiveTokenId, receiveToken }) => {
+  const { watch } = useFormContext()
+
+  const sellAmount = Number(watch(sellTokenId))
+  const receiveAmount = Number(watch(receiveTokenId))
+
+  if (!(sellAmount > 0 && receiveAmount > 0)) {
+    return null
+  }
+
+  function _calculatePrice(): string {
+    return calculatePrice(sellAmount, receiveAmount).toFixed(2)
+  }
+
+  return (
+    <Wrapper>
+      <Dd>Order details:</Dd>
+      <Dt>
+        Sell up to{' '}
+        <Highlight>
+          {watch(sellTokenId)} {sellToken.symbol}
+        </Highlight>{' '}
+        at a price{' '}
+        <Highlight>
+          1 {sellToken.symbol} = {_calculatePrice()} {receiveToken.symbol}
+        </Highlight>{' '}
+        or better. <br />
+        Your order might be partially filled.
+      </Dt>
+
+      <Dd>Fee:</Dd>
+      <Dt>
+        <Highlight>{FEE_PERCENTAGE}%</Highlight>, included already in your limit price.
+      </Dt>
+
+      <Dd>Expiration date:</Dd>
+      <Dt>
+        <Highlight>30 min</Highlight>
+      </Dt>
+    </Wrapper>
+  )
+}
+
+export default OrderDetails

--- a/src/components/TradeWidget/OrderDetails.tsx
+++ b/src/components/TradeWidget/OrderDetails.tsx
@@ -6,15 +6,15 @@ import { FEE_PERCENTAGE } from 'const'
 const Wrapper = styled.dl`
   margin: 2em 0 0 0;
   font-size: 0.8em;
-`
 
-const Dd = styled.dd`
-  font-weight: bold;
-  margin: 0;
-`
+  dd {
+    font-weight: bold;
+    margin: 0;
+  }
 
-const Dt = styled.dt`
-  margin: 0 0 0.25em 4em;
+  dt {
+    margin: 0 0 0.25em 4em;
+  }
 `
 
 const Highlight = styled.span`
@@ -48,8 +48,8 @@ const OrderDetails: React.FC<Props> = ({ sellAmount, sellTokenName, receiveAmoun
 
   return (
     <Wrapper>
-      <Dd>Order details:</Dd>
-      <Dt>
+      <dd>Order details:</dd>
+      <dt>
         Sell up to{' '}
         <Highlight>
           {sellAmount} {sellTokenName}
@@ -60,17 +60,17 @@ const OrderDetails: React.FC<Props> = ({ sellAmount, sellTokenName, receiveAmoun
         </Highlight>{' '}
         or better. <br />
         Your order might be partially filled.
-      </Dt>
+      </dt>
 
-      <Dd>Fee:</Dd>
-      <Dt>
+      <dd>Fee:</dd>
+      <dt>
         <Highlight>{FEE_PERCENTAGE}%</Highlight>, included already in your limit price.
-      </Dt>
+      </dt>
 
-      <Dd>Expiration date:</Dd>
-      <Dt>
+      <dd>Expiration date:</dd>
+      <dt>
         <Highlight>30 min</Highlight>
-      </Dt>
+      </dt>
     </Wrapper>
   )
 }

--- a/src/components/TradeWidget/OrderDetails.tsx
+++ b/src/components/TradeWidget/OrderDetails.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { useFormContext } from 'react-hook-form'
 
-import { TokenDetails } from 'types'
 import { FEE_PERCENTAGE } from 'const'
 
 const Wrapper = styled.dl`
@@ -30,24 +28,22 @@ function calculatePrice(sellAmount: number, receiveAmount: number): number {
 }
 
 interface Props {
-  sellTokenId: string
-  sellToken: TokenDetails
-  receiveTokenId: string
-  receiveToken: TokenDetails
+  sellAmount: string
+  sellTokenName: string
+  receiveAmount: string
+  receiveTokenName: string
 }
 
-const OrderDetails: React.FC<Props> = ({ sellTokenId, sellToken, receiveTokenId, receiveToken }) => {
-  const { watch } = useFormContext()
+const OrderDetails: React.FC<Props> = ({ sellAmount, sellTokenName, receiveAmount, receiveTokenName }) => {
+  const sellAmountNumber = Number(sellAmount)
+  const receiveAmountNumber = Number(receiveAmount)
 
-  const sellAmount = Number(watch(sellTokenId))
-  const receiveAmount = Number(watch(receiveTokenId))
-
-  if (!(sellAmount > 0 && receiveAmount > 0)) {
+  if (!(sellAmountNumber > 0 && receiveAmountNumber > 0)) {
     return null
   }
 
   function _calculatePrice(): string {
-    return calculatePrice(sellAmount, receiveAmount).toFixed(2)
+    return calculatePrice(sellAmountNumber, receiveAmountNumber).toFixed(2)
   }
 
   return (
@@ -56,11 +52,11 @@ const OrderDetails: React.FC<Props> = ({ sellTokenId, sellToken, receiveTokenId,
       <Dt>
         Sell up to{' '}
         <Highlight>
-          {watch(sellTokenId)} {sellToken.symbol}
+          {sellAmount} {sellTokenName}
         </Highlight>{' '}
         at a price{' '}
         <Highlight>
-          1 {sellToken.symbol} = {_calculatePrice()} {receiveToken.symbol}
+          1 {sellTokenName} = {_calculatePrice()} {receiveTokenName}
         </Highlight>{' '}
         or better. <br />
         Your order might be partially filled.

--- a/src/components/TradeWidget/OrderDetails.tsx
+++ b/src/components/TradeWidget/OrderDetails.tsx
@@ -16,7 +16,7 @@ const Dd = styled.dd`
 `
 
 const Dt = styled.dt`
-  margin-left: 4em;
+  margin: 0 0 0.25em 4em;
 `
 
 const Highlight = styled.span`

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -147,7 +147,7 @@ function validatePositive(value: string): true | string {
 }
 
 interface Props {
-  token: TokenDetails
+  selectedToken: TokenDetails
   tokens: TokenDetails[]
   balance: TokenBalanceDetails
   selectLabel: string
@@ -157,7 +157,7 @@ interface Props {
 }
 
 const TokenRow: React.FC<Props> = ({
-  token,
+  selectedToken,
   tokens,
   selectLabel,
   onSelectChange,
@@ -170,7 +170,7 @@ const TokenRow: React.FC<Props> = ({
   const { register, errors, setValue, watch } = useFormContext()
   const error = errors[inputId]
 
-  const max = Number(getMax(balance, token))
+  const max = Number(getMax(balance, selectedToken))
   const inputValue = Number(watch(inputId)) || 0
   const overMax = validateMaxAmount && inputValue > max ? inputValue - max : 0
 
@@ -181,7 +181,7 @@ const TokenRow: React.FC<Props> = ({
   ) : (
     !!overMax && (
       <WalletDetail className="warning">
-        Selling {overMax.toFixed(4)} {token.symbol} over your current balance
+        Selling {overMax.toFixed(4)} {selectedToken.symbol} over your current balance
       </WalletDetail>
     )
   )
@@ -192,7 +192,7 @@ const TokenRow: React.FC<Props> = ({
 
   return (
     <Wrapper>
-      <TokenImgWrapper alt={token.name} src={token.image} />
+      <TokenImgWrapper alt={selectedToken.name} src={selectedToken.image} />
       <SelectBox>
         <label>{selectLabel}</label>
         <Select
@@ -201,7 +201,7 @@ const TokenRow: React.FC<Props> = ({
           noOptionsMessage={(): string => 'No results'}
           formatOptionLabel={formatOptionLabel}
           options={options}
-          value={{ token }}
+          value={{ token: selectedToken }}
           onChange={(selected, { action }): void => {
             if (action === 'select-option' && 'token' in selected) {
               onSelectChange(selected.token)

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -17,6 +17,13 @@ import { tokenListApi } from 'api'
 import { Network, TokenDetails } from 'types'
 
 import { getToken } from 'utils'
+// TODO: get from config
+const feeAmount = 0.1
+
+// TODO: move to utils?
+function calculatePrice(sellAmount: number, receiveAmount: number): number {
+  return sellAmount > 0 ? receiveAmount / sellAmount : 0
+}
 
 const WrappedWidget = styled(Widget)`
   overflow-x: visible;
@@ -52,6 +59,25 @@ const SubmitButton = styled.button`
   }
 `
 
+const OrderDetails = styled.dl`
+  margin: 2em 0 0 0;
+  font-size: 0.8em;
+`
+
+const Dd = styled.dd`
+  font-weight: bold;
+  margin: 0;
+`
+
+const Dt = styled.dt`
+  margin-left: 4em;
+`
+
+const Highlight = styled.span`
+  font-weight: bold;
+  color: #367be0;
+`
+
 const TradeWidget: React.FC = () => {
   const { networkId } = useWalletConnection()
   // Avoid displaying an empty list of tokens when the wallet is not connected
@@ -81,6 +107,7 @@ const TradeWidget: React.FC = () => {
   ])
 
   const methods = useForm({ mode: 'onBlur' })
+  const { watch, handleSubmit } = methods
   const sellTokenId = 'sellToken'
   const receiveTokenId = 'receiveToken'
 
@@ -103,11 +130,24 @@ const TradeWidget: React.FC = () => {
   }
 
   let sameToken = sellToken === receiveToken
+  /**
+   * Regardless of the validation, check the current input values
+   * Returns true if both are valid numbers > 0
+   */
+  function showOrderDetails(): boolean {
+    return Number(watch(sellTokenId)) > 0 && Number(watch(receiveTokenId)) > 0
+  }
+
+  function _calculatePrice(): string {
+    const sellAmount = Number(watch(sellTokenId))
+    const receiveAmount = Number(watch(receiveTokenId))
+    return calculatePrice(sellAmount, receiveAmount).toFixed(2)
+  }
 
   return (
     <WrappedWidget>
       <FormContext {...methods}>
-        <WrapperForm onSubmit={methods.handleSubmit(console.log)}>
+        <WrapperForm onSubmit={handleSubmit(data => console.log('data', data))}>
           {sameToken && <WarningLabel>Tokens cannot be the same!</WarningLabel>}
           <TokenRow
             token={sellToken}
@@ -129,6 +169,33 @@ const TradeWidget: React.FC = () => {
             onSelectChange={onSelectChangeFactory(setReceiveToken, sellToken)}
             inputId={receiveTokenId}
           />
+          {showOrderDetails() && (
+            <OrderDetails>
+              <Dd>Order details:</Dd>
+              <Dt>
+                Sell up to{' '}
+                <Highlight>
+                  {watch(sellTokenId)} {sellToken.symbol}
+                </Highlight>{' '}
+                at a price{' '}
+                <Highlight>
+                  1 {sellToken.symbol} = {_calculatePrice()} {receiveToken.symbol}
+                </Highlight>{' '}
+                or better. <br />
+                Your order might be partially filled.
+              </Dt>
+
+              <Dd>Fee:</Dd>
+              <Dt>
+                <Highlight>{feeAmount}%</Highlight>, included already in your limit price.
+              </Dt>
+
+              <Dd>Expiration date:</Dd>
+              <Dt>
+                <Highlight>30 min</Highlight>
+              </Dt>
+            </OrderDetails>
+          )}
           <SubmitButton type="submit" disabled={!methods.formState.isValid}>
             <FontAwesomeIcon icon={faPaperPlane} size="lg" />{' '}
             {sameToken ? 'Please select different tokens' : 'Send limit order'}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -24,7 +24,7 @@ const WrappedWidget = styled(Widget)`
   min-width: 0;
 `
 
-const WrapperForm = styled.form`
+const WrappedForm = styled.form`
   display: flex;
   flex-direction: column;
 `
@@ -109,7 +109,7 @@ const TradeWidget: React.FC = () => {
   return (
     <WrappedWidget>
       <FormContext {...methods}>
-        <WrapperForm onSubmit={handleSubmit(data => console.log('data', data))}>
+        <WrappedForm onSubmit={handleSubmit(data => console.log('data', data))}>
           {sameToken && <WarningLabel>Tokens cannot be the same!</WarningLabel>}
           <TokenRow
             token={sellToken}
@@ -141,7 +141,7 @@ const TradeWidget: React.FC = () => {
             <FontAwesomeIcon icon={faPaperPlane} size="lg" />{' '}
             {sameToken ? 'Please select different tokens' : 'Send limit order'}
           </SubmitButton>
-        </WrapperForm>
+        </WrappedForm>
       </FormContext>
     </WrappedWidget>
   )

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -17,7 +17,7 @@ import { tokenListApi } from 'api'
 
 import { Network, TokenDetails } from 'types'
 
-import { getToken } from 'utils'
+import { getToken, safeTokenName } from 'utils'
 
 const WrappedWidget = styled(Widget)`
   overflow-x: visible;
@@ -82,7 +82,7 @@ const TradeWidget: React.FC = () => {
   ])
 
   const methods = useForm({ mode: 'onBlur' })
-  const { handleSubmit } = methods
+  const { handleSubmit, watch } = methods
   const sellTokenId = 'sellToken'
   const receiveTokenId = 'receiveToken'
 
@@ -132,10 +132,10 @@ const TradeWidget: React.FC = () => {
             inputId={receiveTokenId}
           />
           <OrderDetails
-            sellTokenId={sellTokenId}
-            sellToken={sellToken}
-            receiveTokenId={receiveTokenId}
-            receiveToken={receiveToken}
+            sellAmount={watch(sellTokenId)}
+            sellTokenName={safeTokenName(sellToken)}
+            receiveAmount={watch(receiveTokenId)}
+            receiveTokenName={safeTokenName(receiveToken)}
           />
           <SubmitButton type="submit" disabled={!methods.formState.isValid}>
             <FontAwesomeIcon icon={faPaperPlane} size="lg" />{' '}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import useForm, { FormContext } from 'react-hook-form'
 
 import TokenRow from './TokenRow'
+import OrderDetails from './OrderDetails'
 import Widget from 'components/layout/Widget'
 
 import { useParams } from 'react-router'
@@ -17,13 +18,6 @@ import { tokenListApi } from 'api'
 import { Network, TokenDetails } from 'types'
 
 import { getToken } from 'utils'
-
-import { FEE_PERCENTAGE } from 'const'
-
-// TODO: move to utils?
-function calculatePrice(sellAmount: number, receiveAmount: number): number {
-  return sellAmount > 0 ? receiveAmount / sellAmount : 0
-}
 
 const WrappedWidget = styled(Widget)`
   overflow-x: visible;
@@ -59,25 +53,6 @@ const SubmitButton = styled.button`
   }
 `
 
-const OrderDetails = styled.dl`
-  margin: 2em 0 0 0;
-  font-size: 0.8em;
-`
-
-const Dd = styled.dd`
-  font-weight: bold;
-  margin: 0;
-`
-
-const Dt = styled.dt`
-  margin-left: 4em;
-`
-
-const Highlight = styled.span`
-  font-weight: bold;
-  color: #367be0;
-`
-
 const TradeWidget: React.FC = () => {
   const { networkId } = useWalletConnection()
   // Avoid displaying an empty list of tokens when the wallet is not connected
@@ -107,7 +82,7 @@ const TradeWidget: React.FC = () => {
   ])
 
   const methods = useForm({ mode: 'onBlur' })
-  const { watch, handleSubmit } = methods
+  const { handleSubmit } = methods
   const sellTokenId = 'sellToken'
   const receiveTokenId = 'receiveToken'
 
@@ -130,19 +105,6 @@ const TradeWidget: React.FC = () => {
   }
 
   let sameToken = sellToken === receiveToken
-  /**
-   * Regardless of the validation, check the current input values
-   * Returns true if both are valid numbers > 0
-   */
-  function showOrderDetails(): boolean {
-    return Number(watch(sellTokenId)) > 0 && Number(watch(receiveTokenId)) > 0
-  }
-
-  function _calculatePrice(): string {
-    const sellAmount = Number(watch(sellTokenId))
-    const receiveAmount = Number(watch(receiveTokenId))
-    return calculatePrice(sellAmount, receiveAmount).toFixed(2)
-  }
 
   return (
     <WrappedWidget>
@@ -169,33 +131,12 @@ const TradeWidget: React.FC = () => {
             onSelectChange={onSelectChangeFactory(setReceiveToken, sellToken)}
             inputId={receiveTokenId}
           />
-          {showOrderDetails() && (
-            <OrderDetails>
-              <Dd>Order details:</Dd>
-              <Dt>
-                Sell up to{' '}
-                <Highlight>
-                  {watch(sellTokenId)} {sellToken.symbol}
-                </Highlight>{' '}
-                at a price{' '}
-                <Highlight>
-                  1 {sellToken.symbol} = {_calculatePrice()} {receiveToken.symbol}
-                </Highlight>{' '}
-                or better. <br />
-                Your order might be partially filled.
-              </Dt>
-
-              <Dd>Fee:</Dd>
-              <Dt>
-                <Highlight>{FEE_PERCENTAGE}%</Highlight>, included already in your limit price.
-              </Dt>
-
-              <Dd>Expiration date:</Dd>
-              <Dt>
-                <Highlight>30 min</Highlight>
-              </Dt>
-            </OrderDetails>
-          )}
+          <OrderDetails
+            sellTokenId={sellTokenId}
+            sellToken={sellToken}
+            receiveTokenId={receiveTokenId}
+            receiveToken={receiveToken}
+          />
           <SubmitButton type="submit" disabled={!methods.formState.isValid}>
             <FontAwesomeIcon icon={faPaperPlane} size="lg" />{' '}
             {sameToken ? 'Please select different tokens' : 'Send limit order'}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -112,7 +112,7 @@ const TradeWidget: React.FC = () => {
         <WrappedForm onSubmit={handleSubmit(data => console.log('data', data))}>
           {sameToken && <WarningLabel>Tokens cannot be the same!</WarningLabel>}
           <TokenRow
-            token={sellToken}
+            selectedToken={sellToken}
             tokens={tokens}
             balance={sellTokenBalance}
             selectLabel="sell"
@@ -124,7 +124,7 @@ const TradeWidget: React.FC = () => {
             <FontAwesomeIcon icon={faExchangeAlt} rotation={90} size="2x" />
           </IconWrapper>
           <TokenRow
-            token={receiveToken}
+            selectedToken={receiveToken}
             tokens={tokens}
             balance={receiveTokenBalance}
             selectLabel="receive"

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -17,8 +17,8 @@ import { tokenListApi } from 'api'
 import { Network, TokenDetails } from 'types'
 
 import { getToken } from 'utils'
-// TODO: get from config
-const feeAmount = 0.1
+
+import { FEE_PERCENTAGE } from 'const'
 
 // TODO: move to utils?
 function calculatePrice(sellAmount: number, receiveAmount: number): number {
@@ -187,7 +187,7 @@ const TradeWidget: React.FC = () => {
 
               <Dd>Fee:</Dd>
               <Dt>
-                <Highlight>{feeAmount}%</Highlight>, included already in your limit price.
+                <Highlight>{FEE_PERCENTAGE}%</Highlight>, included already in your limit price.
               </Dt>
 
               <Dd>Expiration date:</Dd>

--- a/src/const.ts
+++ b/src/const.ts
@@ -17,6 +17,7 @@ export const BATCH_TIME = 300
 
 // UI constants
 export const HIGHLIGHT_TIME = 5000
+export const FEE_PERCENTAGE = (1 / FEE_DENOMINATOR) * 100 // syntatic sugar for displaying purposes
 
 export const LEGALDOCUMENT = {
   CONTACT_ADDRESS: '[INSERT ADDRESS]',

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,5 +1,6 @@
 import BN from 'bn.js'
 import { TEN } from 'const'
+import { TokenDetails } from 'types'
 
 const DEFAULT_DECIMALS = 4
 const DEFAULT_PRECISION = 18
@@ -110,4 +111,8 @@ export function abbreviateString(inputString: string, prefixLength: number, suff
   const prefix = inputString.slice(0, _prefixLength)
   const suffix = suffixLength > 0 ? inputString.slice(-suffixLength) : ''
   return prefix + ELLIPSIS + suffix
+}
+
+export function safeTokenName(token: TokenDetails): string {
+  return token.symbol || token.name || abbreviateString(token.address, 6, 4)
 }


### PR DESCRIPTION
Part of #102 

Depends on #165 

---

Adding the order details with a simple price calculation, as per the requirement **RF.2.5 Swap widget: Create sell order**.

![order-details](https://user-images.githubusercontent.com/43217/68064522-f6c94880-fcd9-11e9-8019-f93b96def805.png)
