### PR TITLE
Remove update token

### DIFF
--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -23,7 +23,7 @@ interface WithdrawState {
 }
 
 const DepositWidget: React.FC = () => {
-  const { balances, setBalances, error } = useTokenBalances()
+  const { balances, error } = useTokenBalances()
   const {
     // Dispatchers
     enableToken,
@@ -34,7 +34,7 @@ const DepositWidget: React.FC = () => {
     enabling,
     claiming,
     highlighted,
-  } = useRowActions({ balances, setBalances })
+  } = useRowActions({ balances })
   const windowSpecs = useWindowSizes()
 
   const [withdrawRequest, setWithdrawRequest] = useSafeState<WithdrawState>({

--- a/src/hooks/useTokenBalances.ts
+++ b/src/hooks/useTokenBalances.ts
@@ -15,7 +15,6 @@ import { PendingFlux } from 'api/deposit/DepositApi'
 interface UseTokenBalanceResult {
   balances: TokenBalanceDetails[]
   error: boolean
-  setBalances: React.Dispatch<React.SetStateAction<TokenBalanceDetails[]>>
 }
 
 function calculateTotalBalance(balance: BN, currentBatchId: number, pendingDeposit: PendingFlux): BN {
@@ -105,5 +104,5 @@ export const useTokenBalances = (): UseTokenBalanceResult => {
       })
   }, [setBalances, setError, walletInfo])
 
-  return { balances, error, setBalances }
+  return { balances, error }
 }


### PR DESCRIPTION
Follow up from https://github.com/gnosis/dex-react/pull/338#pullrequestreview-335556679

Removing 'manual' interface updates.
Balances states now becomes read only, with the updates coming directly from the network.

Keep in mind this makes the mock behaviour stop working for the deposits page.