### PR TITLE
Update TokenList to use MCD DAI for mainnet

### DIFF
--- a/src/api/tokenList/tokenList.json
+++ b/src/api/tokenList/tokenList.json
@@ -76,7 +76,7 @@
     "symbol": "DAI",
     "decimals": 18,
     "addressByNetwork": {
-      "1": "0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359",
+      "1": "0x6b175474e89094c44da98b954eedeac495271d0f",
       "4": "0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa"
     },
     "website": "https://makerdao.com/",


### PR DESCRIPTION
The rinkeby address of DAI was already MCD.
But the mainnet address was not.

This PR corrects this.
