### PR TITLE
248/trade page usability

### DIFF
--- a/src/components/TokenSelector.tsx
+++ b/src/components/TokenSelector.tsx
@@ -76,9 +76,10 @@ interface Props {
   tokens: TokenDetails[]
   selected: TokenDetails
   onChange: (selected: TokenDetails) => void
+  tabIndex?: number
 }
 
-const TokenSelector: React.FC<Props> = ({ label, isDisabled, tokens, selected, onChange }) => {
+const TokenSelector: React.FC<Props> = ({ label, isDisabled, tokens, selected, onChange, tabIndex = 0 }) => {
   const options = useMemo(() => tokens.map(token => ({ token, value: token.symbol, label: token.name })), [tokens])
 
   return (
@@ -97,6 +98,7 @@ const TokenSelector: React.FC<Props> = ({ label, isDisabled, tokens, selected, o
             onChange(selected.token)
           }
         }}
+        tabIndex={tabIndex.toString()}
       />
     </Wrapper>
   )

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useCallback } from 'react'
+import React, { useEffect, useCallback, useMemo } from 'react'
 import BN from 'bn.js'
 import styled from 'styled-components'
 import { useFormContext } from 'react-hook-form'
-import { FieldValues } from 'react-hook-form/dist/types'
 
 import LinkWithPastLocation from 'components/LinkWithPastLocation'
 import TokenImg from 'components/TokenImg'
@@ -108,7 +107,6 @@ interface Props {
   isDisabled: boolean
   validateMaxAmount?: true
   tabIndex: number
-  onSubmit: (data: FieldValues) => Promise<void>
 }
 
 const TokenRow: React.FC<Props> = ({
@@ -121,9 +119,8 @@ const TokenRow: React.FC<Props> = ({
   isDisabled,
   validateMaxAmount,
   tabIndex,
-  onSubmit,
 }) => {
-  const { register, errors, setValue, watch, handleSubmit } = useFormContext()
+  const { register, errors, setValue, watch } = useFormContext()
   const error = errors[inputId]
   const inputValue = watch(inputId)
 
@@ -181,19 +178,6 @@ const TokenRow: React.FC<Props> = ({
     [inputId, setValue],
   )
 
-  const onKeyPress = useCallback(
-    (event: React.KeyboardEvent<HTMLInputElement>): void => {
-      if (event.key === 'Enter') {
-        // On enter, submit the form
-        handleSubmit(onSubmit)
-      } else {
-        // Any other key, validate inserted chars
-        preventInvalidChars(event)
-      }
-    },
-    [handleSubmit, onSubmit],
-  )
-
   const exchangeBalanceAndPendingBalance = balance && balance.exchangeBalance.add(balance.depositingBalance)
 
   return (
@@ -219,7 +203,7 @@ const TokenRow: React.FC<Props> = ({
             pattern: { value: validInputPattern, message: 'Invalid amount' },
             validate: { positive: validatePositive },
           })}
-          onKeyPress={onKeyPress}
+          onKeyPress={preventInvalidChars}
           onChange={enforcePrecision}
           onBlur={removeExcessZeros}
           tabIndex={tabIndex + 2}

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -106,6 +106,7 @@ interface Props {
   inputId: string
   isDisabled: boolean
   validateMaxAmount?: true
+  tabIndex: number
 }
 
 const TokenRow: React.FC<Props> = ({
@@ -117,6 +118,7 @@ const TokenRow: React.FC<Props> = ({
   inputId,
   isDisabled,
   validateMaxAmount,
+  tabIndex,
 }) => {
   const { register, errors, setValue, watch } = useFormContext()
   const error = errors[inputId]
@@ -187,6 +189,7 @@ const TokenRow: React.FC<Props> = ({
         tokens={tokens}
         selected={selectedToken}
         onChange={onSelectChange}
+        tabIndex={tabIndex}
       />
       <InputBox>
         <input
@@ -203,12 +206,15 @@ const TokenRow: React.FC<Props> = ({
           onKeyPress={preventInvalidChars}
           onChange={enforcePrecision}
           onBlur={removeExcessZeros}
+          tabIndex={tabIndex + 2}
         />
         {errorOrWarning}
         <WalletDetail>
           <div>
             <strong>
-              <LinkWithPastLocation to="/deposit">Exchange wallet:</LinkWithPastLocation>
+              <LinkWithPastLocation to="/deposit" tabIndex={-1}>
+                Exchange wallet:
+              </LinkWithPastLocation>
             </strong>{' '}
             <span className="success">
               {balance ? formatAmount(exchangeBalanceAndPendingBalance, balance.decimals) : '0'}

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useMemo } from 'react'
+import React, { useEffect, useCallback } from 'react'
 import BN from 'bn.js'
 import styled from 'styled-components'
 import { useFormContext } from 'react-hook-form'
@@ -178,6 +178,12 @@ const TokenRow: React.FC<Props> = ({
     [inputId, setValue],
   )
 
+  const onKeyPress = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>): void =>
+      event.key === 'Enter' ? removeExcessZeros(event) : preventInvalidChars(event),
+    [removeExcessZeros],
+  )
+
   const exchangeBalanceAndPendingBalance = balance && balance.exchangeBalance.add(balance.depositingBalance)
 
   return (
@@ -203,7 +209,7 @@ const TokenRow: React.FC<Props> = ({
             pattern: { value: validInputPattern, message: 'Invalid amount' },
             validate: { positive: validatePositive },
           })}
-          onKeyPress={preventInvalidChars}
+          onKeyPress={onKeyPress}
           onChange={enforcePrecision}
           onBlur={removeExcessZeros}
           tabIndex={tabIndex + 2}

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -162,7 +162,7 @@ const TokenRow: React.FC<Props> = ({
   }, [enforcePrecision])
 
   const removeExcessZeros = useCallback(
-    () => (event: React.SyntheticEvent<HTMLInputElement>): void => {
+    (event: React.SyntheticEvent<HTMLInputElement>): void => {
       // Q: Why do we need this function instead of relying on `preventInvalidChars` or `enforcePrecision`?
       // A: Because on those functions we still want the user to be able to input partial values. E.g.:
       //    0 -> 0. -> 0.1 -> 0.10 -> 0.105

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -158,7 +158,7 @@ const TokenRow: React.FC<Props> = ({
     enforcePrecision()
   }, [enforcePrecision])
 
-  const removeExcessZeros = useMemo(
+  const removeExcessZeros = useCallback(
     () => (event: React.SyntheticEvent<HTMLInputElement>): void => {
       // Q: Why do we need this function instead of relying on `preventInvalidChars` or `enforcePrecision`?
       // A: Because on those functions we still want the user to be able to input partial values. E.g.:

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useCallback, useMemo } from 'react'
+import React, { useEffect, useCallback } from 'react'
 import BN from 'bn.js'
 import styled from 'styled-components'
 import { useFormContext } from 'react-hook-form'
+import { FieldValues } from 'react-hook-form/dist/types'
 
 import LinkWithPastLocation from 'components/LinkWithPastLocation'
 import TokenImg from 'components/TokenImg'
@@ -107,6 +108,7 @@ interface Props {
   isDisabled: boolean
   validateMaxAmount?: true
   tabIndex: number
+  onSubmit: (data: FieldValues) => Promise<void>
 }
 
 const TokenRow: React.FC<Props> = ({
@@ -119,8 +121,9 @@ const TokenRow: React.FC<Props> = ({
   isDisabled,
   validateMaxAmount,
   tabIndex,
+  onSubmit,
 }) => {
-  const { register, errors, setValue, watch } = useFormContext()
+  const { register, errors, setValue, watch, handleSubmit } = useFormContext()
   const error = errors[inputId]
   const inputValue = watch(inputId)
 
@@ -178,6 +181,19 @@ const TokenRow: React.FC<Props> = ({
     [inputId, setValue],
   )
 
+  const onKeyPress = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>): void => {
+      if (event.key === 'Enter') {
+        // On enter, submit the form
+        handleSubmit(onSubmit)
+      } else {
+        // Any other key, validate inserted chars
+        preventInvalidChars(event)
+      }
+    },
+    [handleSubmit, onSubmit],
+  )
+
   const exchangeBalanceAndPendingBalance = balance && balance.exchangeBalance.add(balance.depositingBalance)
 
   return (
@@ -203,7 +219,7 @@ const TokenRow: React.FC<Props> = ({
             pattern: { value: validInputPattern, message: 'Invalid amount' },
             validate: { positive: validatePositive },
           })}
-          onKeyPress={preventInvalidChars}
+          onKeyPress={onKeyPress}
           onChange={enforcePrecision}
           onBlur={removeExcessZeros}
           tabIndex={tabIndex + 2}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -184,6 +184,7 @@ const TradeWidget: React.FC = () => {
             isDisabled={isSubmitting}
             validateMaxAmount
             tabIndex={1}
+            onSubmit={onSubmit}
           />
           <IconWrapper onClick={swapTokens}>
             <FontAwesomeIcon icon={faExchangeAlt} rotation={90} size="2x" />
@@ -197,6 +198,7 @@ const TradeWidget: React.FC = () => {
             inputId={receiveInputId}
             isDisabled={isSubmitting}
             tabIndex={2}
+            onSubmit={onSubmit}
           />
           <OrderDetails
             sellAmount={watch(sellInputId)}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useCallback } from 'react'
 import styled from 'styled-components'
 import { faExchangeAlt, faPaperPlane, faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { FieldValues } from 'react-hook-form/dist/types'
@@ -120,23 +120,26 @@ const TradeWidget: React.FC = () => {
   const { isSubmitting, placeOrder } = usePlaceOrder()
   const history = useHistory()
 
-  const swapTokens = (): void => {
+  const swapTokens = useCallback((): void => {
     setSellToken(receiveToken)
     setReceiveToken(sellToken)
-  }
+  }, [receiveToken, sellToken])
 
-  const onSelectChangeFactory = (
-    setToken: React.Dispatch<React.SetStateAction<TokenDetails>>,
-    oppositeToken: TokenDetails,
-  ): ((selected: TokenDetails) => void) => {
-    return (selected: TokenDetails): void => {
-      if (selected.symbol === oppositeToken.symbol) {
-        swapTokens()
-      } else {
-        setToken(selected)
+  const onSelectChangeFactory = useCallback(
+    (
+      setToken: React.Dispatch<React.SetStateAction<TokenDetails>>,
+      oppositeToken: TokenDetails,
+    ): ((selected: TokenDetails) => void) => {
+      return (selected: TokenDetails): void => {
+        if (selected.symbol === oppositeToken.symbol) {
+          swapTokens()
+        } else {
+          setToken(selected)
+        }
       }
-    }
-  }
+    },
+    [swapTokens],
+  )
 
   const sameToken = sellToken === receiveToken
 

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -180,6 +180,7 @@ const TradeWidget: React.FC = () => {
             inputId={sellInputId}
             isDisabled={isSubmitting}
             validateMaxAmount
+            tabIndex={1}
           />
           <IconWrapper onClick={swapTokens}>
             <FontAwesomeIcon icon={faExchangeAlt} rotation={90} size="2x" />
@@ -192,6 +193,7 @@ const TradeWidget: React.FC = () => {
             onSelectChange={onSelectChangeFactory(setReceiveToken, sellToken)}
             inputId={receiveInputId}
             isDisabled={isSubmitting}
+            tabIndex={2}
           />
           <OrderDetails
             sellAmount={watch(sellInputId)}
@@ -199,7 +201,7 @@ const TradeWidget: React.FC = () => {
             receiveAmount={watch(receiveInputId)}
             receiveTokenName={safeTokenName(receiveToken)}
           />
-          <SubmitButton type="submit" disabled={!methods.formState.isValid || isSubmitting}>
+          <SubmitButton type="submit" disabled={!methods.formState.isValid || isSubmitting} tabIndex={5}>
             <FontAwesomeIcon icon={isSubmitting ? faSpinner : faPaperPlane} size="lg" spin={isSubmitting} />{' '}
             {sameToken ? 'Please select different tokens' : 'Send limit order'}
           </SubmitButton>

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -184,7 +184,6 @@ const TradeWidget: React.FC = () => {
             isDisabled={isSubmitting}
             validateMaxAmount
             tabIndex={1}
-            onSubmit={onSubmit}
           />
           <IconWrapper onClick={swapTokens}>
             <FontAwesomeIcon icon={faExchangeAlt} rotation={90} size="2x" />
@@ -198,7 +197,6 @@ const TradeWidget: React.FC = () => {
             inputId={receiveInputId}
             isDisabled={isSubmitting}
             tabIndex={2}
-            onSubmit={onSubmit}
           />
           <OrderDetails
             sellAmount={watch(sellInputId)}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -80,7 +80,7 @@ const TradeWidget: React.FC = () => {
   const receiveInputId = 'receiveToken'
 
   const methods = useForm({
-    mode: 'onBlur',
+    mode: 'onChange',
     defaultValues: {
       [sellInputId]: sellAmount,
       [receiveInputId]: receiveAmount,


### PR DESCRIPTION
Closes #248 

---

- [x] Validating form `onChange`
- [x] When `Enter` key is pressed on either input, the form submission is triggered
- [x] Tab order now is:
  1. Sell token selector
  1. Buy token selector
  1. Sell amount input
  1. Buy amount input
  1. Submit button

Bonus:
- [x] Small refactor to use `useCallBack` for functions defined within the components.