### PR TITLE
207/orders page layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import Layout from 'components/layout/'
 import About from 'pages/About'
 import Deposit from 'pages/Deposit'
 import Trade from 'pages/Trade'
+import Orders from 'pages/Orders'
 import SourceCode from 'pages/SourceCode'
 import NotFound from 'pages/NotFound'
 import ConnectWallet from 'pages/ConnectWallet'
@@ -59,9 +60,10 @@ const App: React.FC = () => (
     <Router basename={process.env.BASE_URL}>
       <Layout>
         <Switch>
+          <PrivateRoute path="/deposit" exact component={Deposit} />
+          <PrivateRoute path="/orders" exact component={Orders} />
           <Route path="/trade/:sell-:buy" component={Trade} />
           <Route path="/about" exact component={About} />
-          <PrivateRoute path="/deposit" exact component={Deposit} />
           <Route path="/source-code" exact component={SourceCode} />
           <Route path="/connect-wallet" exact component={ConnectWallet} />
           <Redirect from="/" to="/trade/DAI-USDC?sell=0&buy=0" />

--- a/src/components/Highlight.tsx
+++ b/src/components/Highlight.tsx
@@ -2,5 +2,5 @@ import styled from 'styled-components'
 
 export default styled.span`
   font-weight: bold;
-  color: #367be0;
+  color: ${(props): string => props.color || '#367be0'};
 `

--- a/src/components/Highlight.tsx
+++ b/src/components/Highlight.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components'
+
+export default styled.span`
+  font-weight: bold;
+  color: #367be0;
+`

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -2,59 +2,127 @@ import React from 'react'
 import styled from 'styled-components'
 
 import Highlight from 'components/Highlight'
-import TokenImg from 'components/TokenImg'
 import { TokenDetails } from 'types'
 import { safeTokenName } from 'utils'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
 
-const TokenImgWrapper = styled(TokenImg)`
-  height: 1.25em;
-  width: 1.25em;
+const OrderRowWrapper = styled.div`
+  .container {
+    justify-self: center;
 
-  vertical-align: middle;
+    display: grid;
+  }
+
+  .order-details {
+    grid-template-columns: 6em 3em 5em;
+    grid-template-rows: 1fr 1fr;
+    justify-items: left;
+  }
+
+  .sub-columns {
+    gap: 0.5em;
+
+    div:first-child {
+      justify-self: end;
+    }
+    & > div {
+      justify-self: start;
+    }
+  }
+
+  .two-columns {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .three-columns {
+    grid-template-columns: minmax(4em, 60%) minmax(3em, 30%) minmax(1em, 10%);
+  }
 `
 
-interface TokenInfoParams {
-  token: TokenDetails
-  amount: string | React.ReactNode
-  highlight?: boolean
+const OrderDetails: React.FC<Pick<Props, 'price' | 'buyToken' | 'sellToken'>> = ({ price, buyToken, sellToken }) => {
+  return (
+    <div className="container order-details">
+      <div>Sell</div>
+      <div>
+        <Highlight>1</Highlight>
+      </div>
+      <div>
+        <strong>{safeTokenName(sellToken)}</strong>
+      </div>
+
+      <div>
+        for <strong>at least</strong>
+      </div>
+      <div>
+        <Highlight className="error">{price}</Highlight>
+      </div>
+      <div>
+        <strong>{safeTokenName(buyToken)}</strong>
+      </div>
+    </div>
+  )
 }
 
-const TokenInfo: React.FC<TokenInfoParams> = ({ token, amount, highlight = true }) => {
+const UnfilledAmount: React.FC<Pick<Props, 'sellToken' | 'unfilledAmount' | 'unlimited'>> = ({
+  sellToken,
+  unfilledAmount,
+  unlimited,
+}) => {
   return (
-    <>
-      {highlight ? <Highlight>{amount}</Highlight> : amount} <TokenImgWrapper src={token.image} />{' '}
-      <strong>{safeTokenName(token)}</strong>
-    </>
+    <div className={'container' + (unlimited ? '' : ' sub-columns two-columns')}>
+      {unlimited ? (
+        <Highlight>no limit</Highlight>
+      ) : (
+        <>
+          <div>{unfilledAmount}</div>
+          <div>
+            <strong>{safeTokenName(sellToken)}</strong>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+const AvailableAmount: React.FC<Pick<Props, 'sellToken' | 'availableAmount' | 'overBalance'>> = ({
+  sellToken,
+  availableAmount,
+  overBalance,
+}) => {
+  return (
+    <div className="container sub-columns three-columns">
+      <div>{availableAmount}</div>
+      <strong>{safeTokenName(sellToken)}</strong>
+      <div className="warning">{overBalance && <FontAwesomeIcon icon={faExclamationTriangle} />}</div>
+    </div>
   )
 }
 
 // TODO: temporary params, adjust when implementing real logic
 // probably just take an Order object?
-interface Params {
+interface Props {
   id: string
   sellToken: TokenDetails
   buyToken: TokenDetails
   price: string
-  sellTotal: string | React.ReactNode
-  matched: string
-  expiresOn: string | React.ReactNode
+  unfilledAmount: string
+  availableAmount: string
+  expiresOn?: string
+  overBalance?: boolean
+  unlimited?: boolean
 }
 
-const OrderRow: React.FC<Params> = ({ id, sellToken, buyToken, price, sellTotal, matched, expiresOn }) => {
+const OrderRow: React.FC<Props> = props => {
+  const { id, expiresOn, unlimited } = props
   return (
-    <div className="rowContainer">
+    <OrderRowWrapper className="rowContainer" data-id={id}>
       <input type="checkbox" />
-      <div className="cell">{id}</div>
-      <div className="cell">
-        Sell <TokenInfo token={sellToken} amount="1" /> for <strong>at least</strong>{' '}
-        <TokenInfo token={buyToken} amount={price} />
-      </div>
-      <div className="cell">
-        <TokenInfo token={sellToken} amount={sellTotal} highlight={false} />
-      </div>
-      <div className="cell">{matched}</div>
-      <div className="cell">{expiresOn}</div>
-    </div>
+      <OrderDetails {...props} />
+      <UnfilledAmount {...props} />
+      <AvailableAmount {...props} />
+      <div className="cell">{unlimited ? <Highlight>Never</Highlight> : expiresOn}</div>
+    </OrderRowWrapper>
   )
 }
 

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -115,8 +115,9 @@ interface Props {
 const OrderRow: React.FC<Props> = props => {
   const { id, expiresOn, unlimited } = props
   return (
-    <OrderRowWrapper className="rowContainer" data-id={id}>
-      <div>
+    <OrderRowWrapper className="orderRow" data-id={id}>
+      <div></div> {/* TODO: display loading spinner */}
+      <div className="checked">
         <input type="checkbox" />
       </div>
       <OrderDetails {...props} />

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import Highlight from 'components/Highlight'
+import TokenImg from 'components/TokenImg'
+import { TokenDetails } from 'types'
+import { safeTokenName } from 'utils'
+
+const TokenImgWrapper = styled(TokenImg)`
+  height: 1.25em;
+  width: 1.25em;
+
+  vertical-align: middle;
+`
+
+interface TokenInfoParams {
+  token: TokenDetails
+  amount: string | React.ReactNode
+  highlight?: boolean
+}
+
+const TokenInfo: React.FC<TokenInfoParams> = ({ token, amount, highlight = true }) => {
+  return (
+    <>
+      {highlight ? <Highlight>{amount}</Highlight> : amount} <TokenImgWrapper src={token.image} />{' '}
+      <strong>{safeTokenName(token)}</strong>
+    </>
+  )
+}
+
+// TODO: temporary params, adjust when implementing real logic
+// probably just take an Order object?
+interface Params {
+  id: string
+  sellToken: TokenDetails
+  buyToken: TokenDetails
+  price: string
+  sellTotal: string | React.ReactNode
+  matched: string
+  expiresOn: string | React.ReactNode
+}
+
+const OrderRow: React.FC<Params> = ({ id, sellToken, buyToken, price, sellTotal, matched, expiresOn }) => {
+  return (
+    <div className="rowContainer">
+      <input type="checkbox" />
+      <div className="cell">{id}</div>
+      <div className="cell">
+        Sell <TokenInfo token={sellToken} amount="1" /> for <strong>at least</strong>{' '}
+        <TokenInfo token={buyToken} amount={price} />
+      </div>
+      <div className="cell">
+        <TokenInfo token={sellToken} amount={sellTotal} highlight={false} />
+      </div>
+      <div className="cell">{matched}</div>
+      <div className="cell">{expiresOn}</div>
+    </div>
+  )
+}
+
+export default OrderRow

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -44,6 +44,10 @@ const OrderRowWrapper = styled.div`
       padding-top: 40px;
     }
   }
+
+  &.pending {
+    color: grey;
+  }
 `
 
 const PendingLink: React.FC<Pick<Props, 'pending'>> = ({ pending }) => {
@@ -61,12 +65,17 @@ const PendingLink: React.FC<Pick<Props, 'pending'>> = ({ pending }) => {
   )
 }
 
-const OrderDetails: React.FC<Pick<Props, 'price' | 'buyToken' | 'sellToken'>> = ({ price, buyToken, sellToken }) => {
+const OrderDetails: React.FC<Pick<Props, 'price' | 'buyToken' | 'sellToken' | 'pending'>> = ({
+  price,
+  buyToken,
+  sellToken,
+  pending,
+}) => {
   return (
     <div className="container order-details">
       <div>Sell</div>
       <div>
-        <Highlight>1</Highlight>
+        <Highlight color={pending ? 'grey' : ''}>1</Highlight>
       </div>
       <div>
         <strong>{safeTokenName(sellToken)}</strong>
@@ -76,7 +85,7 @@ const OrderDetails: React.FC<Pick<Props, 'price' | 'buyToken' | 'sellToken'>> = 
         for <strong>at least</strong>
       </div>
       <div>
-        <Highlight className="error">{price}</Highlight>
+        <Highlight color={pending ? 'grey' : 'red'}>{price}</Highlight>
       </div>
       <div>
         <strong>{safeTokenName(buyToken)}</strong>
@@ -85,15 +94,16 @@ const OrderDetails: React.FC<Pick<Props, 'price' | 'buyToken' | 'sellToken'>> = 
   )
 }
 
-const UnfilledAmount: React.FC<Pick<Props, 'sellToken' | 'unfilledAmount' | 'unlimited'>> = ({
+const UnfilledAmount: React.FC<Pick<Props, 'sellToken' | 'unfilledAmount' | 'unlimited' | 'pending'>> = ({
   sellToken,
   unfilledAmount,
   unlimited,
+  pending,
 }) => {
   return (
     <div className={'container' + (unlimited ? '' : ' sub-columns two-columns')}>
       {unlimited ? (
-        <Highlight>no limit</Highlight>
+        <Highlight color={pending ? 'grey' : ''}>no limit</Highlight>
       ) : (
         <>
           <div>{unfilledAmount}</div>
@@ -146,7 +156,7 @@ const OrderRow: React.FC<Props> = props => {
       <OrderDetails {...props} />
       <UnfilledAmount {...props} />
       <AvailableAmount {...props} />
-      <div className="cell">{unlimited ? <Highlight>Never</Highlight> : expiresOn}</div>
+      <div className="cell">{unlimited ? <Highlight color={pending ? 'grey' : ''}>Never</Highlight> : expiresOn}</div>
     </OrderRowWrapper>
   )
 }

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -17,7 +17,9 @@ const OrderRowWrapper = styled.div`
   .order-details {
     grid-template-columns: 6em 3em 5em;
     grid-template-rows: 1fr 1fr;
-    justify-items: left;
+    justify-items: start;
+    justify-self: start;
+    padding-left: 1.5em;
   }
 
   .sub-columns {
@@ -25,9 +27,6 @@ const OrderRowWrapper = styled.div`
 
     div:first-child {
       justify-self: end;
-    }
-    & > div {
-      justify-self: start;
     }
   }
 

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -12,6 +12,7 @@ import { safeTokenName } from 'utils'
 const OrderRowWrapper = styled.div`
   .container {
     display: grid;
+    position: relative;
   }
 
   .order-details {
@@ -40,8 +41,8 @@ const OrderRowWrapper = styled.div`
     place-items: center;
 
     a {
+      top: 100%;
       position: absolute;
-      padding-top: 40px;
     }
   }
 

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -9,17 +9,13 @@ import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
 
 const OrderRowWrapper = styled.div`
   .container {
-    justify-self: center;
-
     display: grid;
   }
 
   .order-details {
     grid-template-columns: 6em 3em 5em;
-    grid-template-rows: 1fr 1fr;
-    justify-items: start;
+    grid-template-rows: repeat(2, 1fr);
     justify-self: start;
-    padding-left: 1.5em;
   }
 
   .sub-columns {

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -117,7 +117,9 @@ const OrderRow: React.FC<Props> = props => {
   const { id, expiresOn, unlimited } = props
   return (
     <OrderRowWrapper className="rowContainer" data-id={id}>
-      <input type="checkbox" />
+      <div>
+        <input type="checkbox" />
+      </div>
       <OrderDetails {...props} />
       <UnfilledAmount {...props} />
       <AvailableAmount {...props} />

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -106,7 +106,7 @@ interface Props {
   sellToken: TokenDetails
   buyToken: TokenDetails
   price: string
-  unfilledAmount: string
+  unfilledAmount?: string
   availableAmount: string
   expiresOn?: string
   overBalance?: boolean

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import styled from 'styled-components'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faExclamationTriangle, faSpinner } from '@fortawesome/free-solid-svg-icons'
 
 import Highlight from 'components/Highlight'
+import { EtherscanLink } from 'components/EtherscanLink'
+
 import { TokenDetails } from 'types'
 import { safeTokenName } from 'utils'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
 
 const OrderRowWrapper = styled.div`
   .container {
@@ -33,7 +35,31 @@ const OrderRowWrapper = styled.div`
   .three-columns {
     grid-template-columns: minmax(4em, 60%) minmax(3em, 30%) minmax(1em, 10%);
   }
+
+  .pendingCell {
+    place-items: center;
+
+    a {
+      position: absolute;
+      padding-top: 40px;
+    }
+  }
 `
+
+const PendingLink: React.FC<Pick<Props, 'pending'>> = ({ pending }) => {
+  if (!pending) {
+    // Empty div is required due to grid layout
+    return <div></div>
+  }
+
+  // TODO: use proper pending tx hash for link
+  return (
+    <div className="container pendingCell">
+      <FontAwesomeIcon icon={faSpinner} size="lg" spin />
+      <EtherscanLink identifier="bla" type="tx" label={<small>view</small>} />
+    </div>
+  )
+}
 
 const OrderDetails: React.FC<Pick<Props, 'price' | 'buyToken' | 'sellToken'>> = ({ price, buyToken, sellToken }) => {
   return (
@@ -106,13 +132,14 @@ interface Props {
   expiresOn?: string
   overBalance?: boolean
   unlimited?: boolean
+  pending?: boolean
 }
 
 const OrderRow: React.FC<Props> = props => {
-  const { id, expiresOn, unlimited } = props
+  const { id, expiresOn, unlimited, pending = false } = props
   return (
-    <OrderRowWrapper className="orderRow" data-id={id}>
-      <div></div> {/* TODO: display loading spinner */}
+    <OrderRowWrapper className={'orderRow' + (pending ? ' pending' : '')} data-id={id}>
+      <PendingLink {...props} />
       <div className="checked">
         <input type="checkbox" />
       </div>

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -215,7 +215,7 @@ const OrdersWidget: React.FC = () => {
             <ButtonWithIcon disabled>
               <FontAwesomeIcon icon={faTrashAlt} /> Delete orders
             </ButtonWithIcon>
-            <span>Select first the orders you want to delete</span>
+            <span>Select first the order(s) you want to delete</span>
           </div>
         </form>
       </OrdersForm>

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -192,6 +192,16 @@ const OrdersWidget: React.FC = () => {
             />
             <OrderRow id="543" sellToken={TUSD} buyToken={USDC} price="1.03" availableAmount="1,000" unlimited />
             <OrderRow
+              id="1287"
+              sellToken={USDC}
+              buyToken={DAI}
+              price="1.50"
+              unfilledAmount="876.849"
+              availableAmount="876.849"
+              expiresOn="In 1 days"
+              pending
+            />
+            <OrderRow
               id="1257"
               sellToken={PAX}
               buyToken={DAI}

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -1,0 +1,208 @@
+import React, { useMemo } from 'react'
+import styled from 'styled-components'
+import { faExchangeAlt, faChartLine, faTrashAlt } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+
+import Widget from 'components/layout/Widget'
+import Highlight from 'components/Highlight'
+import TokenImg from 'components/TokenImg'
+import { tokenListApi } from 'api'
+import { getToken, safeTokenName } from 'utils'
+import { Network } from 'types'
+
+const OrdersWrapper = styled(Widget)`
+  > a {
+    margin-bottom: -2em;
+  }
+
+  .header {
+    margin-top: 0;
+
+    h2 {
+      margin-bottom: 0.25em;
+    }
+  }
+`
+
+const TokenImgWrapper = styled(TokenImg)`
+  height: 1.25em;
+  width: 1.25em;
+
+  vertical-align: middle;
+`
+
+const ButtonWithIcon = styled.button`
+  > svg {
+    margin: 0 0.25em;
+  }
+`
+
+const CreateButtons = styled.div`
+  margin-top: 2em;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+
+  .strategy {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+
+    a,
+    button {
+      margin-left: 0.5em;
+    }
+  }
+`
+
+const OrdersForm = styled.div`
+  margin-top: 2em;
+  margin-left: 2em;
+
+  .ordersContainer {
+    display: grid;
+    grid-template-columns: auto;
+    margin: 2em 0 2em -3em;
+  }
+
+  .headerRow {
+    text-transform: uppercase;
+    font-weight: bold;
+    font-size: 0.75em;
+
+    > div {
+      border-bottom: 2px solid #ededed;
+      text-align: center;
+    }
+
+    & > * {
+      padding-bottom: 0.25em;
+    }
+  }
+
+  .rowContainer {
+    display: inherit;
+    grid-template-columns: 6% 8% auto 25% 12% 10%;
+    align-items: center;
+    margin: 0.25em 0;
+  }
+
+  .cell {
+    text-align: center;
+    vertical-align: middle;
+  }
+
+  .deleteContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+`
+
+const OrdersWidget: React.FC = () => {
+  // TODO: only for temporary layout
+  const tokens = useMemo(() => tokenListApi.getTokens(Network.Mainnet), [])
+
+  const DAI = getToken('symbol', 'DAI', tokens)
+  const USDC = getToken('symbol', 'USDC', tokens)
+  const TUSD = getToken('symbol', 'TUSD', tokens)
+  const PAX = getToken('symbol', 'PAX', tokens)
+  // end temporary layout vars
+
+  return (
+    <OrdersWrapper>
+      <div className="header">
+        <h2>Your sell orders</h2>
+        <span>Standing orders for the connected account</span>
+        <CreateButtons>
+          <ButtonWithIcon>
+            <FontAwesomeIcon icon={faExchangeAlt} /> Create order
+          </ButtonWithIcon>
+          <div className="strategy">
+            <ButtonWithIcon>
+              <FontAwesomeIcon icon={faChartLine} /> Create new strategy
+            </ButtonWithIcon>
+            <a href="/">
+              <small>Learn more about strategies</small>
+            </a>
+          </div>
+        </CreateButtons>
+      </div>
+      <OrdersForm>
+        <span>
+          You have <Highlight>3</Highlight> standing orders
+        </span>
+        <form action="submit">
+          <div className="ordersContainer">
+            <div className="rowContainer headerRow">
+              <input type="checkbox" />
+              <div className="cell">ID</div>
+              <div className="cell">Order details</div>
+              <div className="cell">Trade at most</div>
+              <div className="cell">Matched</div>
+              <div className="cell">Expires</div>
+            </div>
+
+            <div className="rowContainer">
+              <input type="checkbox" />
+              <div className="cell">1</div>
+              <div className="cell">
+                Sell <Highlight>1</Highlight> <TokenImgWrapper src={DAI.image} /> <strong>{safeTokenName(DAI)}</strong>{' '}
+                for <strong>at least</strong> <Highlight>1.05</Highlight> <TokenImgWrapper src={TUSD.image} />{' '}
+                <strong>{safeTokenName(TUSD)}</strong>
+              </div>
+              <div className="cell">
+                1500 <TokenImgWrapper src={DAI.image} /> <strong>{safeTokenName(DAI)}</strong>
+              </div>
+              <div className="cell">500</div>
+              <div className="cell">In 3 min</div>
+            </div>
+
+            <div className="rowContainer">
+              <input type="checkbox" />
+              <div className="cell">154</div>
+              <div className="cell">
+                Sell <Highlight>1</Highlight> <TokenImgWrapper src={TUSD.image} />{' '}
+                <strong>{safeTokenName(TUSD)}</strong> for <strong>at least</strong> <Highlight>1.03</Highlight>{' '}
+                <TokenImgWrapper src={USDC.image} /> <strong>{safeTokenName(USDC)}</strong>
+              </div>
+              <div className="cell">
+                <Highlight>unlimited</Highlight> <TokenImgWrapper src={TUSD.image} />{' '}
+                <strong>{safeTokenName(TUSD)}</strong>
+              </div>
+              <div className="cell">5,876.8429</div>
+              <div className="cell">
+                <Highlight>Never</Highlight>
+              </div>
+            </div>
+
+            <div className="rowContainer">
+              <input type="checkbox" />
+              <div className="cell">1732</div>
+              <div className="cell">
+                Sell <Highlight>1</Highlight> <TokenImgWrapper src={PAX.image} /> <strong>{safeTokenName(PAX)}</strong>{' '}
+                for <strong>at least</strong> <Highlight>1.10</Highlight> <TokenImgWrapper src={DAI.image} />{' '}
+                <strong>{safeTokenName(DAI)}</strong>
+              </div>
+              <div className="cell">
+                350 <TokenImgWrapper src={PAX.image} /> <strong>{safeTokenName(PAX)}</strong>
+              </div>
+              <div className="cell">0</div>
+              <div className="cell">In 2 days</div>
+            </div>
+          </div>
+
+          <div className="deleteContainer">
+            <ButtonWithIcon disabled>
+              <FontAwesomeIcon icon={faTrashAlt} /> Delete orders
+            </ButtonWithIcon>
+            <span>Select first the orders you want to delete</span>
+          </div>
+        </form>
+      </OrdersForm>
+    </OrdersWrapper>
+  )
+}
+
+export default OrdersWidget

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -51,7 +51,7 @@ const OrdersForm = styled.div`
     display: grid;
     grid-template-columns: repeat(2, 1fr);
 
-    div:last-child {
+    .warning {
       justify-self: end;
     }
   }

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -14,14 +14,6 @@ const OrdersWrapper = styled(Widget)`
   > a {
     margin-bottom: -2em;
   }
-
-  .header {
-    margin-top: 0;
-
-    h2 {
-      margin-bottom: 0.25em;
-    }
-  }
 `
 
 const ButtonWithIcon = styled.button`
@@ -133,7 +125,7 @@ const OrdersWidget: React.FC = () => {
 
   return (
     <OrdersWrapper>
-      <div className="header">
+      <div>
         <h2>Your orders</h2>
         <CreateButtons>
           <ButtonWithIcon>

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react'
+import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import { faExchangeAlt, faChartLine, faTrashAlt, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -135,9 +136,11 @@ const OrdersWidget: React.FC = () => {
       <div>
         <h2>Your orders</h2>
         <CreateButtons>
-          <ButtonWithIcon>
-            <FontAwesomeIcon icon={faExchangeAlt} /> Trade
-          </ButtonWithIcon>
+          <Link to="/trade">
+            <ButtonWithIcon>
+              <FontAwesomeIcon icon={faExchangeAlt} /> Trade
+            </ButtonWithIcon>
+          </Link>
           <div className="strategy">
             <ButtonWithIcon className="danger">
               <FontAwesomeIcon icon={faChartLine} /> Create new strategy

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -57,41 +57,52 @@ const OrdersForm = styled.div`
   }
 
   .ordersContainer {
-    display: grid;
-    grid-template-columns: auto;
+    // negative left margin to better position "hidden" elements
     margin: 2em 0 2em -3em;
-  }
 
-  .rowContainer {
-    display: inherit;
-    grid-template-columns: minmax(2em, 6%) minmax(20em, 1.5fr) 1fr 1fr 1fr;
-    align-items: center;
-    margin: 0.25em 0;
+    display: grid;
+    // 6 columns:
+    // loading indicator | select checkbox | order details | unfilled | available | expires
+    grid-template-columns: 3em 4em minmax(20em, 1.5fr) repeat(3, 1fr);
+    grid-row-gap: 1em;
+    place-items: center;
   }
 
   .headerRow {
+    // make the contents of this div behave as part of the parent
+    // grid container
+    display: contents;
+
     text-transform: uppercase;
     font-weight: bold;
     font-size: 0.75em;
-    align-items: stretch;
-    justify-items: stretch;
 
-    .cell {
+    .title {
+      // create a divider line only bellow titled columns
       border-bottom: 2px solid #ededed;
+      // push the border all the way to the bottom and extend it
+      place-self: stretch;
+
+      // align that text!
+      display: flex;
+      align-items: center;
+      justify-content: center;
       text-align: center;
     }
 
-    div:first-child {
-      align-self: center;
-    }
-
     > * {
-      padding-bottom: 0.25em;
+      // more space for the divider line
+      padding-bottom: 0.5em;
     }
   }
 
-  .cell {
-    text-align: center;
+  .orderRow {
+    display: contents;
+  }
+
+  .checked {
+    // pull checkbox to the left to make divider line be further away
+    justify-self: left;
   }
 
   .deleteContainer {
@@ -153,20 +164,22 @@ const OrdersWidget: React.FC = () => {
         </div>
         <form action="submit">
           <div className="ordersContainer">
-            <div className="rowContainer headerRow">
-              <div>
+            <div className="headerRow">
+              <div></div> {/* Empty div on purpose */}
+              <div className="checked">
                 <input type="checkbox" />
               </div>
-              <div className="cell">Order details</div>
-              <div className="cell">
+              <div className="title">Order details</div>
+              <div className="title">
                 Unfilled <br /> amount
               </div>
-              <div className="cell">
+              <div className="title">
                 Available <br />
                 amount
               </div>
-              <div className="cell">Expires</div>
+              <div className="title">Expires</div>
             </div>
+
             <OrderRow
               id="1"
               sellToken={DAI}

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -72,7 +72,7 @@ const OrdersForm = styled.div`
 
   .rowContainer {
     display: inherit;
-    grid-template-columns: 6% minmax(20em, auto) 20% 25% 10%;
+    grid-template-columns: minmax(2em, 6%) minmax(20em, 1.5fr) 1fr 1fr 1fr;
     align-items: center;
     margin: 0.25em 0;
   }
@@ -82,17 +82,18 @@ const OrdersForm = styled.div`
     font-weight: bold;
     font-size: 0.75em;
     align-items: stretch;
+    justify-items: stretch;
 
-    > * {
+    .cell {
       border-bottom: 2px solid #ededed;
       text-align: center;
     }
+
     div:first-child {
-      border-bottom: none;
-      place-self: center;
+      align-self: center;
     }
 
-    & > * {
+    > * {
       padding-bottom: 0.25em;
     }
   }

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -5,10 +5,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import Widget from 'components/layout/Widget'
 import Highlight from 'components/Highlight'
-import TokenImg from 'components/TokenImg'
 import { tokenListApi } from 'api'
-import { getToken, safeTokenName } from 'utils'
+import { getToken } from 'utils'
 import { Network } from 'types'
+import OrderRow from './OrderRow'
 
 const OrdersWrapper = styled(Widget)`
   > a {
@@ -22,13 +22,6 @@ const OrdersWrapper = styled(Widget)`
       margin-bottom: 0.25em;
     }
   }
-`
-
-const TokenImgWrapper = styled(TokenImg)`
-  height: 1.25em;
-  width: 1.25em;
-
-  vertical-align: middle;
 `
 
 const ButtonWithIcon = styled.button`
@@ -143,54 +136,33 @@ const OrdersWidget: React.FC = () => {
               <div className="cell">Matched</div>
               <div className="cell">Expires</div>
             </div>
-
-            <div className="rowContainer">
-              <input type="checkbox" />
-              <div className="cell">1</div>
-              <div className="cell">
-                Sell <Highlight>1</Highlight> <TokenImgWrapper src={DAI.image} /> <strong>{safeTokenName(DAI)}</strong>{' '}
-                for <strong>at least</strong> <Highlight>1.05</Highlight> <TokenImgWrapper src={TUSD.image} />{' '}
-                <strong>{safeTokenName(TUSD)}</strong>
-              </div>
-              <div className="cell">
-                1500 <TokenImgWrapper src={DAI.image} /> <strong>{safeTokenName(DAI)}</strong>
-              </div>
-              <div className="cell">500</div>
-              <div className="cell">In 3 min</div>
-            </div>
-
-            <div className="rowContainer">
-              <input type="checkbox" />
-              <div className="cell">154</div>
-              <div className="cell">
-                Sell <Highlight>1</Highlight> <TokenImgWrapper src={TUSD.image} />{' '}
-                <strong>{safeTokenName(TUSD)}</strong> for <strong>at least</strong> <Highlight>1.03</Highlight>{' '}
-                <TokenImgWrapper src={USDC.image} /> <strong>{safeTokenName(USDC)}</strong>
-              </div>
-              <div className="cell">
-                <Highlight>unlimited</Highlight> <TokenImgWrapper src={TUSD.image} />{' '}
-                <strong>{safeTokenName(TUSD)}</strong>
-              </div>
-              <div className="cell">5,876.8429</div>
-              <div className="cell">
-                <Highlight>Never</Highlight>
-              </div>
-            </div>
-
-            <div className="rowContainer">
-              <input type="checkbox" />
-              <div className="cell">1732</div>
-              <div className="cell">
-                Sell <Highlight>1</Highlight> <TokenImgWrapper src={PAX.image} /> <strong>{safeTokenName(PAX)}</strong>{' '}
-                for <strong>at least</strong> <Highlight>1.10</Highlight> <TokenImgWrapper src={DAI.image} />{' '}
-                <strong>{safeTokenName(DAI)}</strong>
-              </div>
-              <div className="cell">
-                350 <TokenImgWrapper src={PAX.image} /> <strong>{safeTokenName(PAX)}</strong>
-              </div>
-              <div className="cell">0</div>
-              <div className="cell">In 2 days</div>
-            </div>
+            <OrderRow
+              id="1"
+              sellToken={DAI}
+              buyToken={TUSD}
+              price="1.05"
+              sellTotal="1,500"
+              matched="500"
+              expiresOn="In 3 min"
+            />
+            <OrderRow
+              id="543"
+              sellToken={TUSD}
+              buyToken={USDC}
+              price="1.03"
+              sellTotal={<Highlight>unlimited</Highlight>}
+              matched="5,876.8429"
+              expiresOn={<Highlight>Never</Highlight>}
+            />
+            <OrderRow
+              id="1257"
+              sellToken={PAX}
+              buyToken={DAI}
+              price="1.10"
+              sellTotal="350"
+              matched="0"
+              expiresOn="In 2 days"
+            />
           </div>
 
           <div className="deleteContainer">

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -114,10 +114,6 @@ const OrdersForm = styled.div`
   .warning {
     color: orange;
   }
-
-  .error {
-    color: red;
-  }
 `
 
 const OrdersWidget: React.FC = () => {

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -139,7 +139,7 @@ const OrdersWidget: React.FC = () => {
             <FontAwesomeIcon icon={faExchangeAlt} /> Trade
           </ButtonWithIcon>
           <div className="strategy">
-            <ButtonWithIcon>
+            <ButtonWithIcon className="danger">
               <FontAwesomeIcon icon={faChartLine} /> Create new strategy
             </ButtonWithIcon>
             <a href="/">

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 import styled from 'styled-components'
-import { faExchangeAlt, faChartLine, faTrashAlt } from '@fortawesome/free-solid-svg-icons'
+import { faExchangeAlt, faChartLine, faTrashAlt, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import Widget from 'components/layout/Widget'
@@ -25,6 +25,8 @@ const OrdersWrapper = styled(Widget)`
 `
 
 const ButtonWithIcon = styled.button`
+  min-width: 10em;
+
   > svg {
     margin: 0 0.25em;
   }
@@ -53,16 +55,33 @@ const OrdersForm = styled.div`
   margin-top: 2em;
   margin-left: 2em;
 
+  .infoContainer {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+
+    div:last-child {
+      justify-self: end;
+    }
+  }
+
   .ordersContainer {
     display: grid;
     grid-template-columns: auto;
     margin: 2em 0 2em -3em;
   }
 
+  .rowContainer {
+    display: inherit;
+    grid-template-columns: 6% minmax(20em, auto) 20% 25% 10%;
+    align-items: center;
+    margin: 0.25em 0;
+  }
+
   .headerRow {
     text-transform: uppercase;
     font-weight: bold;
     font-size: 0.75em;
+    align-items: stretch;
 
     > div {
       border-bottom: 2px solid #ededed;
@@ -74,22 +93,22 @@ const OrdersForm = styled.div`
     }
   }
 
-  .rowContainer {
-    display: inherit;
-    grid-template-columns: 6% 8% auto 25% 12% 10%;
-    align-items: center;
-    margin: 0.25em 0;
-  }
-
   .cell {
     text-align: center;
-    vertical-align: middle;
   }
 
   .deleteContainer {
     display: flex;
     flex-direction: column;
     align-items: center;
+  }
+
+  .warning {
+    color: orange;
+  }
+
+  .error {
+    color: red;
   }
 `
 
@@ -106,11 +125,10 @@ const OrdersWidget: React.FC = () => {
   return (
     <OrdersWrapper>
       <div className="header">
-        <h2>Your sell orders</h2>
-        <span>Standing orders for the connected account</span>
+        <h2>Your orders</h2>
         <CreateButtons>
           <ButtonWithIcon>
-            <FontAwesomeIcon icon={faExchangeAlt} /> Create order
+            <FontAwesomeIcon icon={faExchangeAlt} /> Trade
           </ButtonWithIcon>
           <div className="strategy">
             <ButtonWithIcon>
@@ -123,17 +141,27 @@ const OrdersWidget: React.FC = () => {
         </CreateButtons>
       </div>
       <OrdersForm>
-        <span>
-          You have <Highlight>3</Highlight> standing orders
-        </span>
+        <div className="infoContainer">
+          <div>
+            You have <Highlight>3</Highlight> standing orders
+          </div>
+          <div className="warning">
+            <FontAwesomeIcon icon={faExclamationTriangle} />
+            <strong> Low balance</strong>
+          </div>
+        </div>
         <form action="submit">
           <div className="ordersContainer">
             <div className="rowContainer headerRow">
               <input type="checkbox" />
-              <div className="cell">ID</div>
               <div className="cell">Order details</div>
-              <div className="cell">Trade at most</div>
-              <div className="cell">Matched</div>
+              <div className="cell">
+                Unfilled <br /> amount
+              </div>
+              <div className="cell">
+                Available <br />
+                amount
+              </div>
               <div className="cell">Expires</div>
             </div>
             <OrderRow
@@ -141,26 +169,19 @@ const OrdersWidget: React.FC = () => {
               sellToken={DAI}
               buyToken={TUSD}
               price="1.05"
-              sellTotal="1,500"
-              matched="500"
+              unfilledAmount="1,500"
+              availableAmount="1,000"
+              overBalance
               expiresOn="In 3 min"
             />
-            <OrderRow
-              id="543"
-              sellToken={TUSD}
-              buyToken={USDC}
-              price="1.03"
-              sellTotal={<Highlight>unlimited</Highlight>}
-              matched="5,876.8429"
-              expiresOn={<Highlight>Never</Highlight>}
-            />
+            <OrderRow id="543" sellToken={TUSD} buyToken={USDC} price="1.03" availableAmount="1,000" unlimited />
             <OrderRow
               id="1257"
               sellToken={PAX}
               buyToken={DAI}
               price="1.10"
-              sellTotal="350"
-              matched="0"
+              unfilledAmount="5,876.8429"
+              availableAmount="500"
               expiresOn="In 2 days"
             />
           </div>

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -7,7 +7,7 @@ import Widget from 'components/layout/Widget'
 import Highlight from 'components/Highlight'
 import { tokenListApi } from 'api'
 import { getToken } from 'utils'
-import { Network } from 'types'
+import { Network, TokenDetails } from 'types'
 import OrderRow from './OrderRow'
 
 const OrdersWrapper = styled(Widget)`
@@ -114,12 +114,16 @@ const OrdersForm = styled.div`
 
 const OrdersWidget: React.FC = () => {
   // TODO: only for temporary layout
-  const tokens = useMemo(() => tokenListApi.getTokens(Network.Mainnet), [])
+  const { DAI, USDC, TUSD, PAX } = useMemo(() => {
+    const tokens = tokenListApi.getTokens(Network.Mainnet)
 
-  const DAI = getToken('symbol', 'DAI', tokens)
-  const USDC = getToken('symbol', 'USDC', tokens)
-  const TUSD = getToken('symbol', 'TUSD', tokens)
-  const PAX = getToken('symbol', 'PAX', tokens)
+    return {
+      DAI: getToken('symbol', 'DAI', tokens) as Required<TokenDetails>,
+      USDC: getToken('symbol', 'USDC', tokens) as Required<TokenDetails>,
+      TUSD: getToken('symbol', 'TUSD', tokens) as Required<TokenDetails>,
+      PAX: getToken('symbol', 'PAX', tokens) as Required<TokenDetails>,
+    }
+  }, [])
   // end temporary layout vars
 
   return (

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -83,9 +83,13 @@ const OrdersForm = styled.div`
     font-size: 0.75em;
     align-items: stretch;
 
-    > div {
+    > * {
       border-bottom: 2px solid #ededed;
       text-align: center;
+    }
+    div:first-child {
+      border-bottom: none;
+      place-self: center;
     }
 
     & > * {
@@ -157,7 +161,9 @@ const OrdersWidget: React.FC = () => {
         <form action="submit">
           <div className="ordersContainer">
             <div className="rowContainer headerRow">
-              <input type="checkbox" />
+              <div>
+                <input type="checkbox" />
+              </div>
               <div className="cell">Order details</div>
               <div className="cell">
                 Unfilled <br /> amount

--- a/src/components/TradeWidget/OrderDetails.tsx
+++ b/src/components/TradeWidget/OrderDetails.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { FEE_PERCENTAGE } from 'const'
+import Highlight from 'components/Highlight'
 
 const Wrapper = styled.dl`
   margin: 2em 0 0 0;
@@ -15,11 +16,6 @@ const Wrapper = styled.dl`
   dt {
     margin: 0 0 0.25em 4em;
   }
-`
-
-const Highlight = styled.span`
-  font-weight: bold;
-  color: #367be0;
 `
 
 // TODO: move to utils?

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -126,7 +126,7 @@ const Header: React.FC = () => {
             <LinkWithPastLocation to="/deposit">Deposit</LinkWithPastLocation>
           </li>
           <li>
-            <Link to={{ pathname: '/orders', state: { from: location } }}>Orders</Link>
+            <LinkWithPastLocation to="/orders">Orders</LinkWithPastLocation>
           </li>
         </ul>
         <Wallet />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -125,6 +125,9 @@ const Header: React.FC = () => {
           <li>
             <LinkWithPastLocation to="/deposit">Deposit</LinkWithPastLocation>
           </li>
+          <li>
+            <Link to={{ pathname: '/orders', state: { from: location } }}>Orders</Link>
+          </li>
         </ul>
         <Wallet />
       </nav>

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -1,0 +1,1 @@
+export { default } from 'components/OrdersWidget'


### PR DESCRIPTION

Closes #207 

---

Implementing basic [Order page layout based on proposal](https://docs.google.com/document/d/1JGLGRtvyMPNa2w_j6tH6KVqxAIzCh91ajQzIUdR_jxU/edit?ts=5ddba8a1#heading=h.ifln052hb2js) by @anxolin. 

Current implementation:

![list-orders](https://user-images.githubusercontent.com/43217/70069598-e04b3100-15a6-11ea-9417-539ae2241ebc.png)



- [x] Added link to Orders page on header
- [x] Added Orders to App for navigation
- [x] Implemented basic layout (RF.15.1 List of orders)
- [x] Implemented unconfirmed order layout (RF.15.2 Display unconfirmed order)

Feedback is very welcome on the styling in general.

### Not included:
- Loading orders
- Any logic whatsoever