### PR TITLE
208/use service layer on orders page

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -16,6 +16,7 @@ import {
   erc20Allowances,
   FEE_TOKEN,
   exchangeOrders,
+  TOKEN_8,
 } from '../../test/data'
 import Web3 from 'web3'
 import { INITIAL_INFURA_ENDPOINT } from 'const'
@@ -77,7 +78,7 @@ function createDepositApi(erc20Api: Erc20Api, web3: Web3): DepositApi {
 function createExchangeApi(erc20Api: Erc20Api, web3: Web3): ExchangeApi {
   let exchangeApi
   if (isExchangeMock) {
-    const tokens = [FEE_TOKEN, ...tokenList.map(token => token.address)]
+    const tokens = [FEE_TOKEN, ...tokenList.map(token => token.address), TOKEN_8]
     exchangeApi = new ExchangeApiMock({
       balanceStates: exchangeBalanceStates,
       erc20Api,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -20,11 +20,26 @@ import {
 import Web3 from 'web3'
 import { INITIAL_INFURA_ENDPOINT } from 'const'
 
+const isWeb3Mock = process.env.MOCK_WEB3 === 'true'
 const isWalletMock = process.env.MOCK_WALLET === 'true'
 const isTokenListMock = process.env.MOCK_TOKEN_LIST === 'true'
 const isErc20Mock = process.env.MOCK_ERC20 === 'true'
 const isDepositMock = process.env.MOCK_DEPOSIT === 'true'
 const isExchangeMock = process.env.MOCK_EXCHANGE === 'true'
+
+// TODO connect to mainnet if we need AUTOCONNECT at all
+export const getDefaultProvider = (): string | null =>
+  process.env.NODE_ENV === 'test' ? null : INITIAL_INFURA_ENDPOINT
+
+function createWeb3Api(): Web3 {
+  const web3 = new Web3(getDefaultProvider())
+
+  if (isWeb3Mock) {
+    // Only function that needs to be mocked so far. We can add more and add extra logic as needed
+    web3.eth.getCode = async (address: string): Promise<string> => address
+  }
+  return web3
+}
 
 function createWalletApi(web3: Web3): WalletApi {
   let walletApi
@@ -90,13 +105,8 @@ function createTokenListApi(): TokenList {
   return tokenListApi
 }
 
-// TODO connect to mainnet if we need AUTOCONNECT at all
-export const getDefaultProvider = (): string | null =>
-  process.env.NODE_ENV === 'test' ? null : INITIAL_INFURA_ENDPOINT
-
-export const web3 = new Web3(getDefaultProvider())
-
 // Build APIs
+export const web3: Web3 = createWeb3Api()
 export const walletApi: WalletApi = createWalletApi(web3)
 export const erc20Api: Erc20Api = createErc20Api(web3)
 export const depositApi: DepositApi = createDepositApi(erc20Api, web3)

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -16,6 +16,7 @@ import {
   erc20Allowances,
   FEE_TOKEN,
   exchangeOrders,
+  unregisteredTokens,
   TOKEN_8,
 } from '../../test/data'
 import Web3 from 'web3'
@@ -56,7 +57,7 @@ function createWalletApi(web3: Web3): WalletApi {
 function createErc20Api(web3: Web3): Erc20Api {
   let erc20Api
   if (isErc20Mock) {
-    erc20Api = new Erc20ApiMock({ balances: erc20Balances, allowances: erc20Allowances })
+    erc20Api = new Erc20ApiMock({ balances: erc20Balances, allowances: erc20Allowances, tokens: unregisteredTokens })
   } else {
     erc20Api = new Erc20ApiImpl(web3)
   }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -34,6 +34,7 @@ export const getDefaultProvider = (): string | null =>
   process.env.NODE_ENV === 'test' ? null : INITIAL_INFURA_ENDPOINT
 
 function createWeb3Api(): Web3 {
+  // TODO: Create an `EthereumApi` https://github.com/gnosis/dex-react/issues/331
   const web3 = new Web3(getDefaultProvider())
 
   if (isWeb3Mock) {

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useMemo, useState, useEffect } from 'react'
 import BigNumber from 'bignumber.js'
 import styled from 'styled-components'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -178,10 +178,10 @@ const OrderRow: React.FC<Props> = props => {
   const [sellToken, setSellToken] = useState<TokenDetails | null>(null)
   const [buyToken, setBuyToken] = useState<TokenDetails | null>(null)
 
-  useMemo(async () => {
+  useEffect(() => {
     console.log('will fetch tokens')
-    await fetchToken(order.buyTokenId, networkId, setBuyToken)
-    await fetchToken(order.sellTokenId, networkId, setSellToken)
+    fetchToken(order.buyTokenId, networkId, setBuyToken)
+    fetchToken(order.sellTokenId, networkId, setSellToken)
   }, [networkId, order.buyTokenId, order.sellTokenId, setBuyToken, setSellToken])
 
   // TODO: move these memos into respective sub components

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -69,6 +69,14 @@ const PendingLink: React.FC<Pick<Props, 'pending'>> = ({ pending }) => {
   )
 }
 
+function displayTokenSymbolOrLink(token: TokenDetails): React.ReactNode | string {
+  const displayName = safeTokenName(token)
+  if (displayName.startsWith('0x')) {
+    return <EtherscanLink type="token" identifier={token.address} />
+  }
+  return displayName
+}
+
 interface OrderDetailsProps extends Pick<Props, 'pending'> {
   buyToken: TokenDetails
   sellToken: TokenDetails
@@ -82,7 +90,7 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({ price, buyToken, sellToken,
       <Highlight color={pending ? 'grey' : ''}>1</Highlight>
     </div>
     <div>
-      <strong>{safeTokenName(sellToken)}</strong>
+      <strong>{displayTokenSymbolOrLink(sellToken)}</strong>
     </div>
 
     <div>
@@ -92,7 +100,7 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({ price, buyToken, sellToken,
       <Highlight color={pending ? 'grey' : 'red'}>{price}</Highlight>
     </div>
     <div>
-      <strong>{safeTokenName(buyToken)}</strong>
+      <strong>{displayTokenSymbolOrLink(buyToken)}</strong>
     </div>
   </div>
 )
@@ -111,7 +119,7 @@ const UnfilledAmount: React.FC<UnfilledAmountProps> = ({ sellToken, unfilledAmou
       <>
         <div>{unfilledAmount}</div>
         <div>
-          <strong>{safeTokenName(sellToken)}</strong>
+          <strong>{displayTokenSymbolOrLink(sellToken)}</strong>
         </div>
       </>
     )}
@@ -126,7 +134,7 @@ interface AccountBalanceProps extends Pick<Props, 'isOverBalance'> {
 const AccountBalance: React.FC<AccountBalanceProps> = ({ sellToken, accountBalance, isOverBalance }) => (
   <div className="container sub-columns three-columns">
     <div>{accountBalance}</div>
-    <strong>{safeTokenName(sellToken)}</strong>
+    <strong>{displayTokenSymbolOrLink(sellToken)}</strong>
     <div className="warning">{isOverBalance && <FontAwesomeIcon icon={faExclamationTriangle} />}</div>
   </div>
 )

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -213,6 +213,8 @@ interface Props {
   pending?: boolean
 }
 
+const onError = onErrorFactory('Failed to fetch token')
+
 const OrderRow: React.FC<Props> = props => {
   const { order, networkId, pending = false } = props
 
@@ -221,9 +223,8 @@ const OrderRow: React.FC<Props> = props => {
   const [buyToken, setBuyToken] = useSafeState<TokenDetails | null>(null)
 
   useEffect(() => {
-    const errorMsg = 'Failed to fetch token'
-    fetchToken(order.buyTokenId, order.id, networkId, setBuyToken).catch(onErrorFactory(errorMsg))
-    fetchToken(order.sellTokenId, order.id, networkId, setSellToken).catch(onErrorFactory(errorMsg))
+    fetchToken(order.buyTokenId, order.id, networkId, setBuyToken).catch(onError)
+    fetchToken(order.sellTokenId, order.id, networkId, setSellToken).catch(onError)
   }, [networkId, order, setBuyToken, setSellToken])
 
   return (

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -138,7 +138,7 @@ const UnfilledAmount: React.FC<UnfilledAmountProps> = ({ sellToken, order, pendi
     order.remainingAmount,
     sellToken.decimals,
   ])
-  const unlimited = useMemo(() => order.priceDenominator.gt(MIN_UNLIMITED_SELL_ORDER), [order.priceDenominator])
+  const unlimited = order.priceDenominator.gt(MIN_UNLIMITED_SELL_ORDER)
 
   return (
     <div className={'container' + (unlimited ? '' : ' sub-columns two-columns')}>

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -216,7 +216,7 @@ interface Props {
 const onError = onErrorFactory('Failed to fetch token')
 
 const OrderRow: React.FC<Props> = props => {
-  const { order, networkId, pending = false } = props
+  const { order, isOverBalance, networkId, pending = false } = props
 
   // Fetching buy and sell tokens
   const [sellToken, setSellToken] = useSafeState<TokenDetails | null>(null)
@@ -231,14 +231,14 @@ const OrderRow: React.FC<Props> = props => {
     <>
       {sellToken && buyToken && (
         <OrderRowWrapper className={'orderRow' + (pending ? ' pending' : '')}>
-          <PendingLink {...props} />
+          <PendingLink pending={pending} />
           <div className="checked">
             <input type="checkbox" />
           </div>
-          <OrderDetails {...props} sellToken={sellToken} buyToken={buyToken} />
-          <UnfilledAmount {...props} sellToken={sellToken} />
-          <AccountBalance {...props} sellToken={sellToken} />
-          <Expires {...props} />
+          <OrderDetails order={order} sellToken={sellToken} buyToken={buyToken} />
+          <UnfilledAmount order={order} sellToken={sellToken} />
+          <AccountBalance order={order} isOverBalance={isOverBalance} sellToken={sellToken} />
+          <Expires order={order} pending={pending} />
         </OrderRowWrapper>
       )}
     </>

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from 'react'
+import React, { useMemo, useEffect } from 'react'
 import BigNumber from 'bignumber.js'
 import styled from 'styled-components'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -8,6 +8,8 @@ import Highlight from 'components/Highlight'
 import { EtherscanLink } from 'components/EtherscanLink'
 
 import { getTokenFromExchangeById } from 'services'
+
+import useSafeState from 'hooks/useSafeState'
 
 import { TokenDetails, AuctionElement } from 'types'
 import { safeTokenName, formatAmount, formatAmountFull, isBatchIdFarInTheFuture, formatDateFromBatchId } from 'utils'
@@ -187,8 +189,10 @@ async function fetchToken(
   networkId: number,
   setFn: React.Dispatch<React.SetStateAction<TokenDetails | null>>,
 ): Promise<void> {
+  console.log('fetching token %d', tokenId)
   const token = await getTokenFromExchangeById({ tokenId, networkId })
 
+  console.log('fetched token %d', tokenId, token)
   // It is unlikely the token ID coming form the order won't exist
   // Still, if that ever happens, store null and keep this order hidden
   setFn(token)
@@ -205,10 +209,11 @@ const OrderRow: React.FC<Props> = props => {
   const { order, networkId, pending = false } = props
 
   // Fetching buy and sell tokens
-  const [sellToken, setSellToken] = useState<TokenDetails | null>(null)
-  const [buyToken, setBuyToken] = useState<TokenDetails | null>(null)
+  const [sellToken, setSellToken] = useSafeState<TokenDetails | null>(null)
+  const [buyToken, setBuyToken] = useSafeState<TokenDetails | null>(null)
 
   useEffect(() => {
+    console.log('will fetch tokens')
     fetchToken(order.buyTokenId, networkId, setBuyToken)
     fetchToken(order.sellTokenId, networkId, setSellToken)
   }, [networkId, order.buyTokenId, order.sellTokenId, setBuyToken, setSellToken])

--- a/src/utils/onError.tsx
+++ b/src/utils/onError.tsx
@@ -1,0 +1,11 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { toast } from 'react-toastify'
+
+export function onErrorFactory(msg?: string): (error: any) => Promise<void> {
+  const errorMsg = msg ? msg : 'An error has occurred'
+
+  return async (error: any): Promise<void> => {
+    console.error(error)
+    toast.error(errorMsg)
+  }
+}

--- a/test/data/userOrders.ts
+++ b/test/data/userOrders.ts
@@ -37,6 +37,15 @@ export const exchangeOrders = {
       priceDenominator: new BN('10000000000000000000000'),
       remainingAmount: new BN('5876842900000000000000'),
     },
+    {
+      buyTokenId: 0, // FEE Token; not in our list (forcing token fetch)
+      sellTokenId: 1, // WETH
+      validFrom: BATCH_ID,
+      validUntil: dateToBatchId(addDays(NOW, 10)),
+      priceNumerator: new BN('500000000000000000000'),
+      priceDenominator: new BN('1000000000000000000000'),
+      remainingAmount: new BN('300000000000000000000'),
+    },
   ],
 }
 

--- a/test/data/userOrders.ts
+++ b/test/data/userOrders.ts
@@ -1,5 +1,5 @@
 import BN from 'bn.js'
-import { addDays, addMinutes } from 'date-fns'
+import { addDays, addMinutes, addYears } from 'date-fns'
 
 import { ALLOWANCE_MAX_VALUE, MAX_BATCH_ID } from 'const'
 import { dateToBatchId } from 'utils'
@@ -38,13 +38,22 @@ export const exchangeOrders = {
       remainingAmount: new BN('5876842900000000000000'),
     },
     {
-      buyTokenId: 0, // FEE Token; not in our list (forcing token fetch)
+      buyTokenId: 0, // FEE Token; not in our list (forcing token fetch), registered in the exchange. Provides details
       sellTokenId: 1, // WETH
       validFrom: BATCH_ID,
       validUntil: dateToBatchId(addDays(NOW, 10)),
       priceNumerator: new BN('500000000000000000000'),
-      priceDenominator: new BN('1000000000000000000000'),
+      priceDenominator: new BN('10000000000000000000000'),
       remainingAmount: new BN('300000000000000000000'),
+    },
+    {
+      buyTokenId: 1, // WETH
+      sellTokenId: 8, // TOKEN_8; not in our list (forcing token fetch), registered in the exchange. Does not provide details (name, symbol, decimals)
+      validFrom: BATCH_ID,
+      validUntil: dateToBatchId(addYears(NOW, 101)),
+      priceNumerator: new BN('700000000000000000000000'),
+      priceDenominator: new BN('10000000000000000000000'),
+      remainingAmount: new BN('98000000000000000000'),
     },
   ],
 }

--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -1,4 +1,4 @@
 module.exports = (): void => {
-  process.env.MOCK_WALLET = process.env.MOCK_TOKEN_LIST = process.env.MOCK_ERC20 = process.env.MOCK_DEPOSIT = process.env.MOCK_EXCHANGE =
+  process.env.MOCK_WALLET = process.env.MOCK_TOKEN_LIST = process.env.MOCK_ERC20 = process.env.MOCK_DEPOSIT = process.env.MOCK_EXCHANGE = process.env.MOCK_WEB3 =
     process.env.MOCK
 }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -100,6 +100,7 @@ module.exports = ({ stats = false } = {}) => ({
       'process.env.MOCK_ERC20': JSON.stringify(process.env.MOCK_ERC20 || process.env.MOCK || 'false'),
       'process.env.MOCK_DEPOSIT': JSON.stringify(process.env.MOCK_MOCK_DEPOSIT || process.env.MOCK || 'false'),
       'process.env.MOCK_EXCHANGE': JSON.stringify(process.env.MOCK_EXCHANGE || process.env.MOCK || 'false'),
+      'process.env.MOCK_WEB3': JSON.stringify(process.env.MOCK_WEB3 || process.env.MOCK || 'false'),
 
       // AUTOCONNECT: only applies for mock implementation
       'process.env.AUTOCONNECT': JSON.stringify(process.env.AUTOCONNECT || 'true'),


### PR DESCRIPTION
Depends on #316 

---

- [x] Refactoring Orders widget and OrderRow to use the service layer function `getTokenFromExchangeById`
- [x] Hiding order until both tokens are fetched.
- [x] Added mock order that requires token to be fetched and another that has a token without name/symbol
- [x] Simple mock of `web3.eth.getCode`
- [x] Displaying token address and link to etherscan when token has no name/symbol

![Screenshot_20191218_131216](https://user-images.githubusercontent.com/43217/71123857-6c10b000-2198-11ea-8382-4e41328bc01b.png)


Not on this PR:
- Cache/proxy layer on top of API. Results are NOT yet cached.