### PR TITLE
99/real exchange api

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "src/index.js",
   "scripts": {
-    "start": "MOCK_EXCHANGE=true NODE_ENV=development webpack-dev-server --mode development --hot",
+    "start": "NODE_ENV=development webpack-dev-server --mode development --hot",
     "mock": "NODE_ENV=development MOCK=true webpack-dashboard -- webpack-dev-server --mode development --hot",
-    "build": "rimraf ./dist && NODE_ENV=production MOCK_EXCHANGE=true webpack --mode production",
+    "build": "rimraf ./dist && NODE_ENV=production webpack --mode production",
     "lint": "eslint src --ext .ts,.tsx,.js",
     "lint:fix": "eslint --fix . --ext .ts,.tsx,.js",
     "stats": "NODE_ENV=production webpack --mode production --env.stats --profile --json > stats.json && webpack-bundle-analyzer ./stats.json ./dist",

--- a/src/api/exchange/DepositApiImpl.ts
+++ b/src/api/exchange/DepositApiImpl.ts
@@ -175,7 +175,7 @@ export class DepositApiImpl implements DepositApi {
   /********************************    private methods   ********************************/
 
   protected async _getNetworkId(): Promise<number> {
-    let networkId = getNetworkIdFromWeb3(this._web3)
+    const networkId = getNetworkIdFromWeb3(this._web3)
 
     return networkId === null ? this._web3.eth.net.getId() : networkId
   }

--- a/src/api/exchange/DepositApiImpl.ts
+++ b/src/api/exchange/DepositApiImpl.ts
@@ -25,7 +25,7 @@ export class DepositApiImpl implements DepositApi {
   private _ReferenceEpochTokenLocker: EpochTokenLocker
   private _web3: Web3
 
-  private static _address2ContractCache: { [K: string]: EpochTokenLocker } = {}
+  protected static _address2ContractCache: { [K: string]: EpochTokenLocker } = {}
 
   public constructor(web3: Web3) {
     this._ReferenceEpochTokenLocker = new web3.eth.Contract(EpochTokenLockerAbi)
@@ -178,14 +178,15 @@ export class DepositApiImpl implements DepositApi {
     let networkId = getNetworkIdFromWeb3(this._web3)
 
     return networkId === null ? this._web3.eth.net.getId() : networkId
-    }
+  }
 
+  protected async _getContract(): Promise<EpochTokenLocker> {
     const networkId = await this._getNetworkId()
 
     return this._getContractForNetwork(networkId)
   }
 
-  private _getContractForNetwork(networkId: number): EpochTokenLocker {
+  protected _getContractForNetwork(networkId: number): EpochTokenLocker {
     const address = this.getContractAddress(networkId)
 
     assert(address, `EpochTokenLocker was not deployed to network ${networkId}`)
@@ -193,7 +194,7 @@ export class DepositApiImpl implements DepositApi {
     return this._getContractAtAddress(address)
   }
 
-  private _getContractAtAddress(address: string): EpochTokenLocker {
+  protected _getContractAtAddress(address: string): EpochTokenLocker {
     const contract = DepositApiImpl._address2ContractCache[address]
 
     if (contract) return contract

--- a/src/api/exchange/DepositApiImpl.ts
+++ b/src/api/exchange/DepositApiImpl.ts
@@ -174,12 +174,13 @@ export class DepositApiImpl implements DepositApi {
 
   /********************************    private methods   ********************************/
 
-  private async _getContract(): Promise<EpochTokenLocker> {
+  protected async _getNetworkId(): Promise<number> {
     let networkId = getNetworkIdFromWeb3(this._web3)
 
-    if (networkId === null) {
-      networkId = await this._web3.eth.net.getId()
+    return networkId === null ? this._web3.eth.net.getId() : networkId
     }
+
+    const networkId = await this._getNetworkId()
 
     return this._getContractForNetwork(networkId)
   }

--- a/src/api/exchange/DepositApiImpl.ts
+++ b/src/api/exchange/DepositApiImpl.ts
@@ -138,7 +138,7 @@ export class DepositApiImpl implements DepositApi {
       tx.once('transactionHash', txOptionalParams.onSentTransaction)
     }
 
-    log(`[DepositApiImpl] Deposited ${amount} for token ${tokenAddress}. User ${userAddress}`)
+    log(`[DepositApiImpl] Deposited ${amount.toString()} for token ${tokenAddress}. User ${userAddress}`)
     return tx
   }
 
@@ -153,7 +153,7 @@ export class DepositApiImpl implements DepositApi {
       tx.once('transactionHash', txOptionalParams.onSentTransaction)
     }
 
-    log(`[DepositApiImpl] Requested withdraw of ${amount} for token ${tokenAddress}. User ${userAddress}`)
+    log(`[DepositApiImpl] Requested withdraw of ${amount.toString()} for token ${tokenAddress}. User ${userAddress}`)
     return tx
   }
 

--- a/src/api/exchange/ExchangeApiImpl.ts
+++ b/src/api/exchange/ExchangeApiImpl.ts
@@ -1,7 +1,7 @@
 import assert from 'assert'
 
 import { DepositApiImpl } from './DepositApiImpl'
-import { ExchangeApi, Order, PlaceOrderParams, Receipt, TxOptionalParams, StablecoinConverter } from 'types'
+import { ExchangeApi, PlaceOrderParams, Receipt, TxOptionalParams, StablecoinConverter, AuctionElement } from 'types'
 import StablecoinConvertedAbi from './StablecoinConverterAbi'
 import { log } from 'utils'
 
@@ -30,9 +30,9 @@ const orderPattern = `(?<user>${hn(ADDRESS_WIDTH)})(?<sellTokenBalance>${hn(UINT
 
 // decodes Orders for a userAddress if passed one
 // otherwise decodes all Orders for all users
-const decodeAuctionElements = (bytes: string, userAddress?: string): Order[] => {
+const decodeAuctionElements = (bytes: string, userAddress?: string): AuctionElement[] => {
   const userAddressLC = userAddress && userAddress.toLowerCase()
-  const result: Order[] = []
+  const result: AuctionElement[] = []
   const oneOrder = new RegExp(orderPattern, 'g')
   let order
   while ((order = oneOrder.exec(bytes))) {
@@ -98,7 +98,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     ;(window as any).exchange = this._ReferenceExchangeContract
   }
 
-  public async getOrders(userAddress: string): Promise<Order[]> {
+  public async getOrders(userAddress: string): Promise<AuctionElement[]> {
     const contract = await this._getContract()
     log(`[ExchangeApiImpl] Getting Orders for account ${userAddress}`)
 

--- a/src/api/exchange/ExchangeApiImpl.ts
+++ b/src/api/exchange/ExchangeApiImpl.ts
@@ -1,0 +1,146 @@
+import assert from 'assert'
+
+import { DepositApiImpl } from './DepositApiImpl'
+import { ExchangeApi, Order, PlaceOrderParams, Receipt, TxOptionalParams, StablecoinConverter } from 'types'
+import StablecoinConvertedAbi from './StablecoinConverterAbi'
+import { log } from 'utils'
+
+import Web3 from 'web3'
+
+/**
+ * Basic implementation of Stable Coin Converter API
+ */
+export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
+  private _ReferenceExchangeContract: StablecoinConverter
+
+  protected static _address2ContractCache: { [K: string]: StablecoinConverter } = {}
+
+  public constructor(web3: Web3) {
+    super(web3)
+
+    this._ReferenceExchangeContract = new web3.eth.Contract(StablecoinConvertedAbi)
+
+    // TODO remove later
+    ;(window as any).exchange = this._ReferenceExchangeContract
+  }
+
+  public async getOrders(userAddress: string): Promise<Order[]> {
+    // TODO different API
+    // can't return a dynamic array from a contract
+    // const contract = await this._getContract()
+    // return contract.methods.orders(userAddress).call()
+
+    log(`[ExchangeApiImpl] Getting Orders for account ${userAddress}`)
+
+    return []
+  }
+
+  public async getNumTokens(): Promise<number> {
+    const contract = await this._getContract()
+    const numTokens = await contract.methods.numTokens().call()
+    return +numTokens
+  }
+
+  /**
+   * Fee is 1/fee_denominator.
+   * i.e. 1/1000 = 0.1%
+   */
+  public async getFeeDenominator(): Promise<number> {
+    const contract = await this._getContract()
+    const feeDenominator = await contract.methods.feeDenominator().call()
+    return +feeDenominator
+  }
+
+  public async getTokenAddressById(tokenId: number): Promise<string> {
+    const contract = await this._getContract()
+    return contract.methods.tokenIdToAddressMap(tokenId).call()
+  }
+
+  public async getTokenIdByAddress(tokenAddress: string): Promise<number> {
+    const contract = await this._getContract()
+    const tokenId = await contract.methods.tokenAddressToIdMap(tokenAddress).call()
+    return +tokenId
+  }
+
+  public async addToken(tokenAddress: string, txOptionalParams?: TxOptionalParams): Promise<Receipt> {
+    const contract = await this._getContract()
+    const tx = contract.methods.addToken(tokenAddress).send()
+
+    if (txOptionalParams && txOptionalParams.onSentTransaction) {
+      tx.once('transactionHash', txOptionalParams.onSentTransaction)
+    }
+
+    log(`[ExchangeApiImpl] Added Token ${tokenAddress}`)
+
+    return tx
+  }
+
+  public async placeOrder(orderParams: PlaceOrderParams, txOptionalParams?: TxOptionalParams): Promise<Receipt> {
+    const { userAddress, buyTokenId, sellTokenId, validUntil, buyAmount, sellAmount } = orderParams
+
+    const contract = await this._getContract()
+
+    const tx = contract.methods
+      .placeOrder(buyTokenId, sellTokenId, validUntil, buyAmount.toString(), sellAmount.toString())
+      .send({ from: userAddress })
+
+    if (txOptionalParams && txOptionalParams.onSentTransaction) {
+      tx.once('transactionHash', txOptionalParams.onSentTransaction)
+    }
+
+    log(
+      `[ExchangeApiImpl] Placed Order to 
+      SELL ${sellAmount.toString()} tokenId ${sellTokenId} for ${buyAmount.toString()} tokenId ${buyTokenId}
+      order valid until ${validUntil}
+      `,
+    )
+
+    return tx
+  }
+
+  public async cancelOrder(
+    senderAddress: string,
+    orderId: number,
+    txOptionalParams?: TxOptionalParams,
+  ): Promise<Receipt> {
+    const contract = await this._getContract()
+    const tx = contract.methods.cancelOrder([orderId]).send({ from: senderAddress })
+
+    if (txOptionalParams && txOptionalParams.onSentTransaction) {
+      tx.once('transactionHash', txOptionalParams.onSentTransaction)
+    }
+
+    log(`[ExchangeApiImpl] Cancelled Order ${orderId}`)
+
+    return tx
+  }
+
+  /********************************    private methods   ********************************/
+
+  protected async _getContract(): Promise<StablecoinConverter> {
+    const networkId = await this._getNetworkId()
+
+    return this._getContractForNetwork(networkId)
+  }
+
+  protected _getContractForNetwork(networkId: number): StablecoinConverter {
+    const address = this.getContractAddress(networkId)
+
+    assert(address, `StablecoinConverter was not deployed to network ${networkId}`)
+
+    return this._getContractAtAddress(address)
+  }
+
+  protected _getContractAtAddress(address: string): StablecoinConverter {
+    const contract = ExchangeApiImpl._address2ContractCache[address]
+
+    if (contract) return contract
+
+    const newContract = this._ReferenceExchangeContract.clone()
+    newContract.options.address = address
+
+    return (ExchangeApiImpl._address2ContractCache[address] = newContract)
+  }
+}
+
+export default ExchangeApiImpl

--- a/src/api/exchange/ExchangeApiImpl.ts
+++ b/src/api/exchange/ExchangeApiImpl.ts
@@ -156,7 +156,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     const contract = await this._getContract()
 
     const tx = contract.methods
-      .placeOrder(buyTokenId, sellTokenId, validUntil, buyAmount.toString(), sellAmount.toString())
+      .placeOrder(buyTokenId, sellTokenId, validUntil, buyAmount, sellAmount)
       .send({ from: userAddress })
 
     if (txOptionalParams && txOptionalParams.onSentTransaction) {

--- a/src/api/exchange/ExchangeApiImpl.ts
+++ b/src/api/exchange/ExchangeApiImpl.ts
@@ -174,8 +174,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
   }
 
   public async cancelOrder(
-    senderAddress: string,
-    orderId: number,
+    { senderAddress, orderId }: { senderAddress: string; orderId: number },
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt> {
     const contract = await this._getContract()

--- a/src/api/exchange/ExchangeApiMock.ts
+++ b/src/api/exchange/ExchangeApiMock.ts
@@ -1,8 +1,8 @@
 import assert from 'assert'
 
 import { DepositApiMock, BalancesByUserAndToken } from './DepositApiMock'
-import { ExchangeApi, Order, PlaceOrderParams, Erc20Api, Receipt, TxOptionalParams } from 'types'
-import { FEE_DENOMINATOR } from 'const'
+import { ExchangeApi, AuctionElement, PlaceOrderParams, Erc20Api, Receipt, TxOptionalParams, Order } from 'types'
+import { FEE_DENOMINATOR, ONE } from 'const'
 import { waitAndSendReceipt } from 'utils/mock'
 import { RECEIPT } from '../../../test/data'
 
@@ -36,9 +36,9 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
     this.orders = ordersByUser
   }
 
-  public async getOrders(userAddress: string): Promise<Order[]> {
+  public async getOrders(userAddress: string): Promise<AuctionElement[]> {
     this._initOrders(userAddress)
-    return this.orders[userAddress]
+    return this.orders[userAddress].map(order => ({ ...order, user: userAddress, sellTokenBalance: ONE }))
   }
 
   public async getNumTokens(): Promise<number> {

--- a/src/api/exchange/StablecoinConverterAbi.ts
+++ b/src/api/exchange/StablecoinConverterAbi.ts
@@ -1,0 +1,878 @@
+import { AbiItem } from 'web3-utils'
+
+const StablecoinConvertedAbi: AbiItem[] = [
+  {
+    constant: true,
+    inputs: [],
+    name: 'getSecondsRemainingInBatch',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'feeDenominator',
+    outputs: [
+      {
+        name: '',
+        type: 'uint128',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: 'user',
+        type: 'address',
+      },
+      {
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'getPendingWithdrawAmount',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'token',
+        type: 'address',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'requestWithdraw',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: 'user',
+        type: 'address',
+      },
+      {
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'getPendingDepositAmount',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'token',
+        type: 'address',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'deposit',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: 'user',
+        type: 'address',
+      },
+      {
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'getPendingWithdrawBatchNumber',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'TOKEN_ADDITION_FEE_IN_OWL',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'feeToken',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '',
+        type: 'uint16',
+      },
+    ],
+    name: 'currentPrices',
+    outputs: [
+      {
+        name: '',
+        type: 'uint128',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'orders',
+    outputs: [
+      {
+        name: 'buyToken',
+        type: 'uint16',
+      },
+      {
+        name: 'sellToken',
+        type: 'uint16',
+      },
+      {
+        name: 'validFrom',
+        type: 'uint32',
+      },
+      {
+        name: 'validUntil',
+        type: 'uint32',
+      },
+      {
+        name: 'priceNumerator',
+        type: 'uint128',
+      },
+      {
+        name: 'priceDenominator',
+        type: 'uint128',
+      },
+      {
+        name: 'usedAmount',
+        type: 'uint128',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'numTokens',
+    outputs: [
+      {
+        name: '',
+        type: 'uint16',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'lastCreditBatchId',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'latestSolution',
+    outputs: [
+      {
+        name: 'batchId',
+        type: 'uint32',
+      },
+      {
+        name: 'solutionSubmitter',
+        type: 'address',
+      },
+      {
+        name: 'feeReward',
+        type: 'uint256',
+      },
+      {
+        name: 'objectiveValue',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: 'user',
+        type: 'address',
+      },
+      {
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'getBalance',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'BATCH_TIME',
+    outputs: [
+      {
+        name: '',
+        type: 'uint32',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'getCurrentBatchId',
+    outputs: [
+      {
+        name: '',
+        type: 'uint32',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'token',
+        type: 'address',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        name: 'batchId',
+        type: 'uint32',
+      },
+    ],
+    name: 'requestFutureWithdraw',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: 'user',
+        type: 'address',
+      },
+      {
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'hasValidWithdrawRequest',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'MAX_TOKENS',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: 'user',
+        type: 'address',
+      },
+      {
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'getPendingDepositBatchNumber',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'user',
+        type: 'address',
+      },
+      {
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'withdraw',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'MAX_TOUCHED_ORDERS',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        name: 'maxTokens',
+        type: 'uint256',
+      },
+      {
+        name: '_feeDenominator',
+        type: 'uint128',
+      },
+      {
+        name: '_feeToken',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'buyToken',
+        type: 'uint16',
+      },
+      {
+        indexed: false,
+        name: 'sellToken',
+        type: 'uint16',
+      },
+      {
+        indexed: false,
+        name: 'validFrom',
+        type: 'uint32',
+      },
+      {
+        indexed: false,
+        name: 'validUntil',
+        type: 'uint32',
+      },
+      {
+        indexed: false,
+        name: 'priceNumerator',
+        type: 'uint128',
+      },
+      {
+        indexed: false,
+        name: 'priceDenominator',
+        type: 'uint128',
+      },
+    ],
+    name: 'OrderPlacement',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'id',
+        type: 'uint256',
+      },
+    ],
+    name: 'OrderCancelation',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        name: 'user',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'token',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'stateIndex',
+        type: 'uint256',
+      },
+    ],
+    name: 'Deposit',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        name: 'user',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'token',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'stateIndex',
+        type: 'uint256',
+      },
+    ],
+    name: 'WithdrawRequest',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        name: 'user',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'token',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Withdraw',
+    type: 'event',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'addToken',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'buyTokens',
+        type: 'uint16[]',
+      },
+      {
+        name: 'sellTokens',
+        type: 'uint16[]',
+      },
+      {
+        name: 'validFroms',
+        type: 'uint32[]',
+      },
+      {
+        name: 'validUntils',
+        type: 'uint32[]',
+      },
+      {
+        name: 'buyAmounts',
+        type: 'uint128[]',
+      },
+      {
+        name: 'sellAmounts',
+        type: 'uint128[]',
+      },
+    ],
+    name: 'placeValidFromOrders',
+    outputs: [
+      {
+        name: 'orderIds',
+        type: 'uint256[]',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'buyToken',
+        type: 'uint16',
+      },
+      {
+        name: 'sellToken',
+        type: 'uint16',
+      },
+      {
+        name: 'validUntil',
+        type: 'uint32',
+      },
+      {
+        name: 'buyAmount',
+        type: 'uint128',
+      },
+      {
+        name: 'sellAmount',
+        type: 'uint128',
+      },
+    ],
+    name: 'placeOrder',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'ids',
+        type: 'uint256[]',
+      },
+    ],
+    name: 'cancelOrder',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'ids',
+        type: 'uint256[]',
+      },
+    ],
+    name: 'freeStorageOfOrder',
+    outputs: [],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      {
+        name: 'batchIndex',
+        type: 'uint32',
+      },
+      {
+        name: 'claimedObjectiveValue',
+        type: 'uint256',
+      },
+      {
+        name: 'owners',
+        type: 'address[]',
+      },
+      {
+        name: 'orderIds',
+        type: 'uint16[]',
+      },
+      {
+        name: 'volumes',
+        type: 'uint128[]',
+      },
+      {
+        name: 'prices',
+        type: 'uint128[]',
+      },
+      {
+        name: 'tokenIdsForPrice',
+        type: 'uint16[]',
+      },
+    ],
+    name: 'submitSolution',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: 'addr',
+        type: 'address',
+      },
+    ],
+    name: 'tokenAddressToIdMap',
+    outputs: [
+      {
+        name: '',
+        type: 'uint16',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: 'id',
+        type: 'uint16',
+      },
+    ],
+    name: 'tokenIdToAddressMap',
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: 'addr',
+        type: 'address',
+      },
+    ],
+    name: 'hasToken',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'getEncodedAuctionElements',
+    outputs: [
+      {
+        name: 'elements',
+        type: 'bytes',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        name: 'batchIndex',
+        type: 'uint32',
+      },
+    ],
+    name: 'acceptingSolutions',
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'getCurrentObjectiveValue',
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function',
+  },
+]
+
+export default StablecoinConvertedAbi

--- a/src/api/exchange/epochList.ts
+++ b/src/api/exchange/epochList.ts
@@ -2,7 +2,7 @@ import { Network } from 'types'
 
 const Network2Epoch = {
   // TODO get addresses from env or a centralized place (npm package?)
-  [Network.Rinkeby]: '0x9046451F7cF124c1d7d1832F76F5e98a33D1610E',
+  [Network.Rinkeby]: '0x9D1a98dF71420035F67209af8c4138ea1C39b9d2',
   // TODO fill in when deployed
   [Network.Mainnet]: '',
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,6 +8,7 @@ import { Erc20ApiImpl } from './erc20/Erc20ApiImpl'
 import { DepositApiMock } from './exchange/DepositApiMock'
 import { DepositApiImpl } from './exchange/DepositApiImpl'
 import { ExchangeApiMock } from './exchange/ExchangeApiMock'
+import { ExchangeApiImpl } from './exchange/ExchangeApiImpl'
 import { tokenList, exchangeBalanceStates, erc20Balances, erc20Allowances, FEE_TOKEN } from '../../test/data'
 import Web3 from 'web3'
 import { INITIAL_INFURA_ENDPOINT } from 'const'
@@ -63,16 +64,16 @@ function createDepositApi(erc20Api: Erc20Api, web3: Web3): DepositApi {
   return depositApi
 }
 
-function createExchangeApi(erc20Api: Erc20Api): ExchangeApi {
+function createExchangeApi(erc20Api: Erc20Api, web3: Web3): ExchangeApi {
+  let exchangeApi
   if (isExchangeMock) {
     const tokens = [FEE_TOKEN, ...tokenList.map(token => token.address)]
-    const exchangeApi = new ExchangeApiMock(exchangeBalanceStates, erc20Api, tokens)
-    window['exchangeApi'] = exchangeApi
-    return exchangeApi
+    exchangeApi = new ExchangeApiMock(exchangeBalanceStates, erc20Api, tokens)
   } else {
-    // TODO: Add actual implementation
-    throw new Error('Not implemented yet. Only mock implementation available')
+    exchangeApi = new ExchangeApiImpl(web3)
   }
+  window['exchangeApi'] = exchangeApi
+  return exchangeApi
 }
 
 // TODO connect to mainnet if we need AUTOCONNECT at all
@@ -85,4 +86,4 @@ export const walletApi: WalletApi = createWalletApi(web3)
 export const tokenListApi: TokenList = createTokenListApi()
 export const erc20Api: Erc20Api = createErc20Api(web3)
 export const depositApi: DepositApi = createDepositApi(erc20Api, web3)
-export const exchangeApi: ExchangeApi = createExchangeApi(erc20Api)
+export const exchangeApi: ExchangeApi = createExchangeApi(erc20Api, web3)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -154,6 +154,8 @@ export interface EpochTokenLocker extends Contract {
 }
 
 export interface Order {
+  user: string
+  sellTokenBalance: BN
   buyTokenId: number
   sellTokenId: number
   validFrom: number

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -310,3 +310,160 @@ export interface ERC20 extends Contract {
     ): TransactionObject<boolean, [string, string, string | number | BN]>
   }
 }
+
+export interface StablecoinConverter extends Contract {
+  clone(): StablecoinConverter
+
+  methods: EpochTokenLocker['methods'] & {
+    getSecondsRemainingInBatch(): TransactionObject<string>
+
+    feeDenominator(): TransactionObject<string>
+
+    getPendingWithdrawAmount(user: string, token: string): TransactionObject<string, [string, string]>
+
+    requestWithdraw(
+      token: string,
+      amount: number | string | BN,
+    ): TransactionObject<void, [string, number | string | BN]>
+
+    getPendingDepositAmount(user: string, token: string): TransactionObject<string, [string, string]>
+
+    deposit(token: string, amount: number | string | BN): TransactionObject<void, [string, number | string | BN]>
+
+    getPendingWithdrawBatchNumber(user: string, token: string): TransactionObject<string, [string, string]>
+
+    TOKEN_ADDITION_FEE_IN_OWL(): TransactionObject<string>
+
+    feeToken(): TransactionObject<string>
+
+    currentPrices(arg0: number | string | BN): TransactionObject<string, [number | string | BN]>
+
+    orders(
+      arg0: string,
+      arg1: number | string | BN,
+    ): TransactionObject<
+      {
+        buyToken: BN
+        sellToken: BN
+        validFrom: BN
+        validUntil: BN
+        isSellOrder: boolean
+        priceNumerator: BN
+        priceDenominator: BN
+        usedAmount: BN
+        0: BN
+        1: BN
+        2: BN
+        3: BN
+        4: BN
+        5: BN
+        6: BN
+      },
+      [string, number | string | BN]
+    >
+
+    numTokens(): TransactionObject<string>
+
+    lastCreditBatchId(arg0: string, arg1: string): TransactionObject<string>
+
+    latestSolution(): TransactionObject<{
+      batchId: string
+      solutionSubmitter: string
+      feeReward: string
+      objectiveValue: string
+      0: string
+      1: string
+      2: string
+      3: string
+    }>
+
+    getBalance(user: string, token: string): TransactionObject<string, [string, string]>
+
+    getCurrentBatchId(): TransactionObject<string>
+
+    requestFutureWithdraw(
+      token: string,
+      amount: number | string | BN,
+      batchId: number | string | BN,
+    ): TransactionObject<void, [string, number | string | BN, number | string | BN]>
+
+    hasValidWithdrawRequest(user: string, token: string): TransactionObject<boolean, [string, string]>
+
+    MAX_TOKENS(): TransactionObject<string>
+
+    getPendingDepositBatchNumber(user: string, token: string): TransactionObject<string, [string, string]>
+
+    withdraw(user: string, token: string): TransactionObject<void, [string, string]>
+
+    MAX_TOUCHED_ORDERS(): TransactionObject<string>
+
+    addToken(token: string): TransactionObject<void, [string]>
+
+    placeValidFromOrders(
+      buyTokens: (number | string | BN)[],
+      sellTokens: (number | string | BN)[],
+      validFroms: (number | string | BN)[],
+      validUntils: (number | string | BN)[],
+      buyAmounts: (number | string | BN)[],
+      sellAmounts: (number | string | BN)[],
+    ): TransactionObject<
+      string[],
+      [
+        (number | string | BN)[],
+        (number | string | BN)[],
+        (number | string | BN)[],
+        (number | string | BN)[],
+        (number | string | BN)[],
+        (number | string | BN)[],
+      ]
+    >
+
+    placeOrder(
+      buyToken: number | string | BN,
+      sellToken: number | string | BN,
+      validUntil: number | string | BN,
+      buyAmount: number | string | BN,
+      sellAmount: number | string | BN,
+    ): TransactionObject<
+      string,
+      [number | string | BN, number | string | BN, number | string | BN, number | string | BN, number | string | BN]
+    >
+
+    cancelOrder(ids: (number | string | BN)[]): TransactionObject<void, [(number | string | BN)[]]>
+
+    freeStorageOfOrder(ids: (number | string | BN)[]): TransactionObject<void, [(number | string | BN)[]]>
+
+    submitSolution(
+      batchIndex: number | string | BN,
+      claimedObjectiveValue: number | string | BN,
+      owners: string[],
+      orderIds: (number | string | BN)[],
+      volumes: (number | string | BN)[],
+      prices: (number | string | BN)[],
+      tokenIdsForPrice: (number | string | BN)[],
+    ): TransactionObject<
+      string,
+      [
+        number | string | BN,
+        number | string | BN,
+        string[],
+        (number | string | BN)[],
+        (number | string | BN)[],
+        (number | string | BN)[],
+        (number | string | BN)[],
+      ]
+    >
+
+    tokenAddressToIdMap(addr: string): TransactionObject<string, [string]>
+
+    tokenIdToAddressMap(id: number | string | BN): TransactionObject<string, [number | string | BN]>
+
+    hasToken(addr: string): TransactionObject<boolean, [string]>
+
+    getEncodedAuctionElements(): TransactionObject<string>
+
+    acceptingSolutions(batchIndex: number | string | BN): TransactionObject<boolean, [number | string | BN]>
+
+    getCurrentObjectiveValue(): TransactionObject<string>
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -154,8 +154,6 @@ export interface EpochTokenLocker extends Contract {
 }
 
 export interface Order {
-  user: string
-  sellTokenBalance: BN
   buyTokenId: number
   sellTokenId: number
   validFrom: number
@@ -163,6 +161,11 @@ export interface Order {
   priceNumerator: BN
   priceDenominator: BN
   remainingAmount: BN
+}
+
+export interface AuctionElement extends Order {
+  user: string
+  sellTokenBalance: BN
 }
 
 export interface PlaceOrderParams {
@@ -175,7 +178,7 @@ export interface PlaceOrderParams {
 }
 
 export interface ExchangeApi extends DepositApi {
-  getOrders(userAddress: string): Promise<Order[]>
+  getOrders(userAddress: string): Promise<AuctionElement[]>
   getNumTokens(): Promise<number>
   getFeeDenominator(): Promise<number>
   getTokenAddressById(tokenId: number): Promise<string> // tokenAddressToIdMap

--- a/test/api/ExchangeApi/ExchangeApiMock.test.ts
+++ b/test/api/ExchangeApi/ExchangeApiMock.test.ts
@@ -117,6 +117,7 @@ describe('addToken', () => {
 
 describe('placeOrder', () => {
   const expected = {
+    sellTokenBalance: ONE,
     buyTokenId: 1,
     sellTokenId: 2,
     validFrom: BATCH_ID,
@@ -140,7 +141,7 @@ describe('placeOrder', () => {
     const response = await instance.placeOrder(params)
     expect(response).toBe(RECEIPT)
     const actual = (await instance.getOrders(USER_1)).pop()
-    expect(actual).toEqual(expected)
+    expect(actual).toEqual({ ...expected, user: USER_1 })
   })
 
   test('place first order', async () => {
@@ -150,7 +151,7 @@ describe('placeOrder', () => {
     const response = await instance.placeOrder(params)
     expect(response).toBe(RECEIPT)
     const actual = (await instance.getOrders(USER_2)).pop()
-    expect(actual).toEqual(expected)
+    expect(actual).toEqual({ ...expected, user: USER_2 })
   })
 })
 describe('cancelOrder', () => {


### PR DESCRIPTION
ExchangeApi implementation with web3

Currently won't work because of:

- ~Only WETH returns a valid tokenID (we may have stale token addresses)~
- web3 Contract methods encode abi with BN incorrectly (will create an issue at web3 tomorrow)
workaround in #221 
- ~can't query dynamic arrays from Contract (will try to use [decoding func from dex-contracts](https://github.com/gnosis/dex-contracts/blob/4f1183d3b583cc44741f50bf85af00263e108c7d/test/utilities.js#L177-L202))~