### PR TITLE
Use BN over Number

### DIFF
--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -7,7 +7,7 @@ import { useFormContext } from 'react-hook-form'
 import TokenImg from 'components/TokenImg'
 import TokenSelector from 'components/TokenSelector'
 import { TokenDetails, TokenBalanceDetails } from 'types'
-import { formatAmount, formatAmountFull, parseAmount } from 'utils'
+import { formatAmount, formatAmountFull, parseAmount, adjustPrecision } from 'utils'
 import { ZERO } from 'const'
 
 const Wrapper = styled.div`
@@ -78,16 +78,6 @@ function displayBalance(balance: TokenBalanceDetails | undefined | null, key: st
     return '0'
   }
   return formatAmount(balance[key], balance.decimals) || '0'
-}
-
-function adjustPrecision(value: string | undefined | null, precision: number): string {
-  const match = (value || '').match(/(^\d+\.)(\d+)$/)
-  if (match && match[2].length > precision) {
-    let [, intPart, decimalPart] = match
-    decimalPart = decimalPart.slice(0, precision)
-    return intPart + decimalPart
-  }
-  return value
 }
 
 // TODO: move into a validators file?

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useEffect, useCallback } from 'react'
+import BN from 'bn.js'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import { useFormContext } from 'react-hook-form'
@@ -6,7 +7,8 @@ import { useFormContext } from 'react-hook-form'
 import TokenImg from 'components/TokenImg'
 import TokenSelector from 'components/TokenSelector'
 import { TokenDetails, TokenBalanceDetails } from 'types'
-import { formatAmount, formatAmountFull } from 'utils'
+import { formatAmount, formatAmountFull, parseAmount } from 'utils'
+import { ZERO } from 'const'
 
 const Wrapper = styled.div`
   display: flex;
@@ -78,13 +80,19 @@ function displayBalance(balance: TokenBalanceDetails | undefined | null, key: st
   return formatAmount(balance[key], balance.decimals) || '0'
 }
 
-function getMax(balance: TokenBalanceDetails | null, token: TokenDetails): string {
-  return formatAmountFull((balance || {}).exchangeBalance, token.decimals, false) || '0'
+function adjustPrecision(value: string | undefined | null, precision: number): string {
+  const match = (value || '').match(/(^\d+\.)(\d+)$/)
+  if (match && match[2].length > precision) {
+    let [, intPart, decimalPart] = match
+    decimalPart = decimalPart.slice(0, precision)
+    return intPart + decimalPart
+  }
+  return value
 }
 
 // TODO: move into a validators file?
-function validatePositive(value: string): true | string {
-  return Number(value) > 0 || 'Invalid amount'
+function validatePositive(value: string, precision: number): true | string {
+  return new BN(parseAmount(value, precision) || '0').gt(ZERO) || 'Invalid amount'
 }
 
 interface Props {
@@ -110,19 +118,23 @@ const TokenRow: React.FC<Props> = ({
 }) => {
   const { register, errors, setValue, watch } = useFormContext()
   const error = errors[inputId]
+  const inputValue = watch(inputId)
 
-  const max = Number(getMax(balance, selectedToken))
-  const inputValue = Number(watch(inputId)) || 0
-  const overMax = validateMaxAmount && inputValue > max ? inputValue - max : 0
+  let overMax = ZERO
+  if (balance && validateMaxAmount) {
+    const max = balance.exchangeBalance
+    const value = new BN(parseAmount(inputValue, selectedToken.decimals) || '0')
+    overMax = value.gt(max) ? value.sub(max) : ZERO
+  }
 
-  const className = error ? 'error' : !!overMax ? 'warning' : ''
+  const className = error ? 'error' : overMax.gt(ZERO) ? 'warning' : ''
 
   const errorOrWarning = error ? (
     <WalletDetail className="error">{error.message}</WalletDetail>
   ) : (
-    !!overMax && (
+    overMax.gt(ZERO) && (
       <WalletDetail className="warning">
-        Selling {overMax.toFixed(4)} {selectedToken.symbol} over your current balance
+        Selling {formatAmountFull(overMax, selectedToken.decimals)} {selectedToken.symbol} over your current balance
       </WalletDetail>
     )
   )
@@ -130,6 +142,17 @@ const TokenRow: React.FC<Props> = ({
   function useMax(): void {
     setValue(inputId, formatAmountFull(balance.exchangeBalance, balance.decimals, false))
   }
+
+  const enforcePrecision = useCallback(() => {
+    const newValue = adjustPrecision(inputValue, selectedToken.decimals)
+    if (inputValue !== newValue) {
+      setValue(inputId, newValue, true)
+    }
+  }, [inputValue, selectedToken.decimals, setValue, inputId])
+
+  useEffect(() => {
+    enforcePrecision()
+  }, [enforcePrecision])
 
   return (
     <Wrapper>
@@ -151,9 +174,10 @@ const TokenRow: React.FC<Props> = ({
           required
           ref={register({
             validate: {
-              positive: (value: string): true | string => validatePositive(value),
+              positive: (value: string): true | string => validatePositive(value, selectedToken.decimals),
             },
           })}
+          onChange={enforcePrecision}
         />
         {errorOrWarning}
         <WalletDetail>

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -73,11 +73,14 @@ const WalletDetail = styled.div`
   }
 `
 
-function displayBalance(balance: TokenBalanceDetails | undefined | null, key: string): string {
+function displayBalance<K extends keyof TokenBalanceDetails>(
+  balance: TokenBalanceDetails | undefined | null,
+  key: K,
+): string {
   if (!balance) {
     return '0'
   }
-  return formatAmount(balance[key], balance.decimals) || '0'
+  return formatAmount(balance[key] as BN, balance.decimals) || '0'
 }
 
 // TODO: move into a validators file?

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -93,6 +93,10 @@ function preventInvalidChars(event: React.KeyboardEvent<HTMLInputElement>): void
   }
 }
 
+function validatePositive(value: string): true | string {
+  return Number(value) > 0 || 'Invalid amount'
+}
+
 interface Props {
   selectedToken: TokenDetails
   tokens: TokenDetails[]
@@ -192,6 +196,7 @@ const TokenRow: React.FC<Props> = ({
           required
           ref={register({
             pattern: { value: validInputPattern, message: 'Invalid amount' },
+            validate: { positive: validatePositive },
           })}
           onKeyPress={preventInvalidChars}
           onChange={enforcePrecision}

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useMemo } from 'react'
+import React, { useEffect, useCallback } from 'react'
 import BN from 'bn.js'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
@@ -83,7 +83,7 @@ function displayBalance<K extends keyof TokenBalanceDetails>(
   return formatAmount(balance[key] as BN, balance.decimals) || '0'
 }
 
-const validInputPattern = new RegExp(/^\d+(\.(\d+)?)?$/) // allows leading and trailing zeros
+const validInputPattern = new RegExp(/^\d+\.?\d*$/) // allows leading and trailing zeros
 const leadingAndTrailingZeros = new RegExp(/(^0*(?=\d)|\.0*$)/, 'g') // removes leading zeros and trailing '.' followed by zeros
 const trailingZerosAfterDot = new RegExp(/(.*\.\d+?)0*$/) // selects valid input without leading zeros after '.'
 
@@ -152,12 +152,13 @@ const TokenRow: React.FC<Props> = ({
     enforcePrecision()
   }, [enforcePrecision])
 
-  const removeExcessZeros = useMemo(
+  const removeExcessZeros = useCallback(
     () => (event: React.SyntheticEvent<HTMLInputElement>): void => {
       // Q: Why do we need this function instead of relying on `preventInvalidChars` or `enforcePrecision`?
       // A: Because on those functions we still want the user to be able to input partial values. E.g.:
       //    0 -> 0. -> 0.1 -> 0.10 -> 0.105
-      //    When losing focus though, we remove everything that's redundant, such as leading zeros, trailing dots and/or zeros
+      //    When losing focus though (`onBlur`), we remove everything that's redundant, such as leading zeros,
+      //    trailing dots and/or zeros
       // Q: Why not use formatAmount/parseAmount that already take care of this?
       // A: Too many steps (convert to and from BN) and binds the function to selectedToken.decimals
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -85,9 +85,11 @@ export function parseAmount(amountFmt: string, amountPrecision = DEFAULT_PRECISI
 
   const groups = /^(\d+)(?:\.(\d+))?$/.exec(amountFmt)
   if (groups) {
-    const [, integerPart, decimalPart = ''] = groups
+    const integerPart = groups[1]
+    let decimalPart = groups[2] || ''
     if (decimalPart.length > amountPrecision) {
-      return null
+      // truncate whatever is over precision
+      decimalPart = decimalPart.slice(0, amountPrecision)
     }
 
     const decimalBN = new BN(decimalPart.padEnd(amountPrecision, '0'))

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -100,6 +100,30 @@ export function parseAmount(amountFmt: string, amountPrecision = DEFAULT_PRECISI
   }
 }
 
+/**
+ * Adjust the decimal precision of the given decimal value, without converting to/from BN or Number
+ * Takes in a string and returns a string
+ *
+ * E.g.:
+ * adjustPrecision('1.2657', 3) === '1.265'
+ *
+ * @param value The decimal value to be adjusted as a string
+ * @param precision How many decimals should be kept
+ */
+export function adjustPrecision(value: string | undefined | null, precision: number): string {
+  if (!value) {
+    return ''
+  }
+
+  const match = value.match(/(^\d+\.)(\d+)$/)
+  if (match && match[2].length > precision) {
+    let [, intPart, decimalPart] = match
+    decimalPart = decimalPart.slice(0, precision)
+    return intPart + decimalPart
+  }
+  return value
+}
+
 export function abbreviateString(inputString: string, prefixLength: number, suffixLength: number = 0): string {
   // abbreviate only if it makes sense, and make sure ellipsis fits into word
   // 1. always add ellipsis

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -115,13 +115,8 @@ export function adjustPrecision(value: string | undefined | null, precision: num
     return ''
   }
 
-  const match = value.match(/(^\d+\.)(\d+)$/)
-  if (match && match[2].length > precision) {
-    let [, intPart, decimalPart] = match
-    decimalPart = decimalPart.slice(0, precision)
-    return intPart + decimalPart
-  }
-  return value
+  const regexp = new RegExp(`(\\.\\d{${precision}})\\d+$`)
+  return value.replace(regexp, '$1')
 }
 
 export function abbreviateString(inputString: string, prefixLength: number, suffixLength: number = 0): string {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -78,28 +78,6 @@ export function formatAmountFull(
   return formatAmount(amount, amountPrecision, amountPrecision, thousandSeparator)
 }
 
-export function parseAmount(amountFmt: string, amountPrecision = DEFAULT_PRECISION): BN | null {
-  if (!amountFmt) {
-    return null
-  }
-
-  const groups = /^(\d+)(?:\.(\d+))?$/.exec(amountFmt)
-  if (groups) {
-    const integerPart = groups[1]
-    let decimalPart = groups[2] || ''
-    if (decimalPart.length > amountPrecision) {
-      // truncate whatever is over precision
-      decimalPart = decimalPart.slice(0, amountPrecision)
-    }
-
-    const decimalBN = new BN(decimalPart.padEnd(amountPrecision, '0'))
-    const factor = TEN.pow(new BN(amountPrecision))
-    return new BN(integerPart).mul(factor).add(decimalBN)
-  } else {
-    return null
-  }
-}
-
 /**
  * Adjust the decimal precision of the given decimal value, without converting to/from BN or Number
  * Takes in a string and returns a string
@@ -117,6 +95,24 @@ export function adjustPrecision(value: string | undefined | null, precision: num
 
   const regexp = new RegExp(`(\\.\\d{${precision}})\\d+$`)
   return value.replace(regexp, '$1')
+}
+
+export function parseAmount(amountFmt: string, amountPrecision = DEFAULT_PRECISION): BN | null {
+  if (!amountFmt) {
+    return null
+  }
+
+  const adjustedAmount = adjustPrecision(amountFmt, amountPrecision)
+  const groups = /^(\d+)(?:\.(\d+))?$/.exec(adjustedAmount)
+  if (groups) {
+    const [, integerPart, decimalPart = ''] = groups
+
+    const decimalBN = new BN(decimalPart.padEnd(amountPrecision, '0'))
+    const factor = TEN.pow(new BN(amountPrecision))
+    return new BN(integerPart).mul(factor).add(decimalBN)
+  } else {
+    return null
+  }
 }
 
 export function abbreviateString(inputString: string, prefixLength: number, suffixLength: number = 0): string {

--- a/test/utils/adjustPrecision.spec.ts
+++ b/test/utils/adjustPrecision.spec.ts
@@ -1,0 +1,34 @@
+import { adjustPrecision } from 'utils'
+
+describe('bellow precision', () => {
+  test('with decimals', () => {
+    expect(adjustPrecision('1.1', 3)).toBe('1.1')
+  })
+  test('only integers', () => {
+    expect(adjustPrecision('1', 3)).toBe('1')
+  })
+  test('partial number', () => {
+    expect(adjustPrecision('1.', 3)).toBe('1.')
+  })
+})
+
+describe('over precision', () => {
+  test('truncating', () => {
+    expect(adjustPrecision('1.2345', 3)).toBe('1.234')
+  })
+  test('zero padding', () => {
+    expect(adjustPrecision('1.00000000', 2)).toBe('1.00')
+  })
+})
+
+describe('null values', () => {
+  test('empty string', () => {
+    expect(adjustPrecision('', 2)).toBe('')
+  })
+  test('undefined', () => {
+    expect(adjustPrecision(undefined, 2)).toBe('')
+  })
+  test('null', () => {
+    expect(adjustPrecision(null, 2)).toBe('')
+  })
+})

--- a/test/utils/parseAmount.spec.ts
+++ b/test/utils/parseAmount.spec.ts
@@ -96,3 +96,13 @@ describe('Big amounts', () => {
     expect(parseAmount(input)).toEqual(new BN(new BN(ALLOWANCE_MAX_VALUE)))
   })
 })
+
+describe('Over precision', () => {
+  test('truncates at precision', () => {
+    expect(parseAmount('1.23', 1)).toEqual(new BN('12'))
+  })
+
+  test('0 padding', () => {
+    expect(parseAmount('10.000', 1)).toEqual(new BN('100'))
+  })
+})


### PR DESCRIPTION
Depends on #175 

---

Proposal to use BN instead of Number on Trading widget.

To be able to work with the proper precision for each token, this change enforces only max precision chars are used for each respective token, preventing the user from inserting more than given precision.

Try it out and let me know what you think

---

**Edit**: Based on comments, did a small refactor on the validation:

- [x] No longer alowing chars other than 0-9 and .
- [x] Validating input based on regex rather than converting value to number
- [x] Removing redundant zeros/dot onBlur
- [x] Refactored displayBalance to use keyof
