### PR TITLE
242/update claim confirmation modal

### DIFF
--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -16,25 +16,15 @@ import { log, formatAmount, getToken } from 'utils'
 import { ZERO } from 'const'
 import { TokenBalanceDetails } from 'types'
 
-interface ModalBodyProps {
-  pendingAmount: string
-  symbol: string
-}
-
-const ModalBody: React.FC<ModalBodyProps> = ({ pendingAmount, symbol }) => {
+const OverwriteModalBody: React.FC = () => {
   return (
     <ModalBodyWrapper>
       <div>
-        <p>
-          There is already a pending withdrawal of {pendingAmount} {symbol}. If you create a new request, it will delete
-          the previous request and create a new one.
-        </p>
-        <p>
-          No funds are lost if you decide to continue, but you will have to wait again for the withdrawal to be
-          consolidated.
-        </p>
+        <p>You have a pending withdraw request. </p>
+        <p>Sending this one will overwrite the pending amount.</p>
+        <p>No funds will be lost.</p>
       </div>
-      <p>Do you wish to create a new withdrawal request that replaces the previous one?</p>
+      <p>Do you wish to replace the previous withdraw request?</p>
     </ModalBodyWrapper>
   )
 }
@@ -51,20 +41,20 @@ const DepositWidget: React.FC = () => {
     symbol: '',
   })
 
-  const [withdrawConfirmationModal, toggleWithdrawConfirmationModal] = useModali({
+  const [withdrawOverwriteModal, toggleWithdrawOverwriteModal] = useModali({
     centered: true,
     animated: true,
     title: 'Confirm withdraw overwrite',
-    message: <ModalBody pendingAmount={withdrawRequest.pendingAmount} symbol={withdrawRequest.symbol} />,
+    message: <OverwriteModalBody />,
     buttons: [
-      <Modali.Button label="Cancel" key="no" isStyleCancel onClick={(): void => toggleWithdrawConfirmationModal()} />,
+      <Modali.Button label="Cancel" key="no" isStyleCancel onClick={(): void => toggleWithdrawOverwriteModal()} />,
       <Modali.Button
-        label="Accept"
+        label="Continue"
         key="yes"
         isStyleDefault
         onClick={async (): Promise<void> => {
           // On confirm, do the request
-          toggleWithdrawConfirmationModal()
+          toggleWithdrawOverwriteModal()
           await requestWithdraw(withdrawRequest.amount, withdrawRequest.tokenAddress)
         }}
       />,
@@ -130,7 +120,7 @@ const DepositWidget: React.FC = () => {
           </div>
         )}
       </Widget>
-      <Modali.Modal {...withdrawConfirmationModal} />
+      <Modali.Modal {...withdrawOverwriteModal} />
     </DepositWidgetWrapper>
   )
 }

--- a/src/components/DepositWidget/useDepositModals.tsx
+++ b/src/components/DepositWidget/useDepositModals.tsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import BN from 'bn.js'
+
+import { ModalBodyWrapper } from './Styled'
+import Modali, { useModali, ModalHook, toggleModaliComponent } from 'modali'
+
+const OverwriteModalBody: React.FC = () => {
+  return (
+    <ModalBodyWrapper>
+      <div>
+        <p>You have a pending withdraw request. </p>
+        <p>Sending this one will overwrite the pending amount.</p>
+        <p>No funds will be lost.</p>
+      </div>
+      <p>Do you wish to replace the previous withdraw request?</p>
+    </ModalBodyWrapper>
+  )
+}
+
+const WithdrawAndClaimModalBody: React.FC = () => {
+  return (
+    <ModalBodyWrapper>
+      <p>By sending this withdraw request, you will automatically receive all claimable amounts back to your wallet.</p>
+    </ModalBodyWrapper>
+  )
+}
+
+const defaultOptions = {
+  centered: true,
+  animated: true,
+}
+
+interface Params {
+  amount: BN
+  tokenAddress: string
+  requestWithdraw: (amount: BN, tokenAddress: string) => Promise<void>
+}
+
+interface Result {
+  withdrawOverwriteModal: ModalHook
+  toggleWithdrawOverwriteModal: toggleModaliComponent
+  withdrawAndClaimModal: ModalHook
+  toggleWithdrawAndClaimModal: toggleModaliComponent
+}
+
+export function useDepositModals(params: Params): Result {
+  const { amount, tokenAddress, requestWithdraw } = params
+
+  const [withdrawOverwriteModal, toggleWithdrawOverwriteModal] = useModali({
+    ...defaultOptions,
+    title: 'Confirm withdraw overwrite',
+    message: <OverwriteModalBody />,
+    buttons: [
+      <Modali.Button label="Cancel" key="no" isStyleCancel onClick={(): void => toggleWithdrawOverwriteModal()} />,
+      <Modali.Button
+        label="Continue"
+        key="yes"
+        isStyleDefault
+        onClick={async (): Promise<void> => {
+          // On confirm, do the request
+          toggleWithdrawOverwriteModal()
+          await requestWithdraw(amount, tokenAddress)
+        }}
+      />,
+    ],
+  })
+
+  const [withdrawAndClaimModal, toggleWithdrawAndClaimModal] = useModali({
+    ...defaultOptions,
+    title: 'Please note',
+    message: <WithdrawAndClaimModalBody />,
+    buttons: [
+      <Modali.Button label="Cancel" key="no" isStyleCancel onClick={(): void => toggleWithdrawAndClaimModal()} />,
+      <Modali.Button
+        label="Continue"
+        key="yes"
+        isStyleDefault
+        onClick={async (): Promise<void> => {
+          // On confirm, do the request
+          toggleWithdrawAndClaimModal()
+          await requestWithdraw(amount, tokenAddress)
+        }}
+      />,
+    ],
+  })
+
+  return { withdrawOverwriteModal, toggleWithdrawOverwriteModal, withdrawAndClaimModal, toggleWithdrawAndClaimModal }
+}

--- a/src/components/DepositWidget/useDepositModals.tsx
+++ b/src/components/DepositWidget/useDepositModals.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import BN from 'bn.js'
 
 import { ModalBodyWrapper } from './Styled'
@@ -46,42 +46,39 @@ interface Result {
 export function useDepositModals(params: Params): Result {
   const { amount, tokenAddress, requestWithdraw } = params
 
+  const getButtons = useCallback(
+    (toggleModal: toggleModaliComponent): React.ReactNode[] => {
+      return [
+        <Modali.Button label="Cancel" key="no" isStyleCancel onClick={toggleModal} />,
+        <Modali.Button
+          label="Continue"
+          key="yes"
+          isStyleDefault
+          onClick={async (): Promise<void> => {
+            // On confirm, do the request
+            toggleModal()
+            await requestWithdraw(amount, tokenAddress)
+          }}
+        />,
+      ]
+    },
+    [amount, requestWithdraw, tokenAddress],
+  )
+
   const [withdrawOverwriteModal, toggleWithdrawOverwriteModal] = useModali({
     ...defaultOptions,
     title: 'Confirm withdraw overwrite',
     message: <OverwriteModalBody />,
-    buttons: [
-      <Modali.Button label="Cancel" key="no" isStyleCancel onClick={(): void => toggleWithdrawOverwriteModal()} />,
-      <Modali.Button
-        label="Continue"
-        key="yes"
-        isStyleDefault
-        onClick={async (): Promise<void> => {
-          // On confirm, do the request
-          toggleWithdrawOverwriteModal()
-          await requestWithdraw(amount, tokenAddress)
-        }}
-      />,
-    ],
+    buttons: getButtons((): void => {
+      toggleWithdrawOverwriteModal()
+    }),
   })
 
   const [withdrawAndClaimModal, toggleWithdrawAndClaimModal] = useModali({
     ...defaultOptions,
     title: 'Please note',
     message: <WithdrawAndClaimModalBody />,
-    buttons: [
-      <Modali.Button label="Cancel" key="no" isStyleCancel onClick={(): void => toggleWithdrawAndClaimModal()} />,
-      <Modali.Button
-        label="Continue"
-        key="yes"
-        isStyleDefault
-        onClick={async (): Promise<void> => {
-          // On confirm, do the request
-          toggleWithdrawAndClaimModal()
-          await requestWithdraw(amount, tokenAddress)
-        }}
-      />,
-    ],
+    buttons: getButtons((): void => toggleWithdrawAndClaimModal()),
   })
 
   return { withdrawOverwriteModal, toggleWithdrawOverwriteModal, withdrawAndClaimModal, toggleWithdrawAndClaimModal }


### PR DESCRIPTION
Closes #242 

---

- [x] Updating message on overwrite modal
- [x] Adding new modal for claim/withdraw notice
- [x] Refactoring modals into a new hook

Modal 1:
![modal1](https://user-images.githubusercontent.com/43217/69679531-324afe80-105d-11ea-9ecd-2580c1944c92.png)

Modal 2:
![modal2](https://user-images.githubusercontent.com/43217/69679536-34ad5880-105d-11ea-8759-3e83ba0653e8.png)
