### PR TITLE
styling suggestions

### DIFF
--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 
 const Wrapper = styled.footer`
+  align-self: flex-end;
   display: flex;
   flex-flow: row wrap;
   justify-content: center;

--- a/src/components/UserWallet/UserWallet.styled.ts
+++ b/src/components/UserWallet/UserWallet.styled.ts
@@ -31,6 +31,11 @@ export const UserWalletItem = styled.div<{ $padding?: string; $wordWrap?: string
   > * {
     margin: 0 6px;
   }
+
+  > svg {
+    width: 70%;
+    height: auto;
+  }
 `
 
 export const UserWalletToggler = styled(UserWalletItem)`

--- a/src/components/UserWallet/index.tsx
+++ b/src/components/UserWallet/index.tsx
@@ -148,7 +148,7 @@ const UserWallet: React.FC<RouteComponentProps> = (props: UserWalletProps) => {
       {userAddress && showWallet && (
         <UserWalletSlideWrapper>
           <UserWalletItem>
-            <QRCode size={100} value={userAddress} />
+            <QRCode value={userAddress} renderAs="svg" />
           </UserWalletItem>
           <UserWalletItem>
             {/* Copy Confirmation */}


### PR DESCRIPTION
- Makes QR responsive in size (canvas can't scale outside of init size)
- Footer was fat on pages with height < 100vh

Before:
![pr326--dexreact review gnosisdev com_trade_DAI-USDC__sell=0 buy=0](https://user-images.githubusercontent.com/5121491/71075776-b47a9e80-2195-11ea-8f4c-c3ac9b5a2b85.png)

After:
![localhost_8080_trade_DAI-USDC_sell=0 buy=0 (1)](https://user-images.githubusercontent.com/5121491/71075794-b9d7e900-2195-11ea-8f81-e4650e68708e.png)

Feel free to resize QR width % as you see fit