### PR TITLE
209/hide expired orders

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -41,12 +41,12 @@ const Layout: React.FC = ({ children }) => (
           order: 2,
           withPastLocation: true,
         },
-        // {
-        //   label: 'Orders',
-        //   to: '/orders',
-        //   order: 3,
-        //   withPastLocation: true,
-        // },
+        {
+          label: 'Orders',
+          to: '/orders',
+          order: 3,
+          withPastLocation: true,
+        },
         // Place holder
         // {
         //   label: 'Strategies',

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -72,17 +72,16 @@ const PendingLink: React.FC<Pick<Props, 'pending' | 'transactionHash'>> = ({ pen
   )
 }
 
-const DeleteOrder: React.FC<Pick<Props, 'isMarkedForDeletion' | 'toggleMarkedForDeletion' | 'pending'>> = ({
-  isMarkedForDeletion,
-  toggleMarkedForDeletion,
-  pending,
-}) => (
+const DeleteOrder: React.FC<Pick<
+  Props,
+  'isMarkedForDeletion' | 'toggleMarkedForDeletion' | 'pending' | 'disabled'
+>> = ({ isMarkedForDeletion, toggleMarkedForDeletion, pending, disabled }) => (
   <div className="checked">
     <input
       type="checkbox"
       onChange={toggleMarkedForDeletion}
       checked={isMarkedForDeletion && !pending}
-      disabled={pending}
+      disabled={disabled}
     />
   </div>
 )
@@ -228,6 +227,7 @@ interface Props {
   transactionHash?: string
   isMarkedForDeletion: boolean
   toggleMarkedForDeletion: () => void
+  disabled: boolean
 }
 
 const onError = onErrorFactory('Failed to fetch token')
@@ -241,6 +241,7 @@ const OrderRow: React.FC<Props> = props => {
     transactionHash,
     isMarkedForDeletion,
     toggleMarkedForDeletion,
+    disabled,
   } = props
 
   // Fetching buy and sell tokens
@@ -261,6 +262,7 @@ const OrderRow: React.FC<Props> = props => {
             isMarkedForDeletion={isMarkedForDeletion}
             toggleMarkedForDeletion={toggleMarkedForDeletion}
             pending={pending}
+            disabled={disabled}
           />
           <OrderDetails order={order} sellToken={sellToken} buyToken={buyToken} />
           <UnfilledAmount order={order} sellToken={sellToken} />

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback } from 'react'
+import React, { useMemo, useCallback, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
 import { faExchangeAlt, faChartLine, faTrashAlt, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
@@ -7,6 +7,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useWalletConnection } from 'hooks/useWalletConnection'
 import { useOrders } from 'hooks/useOrders'
 import useSafeState from 'hooks/useSafeState'
+
+import { AuctionElement } from 'api/exchange/ExchangeApi'
+
+import { dateToBatchId } from 'utils'
 
 import Widget from 'components/Layout/Widget'
 import Highlight from 'components/Highlight'
@@ -160,7 +164,16 @@ const OrdersForm = styled.div`
 `
 
 const OrdersWidget: React.FC = () => {
-  const orders = useOrders()
+  const allOrders = useOrders()
+
+  const [orders, setOrders] = useSafeState<AuctionElement[]>(allOrders)
+
+  useEffect(() => {
+    const filteredOrders = allOrders.filter(order => order.validUntil > dateToBatchId())
+
+    setOrders(filteredOrders)
+  }, [allOrders, setOrders])
+
   const noOrders = orders.length === 0
 
   // this page is behind login wall so networkId should always be set

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -267,6 +267,7 @@ const OrdersWidget: React.FC = () => {
                     type="checkbox"
                     onChange={toggleSelectAll}
                     checked={orders.length === markedForDeletion.size}
+                    disabled={deleting}
                   />
                 </div>
                 <div className="title">Order details</div>
@@ -289,6 +290,7 @@ const OrdersWidget: React.FC = () => {
                   isMarkedForDeletion={markedForDeletion.has(order.id)}
                   toggleMarkedForDeletion={toggleMarkForDeletionFactory(order.id)}
                   pending={deleting && markedForDeletion.has(order.id)}
+                  disabled={deleting}
                 />
               ))}
             </div>

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -216,10 +216,11 @@ const OrdersWidget: React.FC = () => {
       if (success) {
         // reset selections
         // TODO: might no longer be needed once filtering is in place
+        setOrders(orders.filter(order => !markedForDeletion.has(order.id)))
         setMarkedForDeletion(new Set<string>())
       }
     },
-    [deleteOrders, markedForDeletion, setMarkedForDeletion],
+    [deleteOrders, markedForDeletion, orders, setMarkedForDeletion, setOrders],
   )
 
   return (


### PR DESCRIPTION
Dependent on #362 
Part of #209 

---

- Not displaying orders that are already expired.
- Disabling all checkboxes while deleting.
- Adding back Orders link to nav bar

### NOT part of this PR:
- Button to show/hide expired orders https://github.com/gnosis/dex-react/pull/370