### PR TITLE
Update to last version of dex-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "@gnosis.pm/dapp-ui": "^0.5.3",
-    "@gnosis.pm/dex-js": "0.1.4",
+    "@gnosis.pm/dex-js": "0.1.5-RC.1",
     "@hot-loader/react-dom": "^16.8.6",
     "@types/react": "^16.9.13",
     "@types/react-select": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "@gnosis.pm/dapp-ui": "^0.5.3",
-    "@gnosis.pm/dex-js": "0.1.5-RC.1",
+    "@gnosis.pm/dex-js": "0.1.5-RC.3",
     "@hot-loader/react-dom": "^16.8.6",
     "@types/react": "^16.9.13",
     "@types/react-select": "^3.0.5",

--- a/src/api/deposit/DepositApi.ts
+++ b/src/api/deposit/DepositApi.ts
@@ -1,18 +1,13 @@
 import BN from 'bn.js'
-import { AbiItem } from 'web3-utils'
 import { log, assert, toBN } from 'utils'
 import { ZERO } from 'const'
 
-import { BatchExchangeContract } from '@gnosis.pm/dex-js'
+import { BatchExchangeContract, batchExchangeAbi } from '@gnosis.pm/dex-js'
 import { getAddressForNetwork } from './batchExchangeAddresses'
 import { Receipt, TxOptionalParams } from 'types'
 
 import Web3 from 'web3'
 import { getProviderState, Provider, ProviderState } from '@gnosis.pm/dapp-ui'
-
-// TODO: Very likely, this ABI makes webpack build heavier. Review how to instruct to discard info
-//  https://github.com/gnosis/dex-react/issues/97
-import { abi as batchExchangeAbi } from '@gnosis.pm/dex-contracts/build/contracts/BatchExchange.json'
 
 export interface DepositApi {
   getContractAddress(networkId: number): string | null
@@ -78,7 +73,7 @@ export class DepositApiImpl implements DepositApi {
   protected static _contractsCache: { [K: string]: BatchExchangeContract } = {}
 
   public constructor(web3: Web3) {
-    this._contractPrototype = new web3.eth.Contract(batchExchangeAbi as AbiItem[]) as BatchExchangeContract
+    this._contractPrototype = new web3.eth.Contract(batchExchangeAbi) as BatchExchangeContract
     this._web3 = web3
 
     // TODO remove later

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,20 +972,19 @@
   dependencies:
     web3connect "^1.0.0-beta.23"
 
-"@gnosis.pm/dex-contracts@^0.1.3":
+"@gnosis.pm/dex-contracts@^0.1.2":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-contracts/-/dex-contracts-0.1.3.tgz#8474ed83c879a3c3a22ce13741e3ad43dac6dd68"
   integrity sha512-HRRw+AGZYe6almCQRj8pNL1AELLnkvB1jqLs20faaoISy+5f9I4nsgHbkw9qzxi/R8NQ8pAc/wIx4rvH7hSeCw==
   dependencies:
     bn.js "^5.0.0"
 
-"@gnosis.pm/dex-js@0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.1.4.tgz#315863df63f104871850123982c74435409975bd"
-  integrity sha512-qKw588hsupYOUT14ZcajCsULFWIHlCvwPcI5s7MhxfwaylQLB6WHz9AUwoy3xZFJD1E1zd4vt7BpuCkIQN2S7w==
+"@gnosis.pm/dex-js@0.1.5-RC.1":
+  version "0.1.5-RC.1"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.1.5-RC.1.tgz#ecda8286c345fbc16643aca6255660b4a6e136e0"
+  integrity sha512-J5V3UzQAOKi31AP6IfUEgzRHwlRYVyxcH98KM/sP8bLyJU6grJlrd005VwIToCx07ap4OFZnqgaS9QFRUXpBXg==
   dependencies:
-    "@gnosis.pm/dex-contracts" "^0.1.3"
-    web3 "^1.2.4"
+    "@gnosis.pm/dex-contracts" "^0.1.2"
 
 "@hot-loader/react-dom@^16.8.6":
   version "16.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -979,10 +979,10 @@
   dependencies:
     bn.js "^5.0.0"
 
-"@gnosis.pm/dex-js@0.1.5-RC.1":
-  version "0.1.5-RC.1"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.1.5-RC.1.tgz#ecda8286c345fbc16643aca6255660b4a6e136e0"
-  integrity sha512-J5V3UzQAOKi31AP6IfUEgzRHwlRYVyxcH98KM/sP8bLyJU6grJlrd005VwIToCx07ap4OFZnqgaS9QFRUXpBXg==
+"@gnosis.pm/dex-js@0.1.5-RC.3":
+  version "0.1.5-RC.3"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.1.5-RC.3.tgz#34cdd68dc388258071191b21beaf74469b5057f7"
+  integrity sha512-ywEebwtT8zLC8Mmo53AmtWBTgca9l+vYby3A4IlR46Vs2Fk5TDgDMgzQlnE8LMZObozY34iz5Q/cq4oeONq9KQ==
   dependencies:
     "@gnosis.pm/dex-contracts" "^0.1.2"
 


### PR DESCRIPTION
Uses the updated version of dex-js: https://github.com/gnosis/dex-js/pull/44

For the web, not much change is needed, only that we can make use of the exported and typed ABI