### PR TITLE
162/fix null on get token

### DIFF
--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -8,7 +8,7 @@ export const log = process.env.NODE_ENV === 'test' ? noop : console.log
 export function getToken<T extends TokenDetails>(
   key: string,
   value: string | undefined = '',
-  tokens: T[] | undefined = [],
+  tokens: T[] | undefined | null,
 ): T | undefined {
-  return tokens.find(token => token[key] === value.toUpperCase())
+  return (tokens || []).find(token => token[key] === value.toUpperCase())
 }

--- a/test/utils/miscellaneous.spec.ts
+++ b/test/utils/miscellaneous.spec.ts
@@ -13,6 +13,9 @@ describe('getToken', () => {
     it('returns `undefined` on `undefined` tokens list', () => {
       expect(getToken('symbol', 'any', undefined)).toBeUndefined()
     })
+    it('returns `undefined` on `null` tokens list', () => {
+      expect(getToken('symbol', 'any', null)).toBeUndefined()
+    })
     it('returns `undefined` when value not in tokens list', () => {
       expect(getToken('symbol', 'any', tokenList)).toBeUndefined()
     })


### PR DESCRIPTION
Left over from #163 

Could see the issue when merging into #165.

The refactor to use default values works for `undefined` arguments, but doesn't work when it's `null`.

Reference: https://www.typescriptlang.org/docs/handbook/functions.html#optional-and-default-parameters