### PR TITLE
switched improper arg placement in enableToken

### DIFF
--- a/src/components/DepositWidget/useRowActions.tsx
+++ b/src/components/DepositWidget/useRowActions.tsx
@@ -74,8 +74,8 @@ export const useRowActions = (params: Params): Result => {
         }
       })
       const result = await erc20Api.approve(
-        tokenAddress,
         userAddress,
+        tokenAddress,
         contractAddress,
         ALLOWANCE_MAX_VALUE,
         txOptionalParams,


### PR DESCRIPTION
Fixes `enableToken` bug

But on a bigger note, we _really_ should change the API functions to accept `Object args` - see issue #193 to avoid issues as these.