### PR TITLE
Fix double history on /trade route

### DIFF
--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -90,7 +90,7 @@ const TradeWidget: React.FC = () => {
 
   const searchQuery = buildSearchQuery({ sell: watch(sellInputId), buy: watch(receiveInputId) })
   const url = `/trade/${sellToken.symbol}-${receiveToken.symbol}?${searchQuery}`
-  useURLParams(url)
+  useURLParams(url, true)
 
   // TESTING
   const NULL_BALANCE_TOKEN = {

--- a/src/hooks/useURLParams.ts
+++ b/src/hooks/useURLParams.ts
@@ -1,14 +1,14 @@
 import { useEffect } from 'react'
 import { useHistory } from 'react-router'
 
-function useURLParams(newParams?: string): void {
+function useURLParams(newParams?: string, replace = false): void {
   const history = useHistory()
 
   useEffect(() => {
     if (newParams) {
-      history.push(newParams)
+      history[replace ? 'replace' : 'push'](newParams)
     }
-  }, [history, newParams])
+  }, [history, newParams, replace])
 }
 
 export default useURLParams


### PR DESCRIPTION
Bug became noticeable with addition of `/orders` route

Reproduce:

1. Go to https://pr287--dexreact.review.gnosisdev.com/
2. Connect Wallet
3. Go to `/orders`
4. Click `Trade` Link
5. Click back (browser navigation back) once
6. Be amazed
7. Click back once more