### PR TITLE
332/new balance apis from contract

### DIFF
--- a/src/api/exchange/DepositApiImpl.ts
+++ b/src/api/exchange/DepositApiImpl.ts
@@ -5,7 +5,7 @@ import { ZERO } from 'const'
 
 import { BatchExchangeContract } from '@gnosis.pm/dex-js'
 import { getAddressForNetwork } from './batchExchangeAddresses'
-import { DepositApi, Receipt, TxOptionalParams } from 'types'
+import { DepositApi, Receipt, TxOptionalParams, PendingFlux } from 'types'
 
 import Web3 from 'web3'
 import { getProviderState, Provider, ProviderState } from '@gnosis.pm/dapp-ui'
@@ -71,72 +71,36 @@ export class DepositApiImpl implements DepositApi {
     return toBN(balance)
   }
 
-  public async getPendingDepositAmount({
+  public async getPendingDeposit({
     userAddress,
     tokenAddress,
   }: {
     userAddress: string
     tokenAddress: string
-  }): Promise<BN> {
-    if (!userAddress || !tokenAddress) return ZERO
+  }): Promise<PendingFlux> {
+    if (!userAddress || !tokenAddress) return { amount: ZERO, batchId: 0 }
 
     const contract = await this._getContract()
-    // TODO: Update APIs to the new get balances changes
-    // https://github.com/gnosis/dex-react/issues/332
-    const { 0: depositAmount } = await contract.methods.getPendingDeposit(userAddress, tokenAddress).call()
 
-    return toBN(depositAmount)
+    const { 0: amount, 1: batchId } = await contract.methods.getPendingDeposit(userAddress, tokenAddress).call()
+
+    return { amount: toBN(amount), batchId: Number(batchId) }
   }
 
-  public async getPendingDepositBatchId({
+  public async getPendingWithdraw({
     userAddress,
     tokenAddress,
   }: {
     userAddress: string
     tokenAddress: string
-  }): Promise<number> {
-    if (!userAddress || !tokenAddress) return 0
+  }): Promise<PendingFlux> {
+    if (!userAddress || !tokenAddress) return { amount: ZERO, batchId: 0 }
 
     const contract = await this._getContract()
-    // TODO: Update APIs to the new get balances changes
-    // https://github.com/gnosis/dex-react/issues/332
-    const { 1: depositBatchId } = await contract.methods.getPendingDeposit(userAddress, tokenAddress).call()
 
-    return +depositBatchId
-  }
+    const { 0: amount, 1: batchId } = await contract.methods.getPendingWithdraw(userAddress, tokenAddress).call()
 
-  public async getPendingWithdrawAmount({
-    userAddress,
-    tokenAddress,
-  }: {
-    userAddress: string
-    tokenAddress: string
-  }): Promise<BN> {
-    if (!userAddress || !tokenAddress) return ZERO
-
-    const contract = await this._getContract()
-    // TODO: Update APIs to the new get balances changes
-    // https://github.com/gnosis/dex-react/issues/332
-    const { 0: withdrawAmount } = await contract.methods.getPendingWithdraw(userAddress, tokenAddress).call()
-
-    return toBN(withdrawAmount)
-  }
-
-  public async getPendingWithdrawBatchId({
-    userAddress,
-    tokenAddress,
-  }: {
-    userAddress: string
-    tokenAddress: string
-  }): Promise<number> {
-    if (!userAddress || !tokenAddress) return 0
-
-    const contract = await this._getContract()
-    // TODO: Update APIs to the new get balances changes
-    // https://github.com/gnosis/dex-react/issues/332
-    const { 1: withdrawBatchId } = await contract.methods.getPendingWithdraw(userAddress, tokenAddress).call()
-
-    return +withdrawBatchId
+    return { amount: toBN(amount), batchId: Number(batchId) }
   }
 
   public async deposit(

--- a/src/api/exchange/DepositApiMock.ts
+++ b/src/api/exchange/DepositApiMock.ts
@@ -3,9 +3,9 @@ import assert from 'assert'
 
 import { getEpoch, log } from 'utils'
 import { ZERO, BATCH_TIME } from 'const'
-import { CONTRACT, RECEIPT } from '../../../test/data'
+import { CONTRACT, RECEIPT, createFlux } from '../../../test/data'
 
-import { DepositApi, BalanceState, Receipt, TxOptionalParams, Erc20Api } from 'types'
+import { DepositApi, BalanceState, Receipt, TxOptionalParams, Erc20Api, PendingFlux } from 'types'
 import { waitAndSendReceipt } from 'utils/mock'
 
 export interface BalancesByUserAndToken {
@@ -47,65 +47,35 @@ export class DepositApiMock implements DepositApi {
     return balanceState ? balanceState.balance : ZERO
   }
 
-  public async getPendingDepositAmount({
+  public async getPendingDeposit({
     userAddress,
     tokenAddress,
   }: {
     userAddress: string
     tokenAddress: string
-  }): Promise<BN> {
+  }): Promise<PendingFlux> {
     const userBalanceStates = this._balanceStates[userAddress]
     if (!userBalanceStates) {
-      return ZERO
+      return createFlux()
     }
     const balanceState = userBalanceStates[tokenAddress]
 
-    return balanceState ? balanceState.pendingDeposits.amount : ZERO
+    return balanceState ? balanceState.pendingDeposits : createFlux()
   }
 
-  public async getPendingDepositBatchId({
+  public async getPendingWithdraw({
     userAddress,
     tokenAddress,
   }: {
     userAddress: string
     tokenAddress: string
-  }): Promise<number> {
+  }): Promise<PendingFlux> {
     const userBalanceStates = this._balanceStates[userAddress]
     if (!userBalanceStates) {
-      return 0
+      return createFlux()
     }
     const balanceState = userBalanceStates[tokenAddress]
-    return balanceState ? balanceState.pendingDeposits.batchId : 0
-  }
-
-  public async getPendingWithdrawAmount({
-    userAddress,
-    tokenAddress,
-  }: {
-    userAddress: string
-    tokenAddress: string
-  }): Promise<BN> {
-    const userBalanceStates = this._balanceStates[userAddress]
-    if (!userBalanceStates) {
-      return ZERO
-    }
-    const balanceState = userBalanceStates[tokenAddress]
-    return balanceState ? balanceState.pendingWithdraws.amount : ZERO
-  }
-
-  public async getPendingWithdrawBatchId({
-    userAddress,
-    tokenAddress,
-  }: {
-    userAddress: string
-    tokenAddress: string
-  }): Promise<number> {
-    const userBalanceStates = this._balanceStates[userAddress]
-    if (!userBalanceStates) {
-      return 0
-    }
-    const balanceState = userBalanceStates[tokenAddress]
-    return balanceState ? balanceState.pendingWithdraws.batchId : 0
+    return balanceState ? balanceState.pendingWithdraws : createFlux()
   }
 
   public async deposit(

--- a/src/components/DepositWidget/Row.tsx
+++ b/src/components/DepositWidget/Row.tsx
@@ -44,16 +44,14 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
     image,
     symbol,
     decimals,
-    exchangeBalance,
-    depositingBalance,
-    withdrawingBalance,
+    totalExchangeBalance,
+    pendingWithdraw,
     claimable,
     walletBalance,
     enabled,
   } = tokenBalances
 
   const [visibleForm, showForm] = useState<'deposit' | 'withdraw' | void>()
-  const exchangeBalanceTotal = exchangeBalance.add(depositingBalance)
 
   // Checks innerWidth
   const showResponsive = !!innerWidth && innerWidth < RESPONSIVE_SIZES.MOBILE_LARGE
@@ -78,15 +76,15 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
           <TokenImg src={image} alt={name} />
           <div>{name}</div>
         </div>
-        <div data-label="Exchange Wallet" title={formatAmountFull(exchangeBalanceTotal, decimals) || ''}>
-          {formatAmount(exchangeBalanceTotal, decimals)}
+        <div data-label="Exchange Wallet" title={formatAmountFull(totalExchangeBalance, decimals) || ''}>
+          {formatAmount(totalExchangeBalance, decimals)}
         </div>
-        <div data-label="Pending Withdrawals" title={formatAmountFull(withdrawingBalance, decimals) || ''}>
+        <div data-label="Pending Withdrawals" title={formatAmountFull(pendingWithdraw.amount, decimals) || ''}>
           {claimable ? (
             <>
               <RowClaimButton className="success" onClick={onClaim} disabled={claiming.has(address)}>
                 {claiming.has(address) && <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />}
-                {formatAmount(withdrawingBalance, decimals)}
+                {formatAmount(pendingWithdraw.amount, decimals)}
               </RowClaimButton>
               <div>
                 <RowClaimLink
@@ -101,10 +99,10 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
                 </RowClaimLink>
               </div>
             </>
-          ) : withdrawingBalance.gt(ZERO) ? (
+          ) : pendingWithdraw.amount.gt(ZERO) ? (
             <>
               <FontAwesomeIcon icon={faClock} style={{ marginRight: 7 }} />
-              {formatAmount(withdrawingBalance, decimals)}
+              {formatAmount(pendingWithdraw.amount, decimals)}
             </>
           ) : (
             0
@@ -168,7 +166,7 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
             </p>
           }
           totalAmountLabel="Exchange wallet"
-          totalAmount={exchangeBalanceTotal}
+          totalAmount={totalExchangeBalance}
           inputLabel="Withdraw amount"
           tokenBalances={tokenBalances}
           submitBtnLabel="Withdraw"

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -50,9 +50,12 @@ const DepositWidget: React.FC = () => {
   } = useDepositModals({ ...withdrawRequest, requestWithdrawToken })
 
   const requestWithdrawConfirmation = async (amount: BN, tokenAddress: string, claimable: boolean): Promise<void> => {
-    const { withdrawingBalance, symbol } = getToken('address', tokenAddress, balances) as Required<TokenBalanceDetails>
+    const {
+      pendingWithdraw: { amount: withdrawingBalance },
+      symbol,
+    } = getToken('address', tokenAddress, balances) as Required<TokenBalanceDetails>
 
-    log(`Confirm withdrawal for ${symbol} with withdrawingBalance ${withdrawingBalance}`)
+    log(`Confirm withdraw for ${symbol} with withdrawingBalance ${withdrawingBalance}`)
 
     if (!withdrawingBalance.isZero()) {
       // Storing current values before displaying modal

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -126,7 +126,7 @@ const TokenRow: React.FC<Props> = ({
 
   let overMax = ZERO
   if (balance && validateMaxAmount) {
-    const max = balance.exchangeBalance
+    const max = balance.totalExchangeBalance
     const value = new BN(parseAmount(inputValue, selectedToken.decimals) || '0')
     overMax = value.gt(max) ? value.sub(max) : ZERO
   }
@@ -144,7 +144,7 @@ const TokenRow: React.FC<Props> = ({
   )
 
   function useMax(): void {
-    setValue(inputId, formatAmountFull(balance.exchangeBalance, balance.decimals, false))
+    setValue(inputId, formatAmountFull(balance.totalExchangeBalance, balance.decimals, false))
   }
 
   const enforcePrecision = useCallback(() => {
@@ -184,8 +184,6 @@ const TokenRow: React.FC<Props> = ({
     [removeExcessZeros],
   )
 
-  const exchangeBalanceAndPendingBalance = balance && balance.exchangeBalance.add(balance.depositingBalance)
-
   return (
     <Wrapper>
       <TokenImgWrapper alt={selectedToken.name} src={selectedToken.image} />
@@ -223,7 +221,7 @@ const TokenRow: React.FC<Props> = ({
               </LinkWithPastLocation>
             </strong>{' '}
             <span className="success">
-              {balance ? formatAmount(exchangeBalanceAndPendingBalance, balance.decimals) : '0'}
+              {balance ? formatAmount(balance.totalExchangeBalance, balance.decimals) : '0'}
             </span>
           </div>
           {validateMaxAmount && <a onClick={useMax}>use max</a>}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -95,6 +95,7 @@ const TradeWidget: React.FC = () => {
   // TESTING
   const NULL_BALANCE_TOKEN = {
     exchangeBalance: ZERO,
+    totalExchangeBalance: ZERO,
     pendingDeposit: { amount: ZERO, batchId: 0 },
     pendingWithdraw: { amount: ZERO, batchId: 0 },
     walletBalance: ZERO,

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -95,8 +95,8 @@ const TradeWidget: React.FC = () => {
   // TESTING
   const NULL_BALANCE_TOKEN = {
     exchangeBalance: ZERO,
-    depositingBalance: ZERO,
-    withdrawingBalance: ZERO,
+    pendingDeposit: { amount: ZERO, batchId: 0 },
+    pendingWithdraw: { amount: ZERO, batchId: 0 },
     walletBalance: ZERO,
     claimable: false,
     enabled: false,

--- a/src/hooks/useTokenBalances.ts
+++ b/src/hooks/useTokenBalances.ts
@@ -1,4 +1,6 @@
 import { useEffect } from 'react'
+import BN from 'bn.js'
+
 import { tokenListApi, erc20Api, depositApi } from 'api'
 
 import useSafeState from './useSafeState'
@@ -22,17 +24,15 @@ async function fetchBalancesForToken(
   const tokenAddress = token.address
   const [
     exchangeBalance,
-    depositingBalance,
-    withdrawingBalance,
-    withdrawBatchId,
+    pendingDeposit,
+    pendingWithdraw,
     currentBachId,
     walletBalance,
     allowance,
   ] = await Promise.all([
     depositApi.getBalance({ userAddress, tokenAddress }),
-    depositApi.getPendingDepositAmount({ userAddress, tokenAddress }),
-    depositApi.getPendingWithdrawAmount({ userAddress, tokenAddress }),
-    depositApi.getPendingWithdrawBatchId({ userAddress, tokenAddress }),
+    depositApi.getPendingDeposit({ userAddress, tokenAddress }),
+    depositApi.getPendingWithdraw({ userAddress, tokenAddress }),
     depositApi.getCurrentBatchId(),
     erc20Api.balanceOf({ userAddress, tokenAddress }),
     erc20Api.allowance({ userAddress, tokenAddress, spenderAddress: contractAddress }),
@@ -42,9 +42,9 @@ async function fetchBalancesForToken(
     ...token,
     decimals: token.decimals,
     exchangeBalance,
-    depositingBalance,
-    withdrawingBalance,
-    claimable: withdrawingBalance.isZero() ? false : withdrawBatchId < currentBachId,
+    pendingDeposit,
+    pendingWithdraw,
+    claimable: pendingWithdraw.amount.isZero() ? false : pendingWithdraw.batchId < currentBachId,
     walletBalance,
     enabled: allowance.gt(ALLOWANCE_FOR_ENABLED_TOKEN),
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,7 @@ export interface TokenBalanceDetails extends TokenDetails {
   walletBalance: BN
   claimable: boolean
   enabled: boolean
+  totalExchangeBalance: BN
 }
 
 export interface TokenList {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,8 +28,8 @@ export interface TokenDetails extends MinimalTokenDetails {
 
 export interface TokenBalanceDetails extends TokenDetails {
   exchangeBalance: BN
-  depositingBalance: BN
-  withdrawingBalance: BN
+  pendingDeposit: PendingFlux
+  pendingWithdraw: PendingFlux
   walletBalance: BN
   claimable: boolean
   enabled: boolean

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,22 +63,8 @@ export interface DepositApi {
   getSecondsRemainingInBatch(): Promise<number>
 
   getBalance({ userAddress, tokenAddress }: { userAddress: string; tokenAddress: string }): Promise<BN>
-  getPendingDepositAmount({ userAddress, tokenAddress }: { userAddress: string; tokenAddress: string }): Promise<BN>
-  getPendingDepositBatchId({
-    userAddress,
-    tokenAddress,
-  }: {
-    userAddress: string
-    tokenAddress: string
-  }): Promise<number>
-  getPendingWithdrawAmount({ userAddress, tokenAddress }: { userAddress: string; tokenAddress: string }): Promise<BN>
-  getPendingWithdrawBatchId({
-    userAddress,
-    tokenAddress,
-  }: {
-    userAddress: string
-    tokenAddress: string
-  }): Promise<number>
+  getPendingDeposit({ userAddress, tokenAddress }: { userAddress: string; tokenAddress: string }): Promise<PendingFlux>
+  getPendingWithdraw({ userAddress, tokenAddress }: { userAddress: string; tokenAddress: string }): Promise<PendingFlux>
 
   deposit(
     {

--- a/test/components/DepositWidget.components.test.tsx
+++ b/test/components/DepositWidget.components.test.tsx
@@ -22,6 +22,7 @@ const initialTokenBalanceDetails = {
   decimals: 18,
   address: '0x0',
   exchangeBalance: ZERO,
+  totalExchangeBalance: ZERO,
   pendingDeposit: createFlux(),
   pendingWithdraw: createFlux(),
   claimable: false,

--- a/test/components/DepositWidget.components.test.tsx
+++ b/test/components/DepositWidget.components.test.tsx
@@ -7,6 +7,7 @@ import { Row, RowProps } from 'components/DepositWidget/Row'
 import { ZERO, ONE } from 'const'
 import { TokenBalanceDetails } from 'types'
 import { TokenLocalState } from 'reducers-actions'
+import { createFlux } from '../data'
 
 const fakeRowState: TokenLocalState = {
   enabling: new Set(),
@@ -21,8 +22,8 @@ const initialTokenBalanceDetails = {
   decimals: 18,
   address: '0x0',
   exchangeBalance: ZERO,
-  depositingBalance: ZERO,
-  withdrawingBalance: ZERO,
+  pendingDeposit: createFlux(),
+  pendingWithdraw: createFlux(),
   claimable: false,
   walletBalance: ZERO,
   enabled: false,
@@ -84,7 +85,7 @@ describe('<Row /> claimable token', () => {
   const tokenBalanceDetails: Partial<TokenBalanceDetails> = {
     enabled: true,
     claimable: true,
-    withdrawingBalance: ONE,
+    pendingWithdraw: createFlux(ONE),
   }
 
   it('contains 2 <button> elements (claim, deposit, withdraw)', () => {

--- a/test/data/exchangeBalanceStates.ts
+++ b/test/data/exchangeBalanceStates.ts
@@ -7,8 +7,8 @@ import { PendingFlux } from 'types'
 
 // Using a function to build flux objects because if we use the same
 // object everywhere, anytime it's updated, it'll reflect everywhere
-const createFlux = (): PendingFlux => {
-  return { amount: ZERO, batchId: 0 }
+export const createFlux = (amount: BN = ZERO, batchId = 0): PendingFlux => {
+  return { amount, batchId }
 }
 
 const STATE_ZERO = {
@@ -17,7 +17,7 @@ const STATE_ZERO = {
   pendingWithdraws: createFlux(),
 }
 
-const exchangeBalanceStates: BalancesByUserAndToken = {
+export const exchangeBalanceStates: BalancesByUserAndToken = {
   [USER_1]: {
     [TOKEN_1]: STATE_ZERO, // 0. WETH: decimals=18
     [TOKEN_2]: {
@@ -53,5 +53,3 @@ const exchangeBalanceStates: BalancesByUserAndToken = {
     [TOKEN_7]: undefined, // 0. DAI: decimals=18
   },
 }
-
-export default exchangeBalanceStates

--- a/test/data/index.ts
+++ b/test/data/index.ts
@@ -1,6 +1,6 @@
 export * from './basic'
 
-export { default as exchangeBalanceStates } from './exchangeBalanceStates'
+export * from './exchangeBalanceStates'
 export { default as erc20Allowances } from './erc20Allowances'
 export { default as erc20Balances } from './erc20Balances'
 export { default as tokenList } from './tokenList'


### PR DESCRIPTION
Closes #332
Closes https://github.com/gnosis/dex-react/issues/228

---

Adjusting frontend to contract changes regarding balance calculation/display.
Resolves the issue first reported on https://github.com/gnosis/dex-react/issues/228.

Exchange balance on the interface now depends on 3 things:
1. balance; from [`getBalance`](https://github.com/gnosis/dex-contracts/blob/master/contracts/EpochTokenLocker.sol#L163)
2. currentBatchId; from [`getCurrentBatchId`](https://github.com/gnosis/dex-contracts/blob/master/contracts/EpochTokenLocker.sol#L145)
3. pendingDeposit; from [`getPendingDeposit`](https://github.com/gnosis/dex-contracts/blob/master/contracts/EpochTokenLocker.sol#L127)

Given by:

``` typescript
// If deposit not matured yet, pending deposit is not part of balance. Add both
if (currentBatchId <= pendingDeposit.batchId) {
  totalExchangeBalance = balance + pendingDeposit.amount
} else {
// Otherwise, pending has matured and is included in the balance, nothing to do
  totalExchangeBalance = balance
}
```

Pending withdraw is not included in the calculation and does not in any way affects the displayed exchange balance, which gives the behaviour:

1. If pendingWithdraw is not matured, its amount is still part of `balance`.  Sum on exchange balance and pending withdraw == real user balance + pending withdraw > real user balance

![Screenshot_20191220_141225](https://user-images.githubusercontent.com/43217/71296390-49b39980-2334-11ea-9dd2-5493689b7af4.png)

2. Otherwise, pendingWithdraw is deduced from `balance`. Sum on exchange balance and claimable withdraw == real user balance

![Screenshot_20191220_141535](https://user-images.githubusercontent.com/43217/71296392-4c15f380-2334-11ea-9761-a84cdff54cd5.png)

### Note:
PR size is as small as it gets. This is a core change touches many files.
