### PR TITLE
209/show expired orders

### DIFF
--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -12,7 +12,14 @@ import { getTokenFromExchangeById } from 'services'
 import useSafeState from 'hooks/useSafeState'
 import { TokenDetails } from 'types'
 
-import { safeTokenName, formatAmount, formatAmountFull, isBatchIdFarInTheFuture, formatDateFromBatchId } from 'utils'
+import {
+  safeTokenName,
+  formatAmount,
+  formatAmountFull,
+  isBatchIdFarInTheFuture,
+  formatDateFromBatchId,
+  isOrderActive,
+} from 'utils'
 import { onErrorFactory } from 'utils/onError'
 import { MIN_UNLIMITED_SELL_ORDER } from 'const'
 import { AuctionElement } from 'api/exchange/ExchangeApi'
@@ -178,12 +185,13 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({ sellToken, order, isOve
     order.sellTokenBalance,
     sellToken.decimals,
   ])
+  const isActive = isOrderActive(order, new Date())
 
   return (
     <div className="container sub-columns three-columns">
       <div>{accountBalance}</div>
       <strong>{displayTokenSymbolOrLink(sellToken)}</strong>
-      <div className="warning">{isOverBalance && <FontAwesomeIcon icon={faExclamationTriangle} />}</div>
+      <div className="warning">{isOverBalance && isActive && <FontAwesomeIcon icon={faExclamationTriangle} />}</div>
     </div>
   )
 }

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -94,6 +94,8 @@ const OrdersForm = styled.div`
     grid-template-columns: repeat(2, 1fr);
     align-items: center;
 
+    margin: 1em 0;
+
     .warning {
       justify-self: end;
     }
@@ -173,6 +175,13 @@ const OrdersForm = styled.div`
     .hidden {
       visibility: hidden;
     }
+  }
+
+  .noOrders {
+    padding: 3em;
+
+    display: flex;
+    justify-content: center;
   }
 
   .warning {
@@ -319,51 +328,57 @@ const OrdersWidget: React.FC = () => {
               </div>
             )}
           </div>
-          <form action="submit" onSubmit={onSubmit}>
-            <div className="ordersContainer">
-              <div className="headerRow">
-                <div className="checked">
-                  <input
-                    type="checkbox"
-                    onChange={toggleSelectAll}
-                    checked={orders.length === markedForDeletion.size}
+          {shownOrdersCount ? (
+            <form action="submit" onSubmit={onSubmit}>
+              <div className="ordersContainer">
+                <div className="headerRow">
+                  <div className="checked">
+                    <input
+                      type="checkbox"
+                      onChange={toggleSelectAll}
+                      checked={orders.length === markedForDeletion.size}
+                      disabled={deleting}
+                    />
+                  </div>
+                  <div className="title">Order details</div>
+                  <div className="title">
+                    Unfilled <br /> amount
+                  </div>
+                  <div className="title">
+                    Account <br />
+                    balance
+                  </div>
+                  <div className="title">Expires</div>
+                </div>
+
+                {orders.map(order => (
+                  <OrderRow
+                    key={order.id}
+                    order={order}
+                    networkId={networkId}
+                    isOverBalance={overBalanceOrders.has(order.id)}
+                    isMarkedForDeletion={markedForDeletion.has(order.id)}
+                    toggleMarkedForDeletion={toggleMarkForDeletionFactory(order.id)}
+                    pending={deleting && markedForDeletion.has(order.id)}
                     disabled={deleting}
                   />
-                </div>
-                <div className="title">Order details</div>
-                <div className="title">
-                  Unfilled <br /> amount
-                </div>
-                <div className="title">
-                  Account <br />
-                  balance
-                </div>
-                <div className="title">Expires</div>
+                ))}
               </div>
 
-              {orders.map(order => (
-                <OrderRow
-                  key={order.id}
-                  order={order}
-                  networkId={networkId}
-                  isOverBalance={overBalanceOrders.has(order.id)}
-                  isMarkedForDeletion={markedForDeletion.has(order.id)}
-                  toggleMarkedForDeletion={toggleMarkForDeletionFactory(order.id)}
-                  pending={deleting && markedForDeletion.has(order.id)}
-                  disabled={deleting}
-                />
-              ))}
+              <div className="deleteContainer">
+                <ButtonWithIcon disabled={markedForDeletion.size == 0 || deleting}>
+                  <FontAwesomeIcon icon={faTrashAlt} /> {showActive ? 'Cancel' : 'Delete'} orders
+                </ButtonWithIcon>
+                <span className={markedForDeletion.size == 0 ? '' : 'hidden'}>
+                  Select first the order(s) you want to {showActive ? 'cancel' : 'delete'}
+                </span>
+              </div>
+            </form>
+          ) : (
+            <div className="noOrders">
+              <span>You have no {showActive ? 'active' : 'expired'} orders</span>
             </div>
-
-            <div className="deleteContainer">
-              <ButtonWithIcon disabled={markedForDeletion.size == 0 || deleting}>
-                <FontAwesomeIcon icon={faTrashAlt} /> {showActive ? 'Cancel' : 'Delete'} orders
-              </ButtonWithIcon>
-              <span className={markedForDeletion.size == 0 ? '' : 'hidden'}>
-                Select first the order(s) you want to {showActive ? 'cancel' : 'delete'}
-              </span>
-            </div>
-          </form>
+          )}
         </OrdersForm>
       )}
     </OrdersWrapper>

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -363,10 +363,10 @@ const OrdersWidget: React.FC = () => {
 
             <div className="deleteContainer">
               <ButtonWithIcon disabled={markedForDeletion.size == 0 || deleting}>
-                <FontAwesomeIcon icon={faTrashAlt} /> Delete orders
+                <FontAwesomeIcon icon={faTrashAlt} /> {showActive ? 'Cancel' : 'Delete'} orders
               </ButtonWithIcon>
               <span className={markedForDeletion.size == 0 ? '' : 'hidden'}>
-                Select first the order(s) you want to delete
+                Select first the order(s) you want to {showActive ? 'cancel' : 'delete'}
               </span>
             </div>
           </form>

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -305,6 +305,20 @@ const OrdersWidget: React.FC = () => {
               <div className="total">
                 You have <Highlight>{allOrders.length}</Highlight> standing orders:
               </div>
+              <ShowOrdersButton
+                type="active"
+                isActive={showActive}
+                shownCount={shownOrdersCount}
+                hiddenCount={hiddenOrdersCount}
+                onClick={toggleShowActive}
+              />
+              <ShowOrdersButton
+                type="expired"
+                isActive={!showActive}
+                shownCount={shownOrdersCount}
+                hiddenCount={hiddenOrdersCount}
+                onClick={toggleShowActive}
+              />
             </div>
             {overBalanceOrders.size > 0 && (
               <div className="warning">

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useCallback, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import styled from 'styled-components'
-import { faExchangeAlt, faChartLine, faTrashAlt, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
+import { faExchangeAlt, faTrashAlt, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import { useWalletConnection } from 'hooks/useWalletConnection'
@@ -291,12 +291,13 @@ const OrdersWidget: React.FC = () => {
               <FontAwesomeIcon icon={faExchangeAlt} /> Trade
             </ButtonWithIcon>
           </Link>
-          <ButtonWithIcon className="danger strategyBtn">
+          {/* TODO: enable when the strategy page is implemented */}
+          {/* <ButtonWithIcon className="danger strategyBtn">
             <FontAwesomeIcon icon={faChartLine} /> Create new strategy
           </ButtonWithIcon>
           <a href="/" className="strategyInfo">
             <small>Learn more about strategies</small>
-          </a>
+          </a> */}
         </CreateButtons>
       </div>
       {!noOrders && networkId && (

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -10,7 +10,7 @@ import useSafeState from 'hooks/useSafeState'
 
 import { AuctionElement } from 'api/exchange/ExchangeApi'
 
-import { batchIdToDate } from 'utils'
+import { isOrderActive } from 'utils'
 
 import Widget from 'components/Layout/Widget'
 import Highlight from 'components/Highlight'
@@ -205,8 +205,6 @@ const ShowOrdersButton: React.FC<ShowOrdersButtonProps> = ({ type, isActive, sho
   )
 }
 
-const isOrderActive = (order: AuctionElement, now: Date): boolean => batchIdToDate(order.validUntil) >= now
-
 const OrdersWidget: React.FC = () => {
   const allOrders = useOrders()
 
@@ -320,7 +318,7 @@ const OrdersWidget: React.FC = () => {
                 onClick={toggleShowActive}
               />
             </div>
-            {overBalanceOrders.size > 0 && (
+            {overBalanceOrders.size > 0 && showActive && (
               <div className="warning">
                 <FontAwesomeIcon icon={faExclamationTriangle} />
                 <strong> Low balance</strong>

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -193,13 +193,7 @@ const ShowOrdersButton: React.FC<ShowOrdersButtonProps> = ({ type, isActive, sho
 
   return (
     <button className={type} disabled={isActive} onClick={onClick}>
-      {!isActive ? (
-        <>
-          Show <Highlight>{count}</Highlight>
-        </>
-      ) : (
-        <>{count}</>
-      )}
+      {!isActive ? <Highlight>{count}</Highlight> : <>{count}</>}
       <> {type}</>
     </button>
   )

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -92,9 +92,26 @@ const OrdersForm = styled.div`
   .infoContainer {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
+    align-items: center;
 
     .warning {
       justify-self: end;
+    }
+
+    .countContainer {
+      display: grid;
+      grid: 'total active expired';
+      align-items: center;
+    }
+
+    .total {
+      grid-area: total;
+    }
+    .active {
+      grid-area: active;
+    }
+    .expired {
+      grid-area: expired;
     }
   }
 
@@ -163,6 +180,30 @@ const OrdersForm = styled.div`
   }
 `
 
+interface ShowOrdersButtonProps {
+  type: 'active' | 'expired'
+  isActive: boolean
+  shownCount: number
+  hiddenCount: number
+  onClick: () => void
+}
+
+const ShowOrdersButton: React.FC<ShowOrdersButtonProps> = ({ type, isActive, shownCount, hiddenCount, onClick }) => {
+  const count = isActive ? shownCount : hiddenCount
+
+  return (
+    <button className={type} disabled={isActive} onClick={onClick}>
+      {!isActive ? (
+        <>
+          Show <Highlight>{count}</Highlight>
+        </>
+      ) : (
+        <>{count}</>
+      )}
+      <> {type}</>
+    </button>
+  )
+}
 const OrdersWidget: React.FC = () => {
   const allOrders = useOrders()
 
@@ -249,8 +290,10 @@ const OrdersWidget: React.FC = () => {
       {!noOrders && networkId && (
         <OrdersForm>
           <div className="infoContainer">
-            <div>
-              You have <Highlight>{orders.length}</Highlight> standing orders
+            <div className="countContainer">
+              <div className="total">
+                You have <Highlight>{allOrders.length}</Highlight> standing orders:
+              </div>
             </div>
             {overBalanceOrders.size > 0 && (
               <div className="warning">

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -4,12 +4,38 @@ import { exchangeApi } from 'api'
 import { useEffect } from 'react'
 import { AuctionElement } from 'api/exchange/ExchangeApi'
 
+/**
+ * Filter out deleted orders.
+ *
+ * When orders are `deleted` from the contract, they are still returned, but with all fields set to zero.
+ * We will not display such orders.
+ *
+ * @param orders all orders returned by the contract
+ */
+function filterDeletedOrders(orders: AuctionElement[]): AuctionElement[] {
+  return orders.filter(
+    order =>
+      !(
+        !order.buyTokenId &&
+        !order.sellTokenId &&
+        !order.priceDenominator &&
+        !order.priceNumerator &&
+        !order.validFrom &&
+        !order.validUntil
+      ),
+  )
+}
+
 export function useOrders(): AuctionElement[] {
   const { userAddress } = useWalletConnection()
   const [orders, setOrders] = useSafeState<AuctionElement[]>([])
 
   useEffect(() => {
-    userAddress && exchangeApi.getOrders(userAddress).then(setOrders)
+    userAddress &&
+      exchangeApi
+        .getOrders(userAddress)
+        .then(filterDeletedOrders)
+        .then(setOrders)
   }, [setOrders, userAddress])
 
   return orders

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -3,6 +3,7 @@ import useSafeState from './useSafeState'
 import { exchangeApi } from 'api'
 import { useEffect } from 'react'
 import { AuctionElement } from 'api/exchange/ExchangeApi'
+import { ZERO } from 'const'
 
 /**
  * Filter out deleted orders.
@@ -16,12 +17,12 @@ function filterDeletedOrders(orders: AuctionElement[]): AuctionElement[] {
   return orders.filter(
     order =>
       !(
-        !order.buyTokenId &&
-        !order.sellTokenId &&
-        !order.priceDenominator &&
-        !order.priceNumerator &&
-        !order.validFrom &&
-        !order.validUntil
+        order.buyTokenId === 0 &&
+        order.sellTokenId === 0 &&
+        order.priceDenominator.eq(ZERO) &&
+        order.priceNumerator.eq(ZERO) &&
+        order.validFrom === 0 &&
+        order.validUntil === 0
       ),
   )
 }

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -1,5 +1,7 @@
 import { TokenDetails } from 'types'
 import { AssertionError } from 'assert'
+import { AuctionElement } from 'api/exchange/ExchangeApi'
+import { batchIdToDate } from './time'
 
 export function assert<T>(val: T, message: string): asserts val is NonNullable<T> {
   if (!val) {
@@ -49,3 +51,5 @@ export function getImageUrl(tokenAddress?: string): string | undefined {
   if (!tokenAddress) return undefined
   return `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/${tokenAddress}/logo.png`
 }
+
+export const isOrderActive = (order: AuctionElement, now: Date): boolean => batchIdToDate(order.validUntil) >= now


### PR DESCRIPTION
Part of #209 
Depends on #363 

---

**WARNING**: First iteration of the UI. Open to better ideas.

- [x] Allowing user to see expired orders
- [x] Showing count of active and expired orders
- [x] Filtering out deleted orders

### Active:
![Screenshot_20191230_144120](https://user-images.githubusercontent.com/43217/71603640-aa03c180-2b12-11ea-92c4-8c7396995ab2.png)

### Expired:
![Screenshot_20191230_144148](https://user-images.githubusercontent.com/43217/71603643-ab34ee80-2b12-11ea-85bc-4f7c720fe6ee.png)

### What currently does not work
- After cancelling/deleting, the order is removed from the local list of orders. But when switching between active/expired it's shown again.
- Local list of orders is only updated after a page refresh. How can I update it based on blocks or batchId?
