### PR TITLE
209/cancel orders

### DIFF
--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -13,8 +13,8 @@ export interface ExchangeApi extends DepositApi {
   getTokenIdByAddress(tokenAddress: string): Promise<number>
   addToken(tokenAddress: string, txOptionalParams?: TxOptionalParams): Promise<Receipt>
   placeOrder(orderParams: PlaceOrderParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
-  cancelOrder(
-    { senderAddress, orderId }: { senderAddress: string; orderId: number },
+  cancelOrders(
+    { senderAddress, orderIds }: { senderAddress: string; orderIds: number[] },
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt>
 }
@@ -129,18 +129,18 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     return tx
   }
 
-  public async cancelOrder(
-    { senderAddress, orderId }: { senderAddress: string; orderId: number },
+  public async cancelOrders(
+    { senderAddress, orderIds }: { senderAddress: string; orderIds: number[] },
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt> {
     const contract = await this._getContract()
-    const tx = contract.methods.cancelOrders([orderId]).send({ from: senderAddress })
+    const tx = contract.methods.cancelOrders(orderIds).send({ from: senderAddress })
 
     if (txOptionalParams && txOptionalParams.onSentTransaction) {
       tx.once('transactionHash', txOptionalParams.onSentTransaction)
     }
 
-    log(`[ExchangeApiImpl] Cancelled Order ${orderId}`)
+    log(`[ExchangeApiImpl] Cancelled Orders ${orderIds}`)
 
     return tx
   }

--- a/src/api/exchange/ExchangeApiMock.ts
+++ b/src/api/exchange/ExchangeApiMock.ts
@@ -121,7 +121,7 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
     this._initOrders(senderAddress)
     const batchId = await this.getCurrentBatchId()
 
-    orderIds.map(orderId => {
+    orderIds.forEach(orderId => {
       if (this.orders[senderAddress][orderId]) {
         this.orders[senderAddress][orderId].validUntil = batchId - 1
       }

--- a/src/api/exchange/ExchangeApiMock.ts
+++ b/src/api/exchange/ExchangeApiMock.ts
@@ -106,22 +106,26 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
     return RECEIPT
   }
 
-  public async cancelOrder(
+  public async cancelOrders(
     {
       senderAddress,
-      orderId,
+      orderIds,
     }: {
       senderAddress: string
-      orderId: number
+      orderIds: number[]
     },
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
 
     this._initOrders(senderAddress)
-    if (this.orders[senderAddress][orderId]) {
-      this.orders[senderAddress][orderId].validUntil = (await this.getCurrentBatchId()) - 1
-    }
+    const batchId = await this.getCurrentBatchId()
+
+    orderIds.map(orderId => {
+      if (this.orders[senderAddress][orderId]) {
+        this.orders[senderAddress][orderId].validUntil = batchId - 1
+      }
+    })
 
     return RECEIPT
   }

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -59,16 +59,15 @@ const OrderRowWrapper = styled.div`
   }
 `
 
-const PendingLink: React.FC<Pick<Props, 'pending'>> = ({ pending }) => {
+const PendingLink: React.FC<Pick<Props, 'pending' | 'transactionHash'>> = ({ pending, transactionHash }) => {
   if (!pending) {
     return null
   }
 
-  // TODO: use proper pending tx hash for link
   return (
     <div className="container pendingCell">
       <FontAwesomeIcon icon={faSpinner} size="lg" spin />
-      <EtherscanLink identifier="bla" type="tx" label={<small>view</small>} />
+      {transactionHash && <EtherscanLink identifier={transactionHash} type="tx" label={<small>view</small>} />}
     </div>
   )
 }
@@ -226,6 +225,7 @@ interface Props {
   isOverBalance: boolean
   networkId: number
   pending?: boolean
+  transactionHash?: string
   isMarkedForDeletion: boolean
   toggleMarkedForDeletion: () => void
 }
@@ -233,7 +233,15 @@ interface Props {
 const onError = onErrorFactory('Failed to fetch token')
 
 const OrderRow: React.FC<Props> = props => {
-  const { order, isOverBalance, networkId, pending = false, isMarkedForDeletion, toggleMarkedForDeletion } = props
+  const {
+    order,
+    isOverBalance,
+    networkId,
+    pending = false,
+    transactionHash,
+    isMarkedForDeletion,
+    toggleMarkedForDeletion,
+  } = props
 
   // Fetching buy and sell tokens
   const [sellToken, setSellToken] = useSafeState<TokenDetails | null>(null)
@@ -248,7 +256,7 @@ const OrderRow: React.FC<Props> = props => {
     <>
       {sellToken && buyToken && (
         <OrderRowWrapper className={'orderRow' + (pending ? ' pending' : '')}>
-          <PendingLink pending={pending} />
+          <PendingLink pending={pending} transactionHash={transactionHash} />
           <DeleteOrder
             isMarkedForDeletion={isMarkedForDeletion}
             toggleMarkedForDeletion={toggleMarkedForDeletion}

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -239,7 +239,7 @@ const OrdersWidget: React.FC = () => {
         <CreateButtons className={noOrders ? 'withoutOrders' : 'withOrders'}>
           {noOrders && (
             <p className="noOrdersInfo">
-              It appears you haven&apos;t place any order yet. <br /> Create one!
+              It appears you haven&apos;t placed any order yet. <br /> Create one!
             </p>
           )}
           <Link to="/trade" className="tradeBtn">

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -198,7 +198,7 @@ const OrdersWidget: React.FC = () => {
     async (event: React.SyntheticEvent<HTMLFormElement>): Promise<void> => {
       event.preventDefault()
 
-      const success = await deleteOrders(Array.from(markedForDeletion.values()))
+      const success = await deleteOrders(Array.from(markedForDeletion))
 
       if (success) {
         // reset selections

--- a/src/components/OrdersWidget/useDeleteOrders.tsx
+++ b/src/components/OrdersWidget/useDeleteOrders.tsx
@@ -7,6 +7,7 @@ import { exchangeApi } from 'api'
 
 import { log, assert } from 'utils'
 import { txOptionalParams } from 'utils/transaction'
+import { useCallback } from 'react'
 
 interface Result {
   deleteOrders: (orderIds: string[]) => Promise<boolean>
@@ -23,34 +24,37 @@ export function useDeleteOrders(): Result {
   const [deleting, setDeleting] = useSafeState<boolean>(false)
   const { userAddress } = useWalletConnection()
 
-  async function deleteOrders(uiOrderIds: string[]): Promise<boolean> {
-    log(`Trying to cancel the orderIds ${uiOrderIds} for user ${userAddress}`)
+  const deleteOrders = useCallback(
+    async (uiOrderIds: string[]): Promise<boolean> => {
+      log(`Trying to cancel the orderIds ${uiOrderIds} for user ${userAddress}`)
 
-    try {
-      assert(userAddress, 'User address is missing. Aborting.')
-      assert(uiOrderIds.length > 0, 'No orders to cancel. Aborting.')
+      try {
+        assert(userAddress, 'User address is missing. Aborting.')
+        assert(uiOrderIds.length > 0, 'No orders to cancel. Aborting.')
 
-      setDeleting(true)
+        setDeleting(true)
 
-      const orderIds = extractExchangeOrderIds(uiOrderIds)
+        const orderIds = extractExchangeOrderIds(uiOrderIds)
 
-      const receipt = await exchangeApi.cancelOrders({ senderAddress: userAddress, orderIds }, txOptionalParams)
+        const receipt = await exchangeApi.cancelOrders({ senderAddress: userAddress, orderIds }, txOptionalParams)
 
-      log(`The transaction has been mined: ${receipt.transactionHash}`)
+        log(`The transaction has been mined: ${receipt.transactionHash}`)
 
-      toast.success('The selected orders have been cancelled')
+        toast.success('The selected orders have been cancelled')
 
-      return true
-    } catch (e) {
-      console.error(`Failed to cancel orders ${uiOrderIds} for user ${userAddress}`, e)
+        return true
+      } catch (e) {
+        console.error(`Failed to cancel orders ${uiOrderIds} for user ${userAddress}`, e)
 
-      toast.error('Failed to cancel selected orders')
+        toast.error('Failed to cancel selected orders')
 
-      return false
-    } finally {
-      setDeleting(false)
-    }
-  }
+        return false
+      } finally {
+        setDeleting(false)
+      }
+    },
+    [setDeleting, userAddress],
+  )
 
   return { deleteOrders, deleting }
 }

--- a/src/components/OrdersWidget/useDeleteOrders.tsx
+++ b/src/components/OrdersWidget/useDeleteOrders.tsx
@@ -1,0 +1,56 @@
+import { toast } from 'react-toastify'
+
+import useSafeState from 'hooks/useSafeState'
+import { useWalletConnection } from 'hooks/useWalletConnection'
+
+import { exchangeApi } from 'api'
+
+import { log, assert } from 'utils'
+import { txOptionalParams } from 'utils/transaction'
+
+interface Result {
+  deleteOrders: (orderIds: string[]) => Promise<boolean>
+  deleting: boolean
+}
+
+function extractExchangeOrderIds(orderIds: string[]): number[] {
+  // For now, we simply convert string to number.
+  // In the future the ids might be more complex, such as userAddress+orderId
+  return orderIds.map(Number)
+}
+
+export function useDeleteOrders(): Result {
+  const [deleting, setDeleting] = useSafeState<boolean>(false)
+  const { userAddress } = useWalletConnection()
+
+  async function deleteOrders(uiOrderIds: string[]): Promise<boolean> {
+    log(`Trying to cancel the orderIds ${uiOrderIds} for user ${userAddress}`)
+
+    try {
+      assert(userAddress, 'User address is missing. Aborting.')
+      assert(uiOrderIds.length > 0, 'No orders to cancel. Aborting.')
+
+      setDeleting(true)
+
+      const orderIds = extractExchangeOrderIds(uiOrderIds)
+
+      const receipt = await exchangeApi.cancelOrders({ senderAddress: userAddress, orderIds }, txOptionalParams)
+
+      log(`The transaction has been mined: ${receipt.transactionHash}`)
+
+      toast.success('The selected orders have been cancelled')
+
+      return true
+    } catch (e) {
+      console.error(`Failed to cancel orders ${uiOrderIds} for user ${userAddress}`, e)
+
+      toast.error('Failed to cancel selected orders')
+
+      return false
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return { deleteOrders, deleting }
+}

--- a/test/api/ExchangeApi/ExchangeApiMock.test.ts
+++ b/test/api/ExchangeApi/ExchangeApiMock.test.ts
@@ -167,7 +167,7 @@ describe('cancelOrder', () => {
   test('cancel existing order', async () => {
     const orderId = (await instance.getOrders(USER_1)).length - 1
 
-    await instance.cancelOrder({ senderAddress: USER_1, orderId })
+    await instance.cancelOrders({ senderAddress: USER_1, orderIds: [orderId] })
 
     const actual = (await instance.getOrders(USER_1))[orderId]
     expect(actual.validUntil).toBe(BATCH_ID - 1)
@@ -176,7 +176,7 @@ describe('cancelOrder', () => {
   test('cancel non existing order does nothing', async () => {
     const expected = await instance.getOrders(USER_1)
 
-    await instance.cancelOrder({ senderAddress: USER_1, orderId: expected.length + 1 })
+    await instance.cancelOrders({ senderAddress: USER_1, orderIds: [expected.length + 1] })
 
     const actual = await instance.getOrders(USER_1)
     expect(actual).toEqual(expected)
@@ -185,7 +185,7 @@ describe('cancelOrder', () => {
   test('cancel non existing order, user with no orders does nothing', async () => {
     const expected = await instance.getOrders(USER_2)
 
-    await instance.cancelOrder({ senderAddress: USER_2, orderId: expected.length + 1 })
+    await instance.cancelOrders({ senderAddress: USER_2, orderIds: [expected.length + 1] })
 
     const actual = await instance.getOrders(USER_2)
     expect(actual).toEqual(expected)


### PR DESCRIPTION
Cancelling selected orders #209 

- Updating API to cancel multiple orders at once as opposed to 1 at a time.
- Triggering cancellation from Orders page
- Displaying order as pending while transaction is mined

### NOT in this PR:
- Hide orders that are cancelled/expired
- Button to display/hide cancelled/expired orders