### PR TITLE
fix wrong address on sell|buy token

### DIFF
--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -125,9 +125,9 @@ const TradeWidget: React.FC = () => {
     if (isConnected) {
       const success = await placeOrder({
         buyAmount: parseAmount(data[receiveInputId], receiveToken.decimals),
-        buyToken: receiveToken,
+        buyToken: getToken('symbol', receiveToken.symbol, tokens),
         sellAmount: parseAmount(data[sellInputId], sellToken.decimals),
-        sellToken,
+        sellToken: getToken('symbol', sellToken.symbol, tokens),
       })
       if (success) {
         // reset form on successful order placing


### PR DESCRIPTION
This bug is again because TradeWidget saves tokens state locally and believes it to be the source of truth (not chain state), which comes from the fact we don't differentiate enough between local state (token list in this case)  and network-dependent token balances from the blockchain.

This is a quick fix for now.