### PR TITLE
329/refactor api params

### DIFF
--- a/src/api/deposit/DepositApi.ts
+++ b/src/api/deposit/DepositApi.ts
@@ -24,7 +24,7 @@ export interface DepositParams extends ReadOnlyParams, WithTxOptionalParams {
 
 export type RequestWithdrawParams = DepositParams
 
-export type WithdrawParams = ReadOnlyParams & WithTxOptionalParams
+export type WithdrawParams = Omit<RequestWithdrawParams, 'amount'>
 
 export interface DepositApi {
   getContractAddress(networkId: number): string | null

--- a/src/api/deposit/DepositApi.ts
+++ b/src/api/deposit/DepositApi.ts
@@ -9,10 +9,14 @@ import { Receipt, TxOptionalParams } from 'types'
 import Web3 from 'web3'
 import { getProviderState, Provider, ProviderState } from '@gnosis.pm/dapp-ui'
 
-export interface ReadOnlyParams {
+interface ReadOnlyParams {
   userAddress: string
   tokenAddress: string
 }
+
+export type GetBalanceParams = ReadOnlyParams
+export type GetPendingDepositParams = ReadOnlyParams
+export type GetPendingWithdrawParams = ReadOnlyParams
 
 interface WithTxOptionalParams {
   txOptionalParams?: TxOptionalParams
@@ -32,9 +36,9 @@ export interface DepositApi {
   getCurrentBatchId(): Promise<number>
   getSecondsRemainingInBatch(): Promise<number>
 
-  getBalance(params: ReadOnlyParams): Promise<BN>
-  getPendingDeposit(params: ReadOnlyParams): Promise<PendingFlux>
-  getPendingWithdraw(params: ReadOnlyParams): Promise<PendingFlux>
+  getBalance(params: GetBalanceParams): Promise<BN>
+  getPendingDeposit(params: GetPendingDepositParams): Promise<PendingFlux>
+  getPendingWithdraw(params: GetPendingWithdrawParams): Promise<PendingFlux>
 
   deposit(params: DepositParams): Promise<Receipt>
   requestWithdraw(params: RequestWithdrawParams): Promise<Receipt>
@@ -93,7 +97,7 @@ export class DepositApiImpl implements DepositApi {
     return +secondsRemainingInBatch
   }
 
-  public async getBalance({ userAddress, tokenAddress }: ReadOnlyParams): Promise<BN> {
+  public async getBalance({ userAddress, tokenAddress }: GetBalanceParams): Promise<BN> {
     if (!userAddress || !tokenAddress) return ZERO
 
     const contract = await this._getContract()
@@ -102,7 +106,7 @@ export class DepositApiImpl implements DepositApi {
     return toBN(balance)
   }
 
-  public async getPendingDeposit({ userAddress, tokenAddress }: ReadOnlyParams): Promise<PendingFlux> {
+  public async getPendingDeposit({ userAddress, tokenAddress }: GetPendingDepositParams): Promise<PendingFlux> {
     if (!userAddress || !tokenAddress) return { amount: ZERO, batchId: 0 }
 
     const contract = await this._getContract()
@@ -112,7 +116,7 @@ export class DepositApiImpl implements DepositApi {
     return { amount: toBN(amount), batchId: Number(batchId) }
   }
 
-  public async getPendingWithdraw({ userAddress, tokenAddress }: ReadOnlyParams): Promise<PendingFlux> {
+  public async getPendingWithdraw({ userAddress, tokenAddress }: GetPendingWithdrawParams): Promise<PendingFlux> {
     if (!userAddress || !tokenAddress) return { amount: ZERO, batchId: 0 }
 
     const contract = await this._getContract()

--- a/src/api/deposit/DepositApiMock.ts
+++ b/src/api/deposit/DepositApiMock.ts
@@ -5,7 +5,7 @@ import { getEpoch, log } from 'utils'
 import { ZERO, BATCH_TIME } from 'const'
 import { CONTRACT, RECEIPT, createFlux } from '../../../test/data'
 
-import { Receipt, TxOptionalParams } from 'types'
+import { Receipt } from 'types'
 import { waitAndSendReceipt } from 'utils/mock'
 import {
   DepositApi,
@@ -81,10 +81,7 @@ export class DepositApiMock implements DepositApi {
     return balanceState ? balanceState.pendingWithdraws : createFlux()
   }
 
-  public async deposit(
-    { userAddress, tokenAddress, amount }: DepositParams,
-    txOptionalParams?: TxOptionalParams,
-  ): Promise<Receipt> {
+  public async deposit({ userAddress, tokenAddress, amount, txOptionalParams }: DepositParams): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
 
     // Create the balance state if it's the first deposit
@@ -111,10 +108,12 @@ export class DepositApiMock implements DepositApi {
     return RECEIPT
   }
 
-  public async requestWithdraw(
-    { userAddress, tokenAddress, amount }: RequestWithdrawParams,
-    txOptionalParams?: TxOptionalParams,
-  ): Promise<Receipt> {
+  public async requestWithdraw({
+    userAddress,
+    tokenAddress,
+    amount,
+    txOptionalParams,
+  }: RequestWithdrawParams): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
 
     const currentBatchId = await this.getCurrentBatchId()
@@ -129,10 +128,7 @@ export class DepositApiMock implements DepositApi {
     return RECEIPT
   }
 
-  public async withdraw(
-    { userAddress, tokenAddress }: WithdrawParams,
-    txOptionalParams?: TxOptionalParams,
-  ): Promise<Receipt> {
+  public async withdraw({ userAddress, tokenAddress, txOptionalParams }: WithdrawParams): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
 
     const currentBatchId = await this.getCurrentBatchId()

--- a/src/api/deposit/DepositApiMock.ts
+++ b/src/api/deposit/DepositApiMock.ts
@@ -10,7 +10,9 @@ import { waitAndSendReceipt } from 'utils/mock'
 import {
   DepositApi,
   PendingFlux,
-  ReadOnlyParams,
+  GetBalanceParams,
+  GetPendingDepositParams,
+  GetPendingWithdrawParams,
   RequestWithdrawParams,
   WithdrawParams,
   DepositParams,
@@ -52,7 +54,7 @@ export class DepositApiMock implements DepositApi {
     return BATCH_TIME - (getEpoch() % BATCH_TIME)
   }
 
-  public async getBalance({ userAddress, tokenAddress }: ReadOnlyParams): Promise<BN> {
+  public async getBalance({ userAddress, tokenAddress }: GetBalanceParams): Promise<BN> {
     const userBalanceStates = this._balanceStates[userAddress]
     if (!userBalanceStates) {
       return ZERO
@@ -62,7 +64,7 @@ export class DepositApiMock implements DepositApi {
     return balanceState ? balanceState.balance : ZERO
   }
 
-  public async getPendingDeposit({ userAddress, tokenAddress }: ReadOnlyParams): Promise<PendingFlux> {
+  public async getPendingDeposit({ userAddress, tokenAddress }: GetPendingDepositParams): Promise<PendingFlux> {
     const userBalanceStates = this._balanceStates[userAddress]
     if (!userBalanceStates) {
       return createFlux()
@@ -72,7 +74,7 @@ export class DepositApiMock implements DepositApi {
     return balanceState ? balanceState.pendingDeposits : createFlux()
   }
 
-  public async getPendingWithdraw({ userAddress, tokenAddress }: ReadOnlyParams): Promise<PendingFlux> {
+  public async getPendingWithdraw({ userAddress, tokenAddress }: GetPendingWithdrawParams): Promise<PendingFlux> {
     const userBalanceStates = this._balanceStates[userAddress]
     if (!userBalanceStates) {
       return createFlux()

--- a/src/api/deposit/DepositApiMock.ts
+++ b/src/api/deposit/DepositApiMock.ts
@@ -7,7 +7,14 @@ import { CONTRACT, RECEIPT, createFlux } from '../../../test/data'
 
 import { Receipt, TxOptionalParams } from 'types'
 import { waitAndSendReceipt } from 'utils/mock'
-import { DepositApi, PendingFlux } from './DepositApi'
+import {
+  DepositApi,
+  PendingFlux,
+  ReadOnlyParams,
+  RequestWithdrawParams,
+  WithdrawParams,
+  DepositParams,
+} from './DepositApi'
 import { Erc20Api } from 'api/erc20/Erc20Api'
 
 export interface BalanceState {
@@ -45,7 +52,7 @@ export class DepositApiMock implements DepositApi {
     return BATCH_TIME - (getEpoch() % BATCH_TIME)
   }
 
-  public async getBalance({ userAddress, tokenAddress }: { userAddress: string; tokenAddress: string }): Promise<BN> {
+  public async getBalance({ userAddress, tokenAddress }: ReadOnlyParams): Promise<BN> {
     const userBalanceStates = this._balanceStates[userAddress]
     if (!userBalanceStates) {
       return ZERO
@@ -55,13 +62,7 @@ export class DepositApiMock implements DepositApi {
     return balanceState ? balanceState.balance : ZERO
   }
 
-  public async getPendingDeposit({
-    userAddress,
-    tokenAddress,
-  }: {
-    userAddress: string
-    tokenAddress: string
-  }): Promise<PendingFlux> {
+  public async getPendingDeposit({ userAddress, tokenAddress }: ReadOnlyParams): Promise<PendingFlux> {
     const userBalanceStates = this._balanceStates[userAddress]
     if (!userBalanceStates) {
       return createFlux()
@@ -71,13 +72,7 @@ export class DepositApiMock implements DepositApi {
     return balanceState ? balanceState.pendingDeposits : createFlux()
   }
 
-  public async getPendingWithdraw({
-    userAddress,
-    tokenAddress,
-  }: {
-    userAddress: string
-    tokenAddress: string
-  }): Promise<PendingFlux> {
+  public async getPendingWithdraw({ userAddress, tokenAddress }: ReadOnlyParams): Promise<PendingFlux> {
     const userBalanceStates = this._balanceStates[userAddress]
     if (!userBalanceStates) {
       return createFlux()
@@ -87,15 +82,7 @@ export class DepositApiMock implements DepositApi {
   }
 
   public async deposit(
-    {
-      userAddress,
-      tokenAddress,
-      amount,
-    }: {
-      userAddress: string
-      tokenAddress: string
-      amount: BN
-    },
+    { userAddress, tokenAddress, amount }: DepositParams,
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
@@ -125,15 +112,7 @@ export class DepositApiMock implements DepositApi {
   }
 
   public async requestWithdraw(
-    {
-      userAddress,
-      tokenAddress,
-      amount,
-    }: {
-      userAddress: string
-      tokenAddress: string
-      amount: BN
-    },
+    { userAddress, tokenAddress, amount }: RequestWithdrawParams,
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
@@ -151,13 +130,7 @@ export class DepositApiMock implements DepositApi {
   }
 
   public async withdraw(
-    {
-      userAddress,
-      tokenAddress,
-    }: {
-      userAddress: string
-      tokenAddress: string
-    },
+    { userAddress, tokenAddress }: WithdrawParams,
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })

--- a/src/api/deposit/DepositApiMock.ts
+++ b/src/api/deposit/DepositApiMock.ts
@@ -113,7 +113,7 @@ export class DepositApiMock implements DepositApi {
 
     // mock transfer tokens from user's mock `wallet`
     await this._erc20Api.transferFrom({
-      senderAddress: this.getContractAddress(),
+      userAddress: this.getContractAddress(),
       tokenAddress,
       fromAddress: userAddress,
       toAddress: this.getContractAddress(),
@@ -179,7 +179,7 @@ export class DepositApiMock implements DepositApi {
 
     // mock transfer tokens to user's mock `wallet`
     await this._erc20Api.transfer({
-      fromAddress: this.getContractAddress(),
+      userAddress: this.getContractAddress(),
       tokenAddress,
       toAddress: userAddress,
       amount,

--- a/src/api/erc20/Erc20Api.ts
+++ b/src/api/erc20/Erc20Api.ts
@@ -21,16 +21,20 @@ export interface AllowanceParams extends UserReadOnlyParams {
   spenderAddress: string
 }
 
-export interface ApproveParams extends AllowanceParams {
+interface WithTxOptionalParams {
+  txOptionalParams?: TxOptionalParams
+}
+
+export interface ApproveParams extends AllowanceParams, WithTxOptionalParams {
   amount: BN
 }
 
-export interface TransferParams extends UserReadOnlyParams {
+export interface TransferParams extends UserReadOnlyParams, WithTxOptionalParams {
   toAddress: string
   amount: BN
 }
 
-export interface TransferFromParams extends TransferParams {
+export interface TransferFromParams extends TransferParams, WithTxOptionalParams {
   fromAddress: string
 }
 
@@ -49,11 +53,11 @@ export interface Erc20Api {
 
   allowance(params: AllowanceParams): Promise<BN>
 
-  approve(params: ApproveParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
+  approve(params: ApproveParams): Promise<Receipt>
 
-  transfer(params: TransferParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
+  transfer(params: TransferParams): Promise<Receipt>
 
-  transferFrom(params: TransferFromParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
+  transferFrom(params: TransferFromParams): Promise<Receipt>
 }
 
 /**
@@ -120,10 +124,13 @@ export class Erc20ApiImpl implements Erc20Api {
     return toBN(result)
   }
 
-  public async approve(
-    { userAddress, tokenAddress, spenderAddress, amount }: ApproveParams,
-    txOptionalParams?: TxOptionalParams,
-  ): Promise<Receipt> {
+  public async approve({
+    userAddress,
+    tokenAddress,
+    spenderAddress,
+    amount,
+    txOptionalParams,
+  }: ApproveParams): Promise<Receipt> {
     const erc20 = this._getERC20AtAddress(tokenAddress)
 
     // TODO: Remove temporal fix for web3. See https://github.com/gnosis/dex-react/issues/231
@@ -138,10 +145,13 @@ export class Erc20ApiImpl implements Erc20Api {
     return tx
   }
 
-  public async transfer(
-    { userAddress, tokenAddress, toAddress, amount }: TransferParams,
-    txOptionalParams?: TxOptionalParams,
-  ): Promise<Receipt> {
+  public async transfer({
+    userAddress,
+    tokenAddress,
+    toAddress,
+    amount,
+    txOptionalParams,
+  }: TransferParams): Promise<Receipt> {
     const erc20 = this._getERC20AtAddress(tokenAddress)
 
     // TODO: Remove temporal fix for web3. See https://github.com/gnosis/dex-react/issues/231
@@ -156,10 +166,14 @@ export class Erc20ApiImpl implements Erc20Api {
     return tx
   }
 
-  public async transferFrom(
-    { userAddress, tokenAddress, fromAddress, toAddress, amount }: TransferFromParams,
-    txOptionalParams?: TxOptionalParams,
-  ): Promise<Receipt> {
+  public async transferFrom({
+    userAddress,
+    tokenAddress,
+    fromAddress,
+    toAddress,
+    amount,
+    txOptionalParams,
+  }: TransferFromParams): Promise<Receipt> {
     const erc20 = this._getERC20AtAddress(tokenAddress)
 
     const tx = erc20.methods.transferFrom(userAddress, toAddress, amount.toString()).send({

--- a/src/api/erc20/Erc20Api.ts
+++ b/src/api/erc20/Erc20Api.ts
@@ -9,15 +9,20 @@ import { toBN } from 'utils'
 
 import Web3 from 'web3'
 
-export interface ContractReadOnlyParams {
+interface BaseParams {
   tokenAddress: string
 }
 
-export interface UserReadOnlyParams extends ContractReadOnlyParams {
+export type NameParams = BaseParams
+export type SymbolParams = BaseParams
+export type DecimalsParams = BaseParams
+export type TotalSupplyParams = BaseParams
+
+export interface BalanceOfParams extends BaseParams {
   userAddress: string
 }
 
-export interface AllowanceParams extends UserReadOnlyParams {
+export interface AllowanceParams extends BalanceOfParams {
   spenderAddress: string
 }
 
@@ -29,7 +34,7 @@ export interface ApproveParams extends AllowanceParams, WithTxOptionalParams {
   amount: BN
 }
 
-export interface TransferParams extends UserReadOnlyParams, WithTxOptionalParams {
+export interface TransferParams extends BalanceOfParams, WithTxOptionalParams {
   toAddress: string
   amount: BN
 }
@@ -44,12 +49,12 @@ export interface TransferFromParams extends TransferParams {
  * See: https://theethereum.wiki/w/index.php/ERC20_Token_Standard
  */
 export interface Erc20Api {
-  name(params: ContractReadOnlyParams): Promise<string>
-  symbol(params: ContractReadOnlyParams): Promise<string>
-  decimals(params: ContractReadOnlyParams): Promise<number>
-  totalSupply(params: ContractReadOnlyParams): Promise<BN>
+  name(params: NameParams): Promise<string>
+  symbol(params: SymbolParams): Promise<string>
+  decimals(params: DecimalsParams): Promise<number>
+  totalSupply(params: TotalSupplyParams): Promise<BN>
 
-  balanceOf(params: UserReadOnlyParams): Promise<BN>
+  balanceOf(params: BalanceOfParams): Promise<BN>
 
   allowance(params: AllowanceParams): Promise<BN>
 
@@ -76,7 +81,7 @@ export class Erc20ApiImpl implements Erc20Api {
     ;(window as any).erc20 = this._contractPrototype
   }
 
-  public async balanceOf({ tokenAddress, userAddress }: UserReadOnlyParams): Promise<BN> {
+  public async balanceOf({ tokenAddress, userAddress }: BalanceOfParams): Promise<BN> {
     if (!userAddress || !tokenAddress) return ZERO
 
     const erc20 = this._getERC20AtAddress(tokenAddress)
@@ -86,19 +91,19 @@ export class Erc20ApiImpl implements Erc20Api {
     return toBN(result)
   }
 
-  public async name({ tokenAddress }: ContractReadOnlyParams): Promise<string> {
+  public async name({ tokenAddress }: NameParams): Promise<string> {
     const erc20 = this._getERC20AtAddress(tokenAddress)
 
     return await erc20.methods.name().call()
   }
 
-  public async symbol({ tokenAddress }: ContractReadOnlyParams): Promise<string> {
+  public async symbol({ tokenAddress }: SymbolParams): Promise<string> {
     const erc20 = this._getERC20AtAddress(tokenAddress)
 
     return await erc20.methods.symbol().call()
   }
 
-  public async decimals({ tokenAddress }: ContractReadOnlyParams): Promise<number> {
+  public async decimals({ tokenAddress }: DecimalsParams): Promise<number> {
     const erc20 = this._getERC20AtAddress(tokenAddress)
 
     const decimals = await erc20.methods.decimals().call()
@@ -106,7 +111,7 @@ export class Erc20ApiImpl implements Erc20Api {
     return Number(decimals)
   }
 
-  public async totalSupply({ tokenAddress }: ContractReadOnlyParams): Promise<BN> {
+  public async totalSupply({ tokenAddress }: TotalSupplyParams): Promise<BN> {
     const erc20 = this._getERC20AtAddress(tokenAddress)
 
     const totalSupply = await erc20.methods.totalSupply().call()

--- a/src/api/erc20/Erc20Api.ts
+++ b/src/api/erc20/Erc20Api.ts
@@ -34,7 +34,7 @@ export interface TransferParams extends UserReadOnlyParams, WithTxOptionalParams
   amount: BN
 }
 
-export interface TransferFromParams extends TransferParams, WithTxOptionalParams {
+export interface TransferFromParams extends TransferParams {
   fromAddress: string
 }
 

--- a/src/api/erc20/Erc20Api.ts
+++ b/src/api/erc20/Erc20Api.ts
@@ -43,23 +43,23 @@ export interface Erc20Api {
 
   transfer(
     {
-      fromAddress,
+      userAddress,
       tokenAddress,
       toAddress,
       amount,
-    }: { fromAddress: string; tokenAddress: string; toAddress: string; amount: BN },
+    }: { userAddress: string; tokenAddress: string; toAddress: string; amount: BN },
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt>
 
   transferFrom(
     {
-      senderAddress,
+      userAddress,
       tokenAddress,
       fromAddress,
       toAddress,
       amount,
     }: {
-      senderAddress: string
+      userAddress: string
       tokenAddress: string
       fromAddress: string
       toAddress: string
@@ -166,18 +166,18 @@ export class Erc20ApiImpl implements Erc20Api {
 
   public async transfer(
     {
-      fromAddress,
+      userAddress,
       tokenAddress,
       toAddress,
       amount,
-    }: { fromAddress: string; tokenAddress: string; toAddress: string; amount: BN },
+    }: { userAddress: string; tokenAddress: string; toAddress: string; amount: BN },
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt> {
     const erc20 = this._getERC20AtAddress(tokenAddress)
 
     // TODO: Remove temporal fix for web3. See https://github.com/gnosis/dex-react/issues/231
     const tx = erc20.methods.transfer(toAddress, amount.toString()).send({
-      from: fromAddress,
+      from: userAddress,
     })
 
     if (txOptionalParams?.onSentTransaction) {
@@ -189,17 +189,17 @@ export class Erc20ApiImpl implements Erc20Api {
 
   public async transferFrom(
     {
-      senderAddress,
+      userAddress,
       tokenAddress,
       fromAddress,
       toAddress,
       amount,
-    }: { senderAddress: string; tokenAddress: string; fromAddress: string; toAddress: string; amount: BN },
+    }: { userAddress: string; tokenAddress: string; fromAddress: string; toAddress: string; amount: BN },
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt> {
     const erc20 = this._getERC20AtAddress(tokenAddress)
 
-    const tx = erc20.methods.transferFrom(senderAddress, toAddress, amount.toString()).send({
+    const tx = erc20.methods.transferFrom(userAddress, toAddress, amount.toString()).send({
       from: fromAddress,
     })
 

--- a/src/api/erc20/Erc20ApiMock.ts
+++ b/src/api/erc20/Erc20ApiMock.ts
@@ -7,8 +7,11 @@ import { log, assert } from 'utils'
 import { waitAndSendReceipt } from 'utils/mock'
 import {
   Erc20Api,
-  UserReadOnlyParams,
-  ContractReadOnlyParams,
+  NameParams,
+  SymbolParams,
+  DecimalsParams,
+  TotalSupplyParams,
+  BalanceOfParams,
   AllowanceParams,
   ApproveParams,
   TransferParams,
@@ -49,7 +52,7 @@ export class Erc20ApiMock implements Erc20Api {
     this._tokens = tokens
   }
 
-  public async balanceOf({ tokenAddress, userAddress }: UserReadOnlyParams): Promise<BN> {
+  public async balanceOf({ tokenAddress, userAddress }: BalanceOfParams): Promise<BN> {
     const userBalances = this._balances[userAddress]
     if (!userBalances) {
       return ZERO
@@ -59,7 +62,7 @@ export class Erc20ApiMock implements Erc20Api {
     return balance ? balance : ZERO
   }
 
-  public async name({ tokenAddress }: ContractReadOnlyParams): Promise<string> {
+  public async name({ tokenAddress }: NameParams): Promise<string> {
     const erc20Info = this._initTokens(tokenAddress)
 
     // Throws when token without `name` to mock contract behavior
@@ -68,7 +71,7 @@ export class Erc20ApiMock implements Erc20Api {
     return erc20Info.name
   }
 
-  public async symbol({ tokenAddress }: ContractReadOnlyParams): Promise<string> {
+  public async symbol({ tokenAddress }: SymbolParams): Promise<string> {
     const erc20Info = this._initTokens(tokenAddress)
 
     // Throws when token without `symbol` to mock contract behavior
@@ -77,7 +80,7 @@ export class Erc20ApiMock implements Erc20Api {
     return erc20Info.symbol
   }
 
-  public async decimals({ tokenAddress }: ContractReadOnlyParams): Promise<number> {
+  public async decimals({ tokenAddress }: DecimalsParams): Promise<number> {
     const erc20Info = this._initTokens(tokenAddress)
 
     // Throws when token without `decimals` to mock contract behavior
@@ -86,7 +89,7 @@ export class Erc20ApiMock implements Erc20Api {
     return erc20Info.decimals
   }
 
-  public async totalSupply({ tokenAddress }: ContractReadOnlyParams): Promise<BN> {
+  public async totalSupply({ tokenAddress }: TotalSupplyParams): Promise<BN> {
     log("Don't care about %s, just making TS shut up", tokenAddress)
     return this._totalSupply
   }

--- a/src/api/erc20/Erc20ApiMock.ts
+++ b/src/api/erc20/Erc20ApiMock.ts
@@ -1,6 +1,6 @@
 import BN from 'bn.js'
 
-import { TxOptionalParams, Receipt } from 'types'
+import { Receipt } from 'types'
 import { ZERO, ALLOWANCE_MAX_VALUE } from 'const'
 import { RECEIPT } from '../../../test/data'
 import { log, assert } from 'utils'
@@ -106,10 +106,13 @@ export class Erc20ApiMock implements Erc20Api {
     return allowance ? allowance : ZERO
   }
 
-  public async approve(
-    { userAddress, tokenAddress, spenderAddress, amount }: ApproveParams,
-    txOptionalParams?: TxOptionalParams,
-  ): Promise<Receipt> {
+  public async approve({
+    userAddress,
+    tokenAddress,
+    spenderAddress,
+    amount,
+    txOptionalParams,
+  }: ApproveParams): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
 
     this._initAllowances({ userAddress, tokenAddress, spenderAddress })
@@ -130,10 +133,13 @@ export class Erc20ApiMock implements Erc20Api {
    * @param amount The amount transferred
    * @param txOptionalParams Optional params
    */
-  public async transfer(
-    { userAddress, tokenAddress, toAddress, amount }: TransferParams,
-    txOptionalParams?: TxOptionalParams,
-  ): Promise<Receipt> {
+  public async transfer({
+    userAddress,
+    tokenAddress,
+    toAddress,
+    amount,
+    txOptionalParams,
+  }: TransferParams): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
     this._initBalances({ userAddress, tokenAddress })
     this._initBalances({ userAddress: toAddress, tokenAddress })
@@ -161,10 +167,14 @@ export class Erc20ApiMock implements Erc20Api {
    * @param amount The amount transferred
    * @param txOptionalParams Optional params
    */
-  public async transferFrom(
-    { userAddress, tokenAddress, fromAddress, toAddress, amount }: TransferFromParams,
-    txOptionalParams?: TxOptionalParams,
-  ): Promise<Receipt> {
+  public async transferFrom({
+    userAddress,
+    tokenAddress,
+    fromAddress,
+    toAddress,
+    amount,
+    txOptionalParams,
+  }: TransferFromParams): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
     this._initBalances({ userAddress: fromAddress, tokenAddress })
     this._initBalances({ userAddress: toAddress, tokenAddress })

--- a/src/api/erc20/Erc20ApiMock.ts
+++ b/src/api/erc20/Erc20ApiMock.ts
@@ -5,7 +5,15 @@ import { ZERO, ALLOWANCE_MAX_VALUE } from 'const'
 import { RECEIPT } from '../../../test/data'
 import { log, assert } from 'utils'
 import { waitAndSendReceipt } from 'utils/mock'
-import { Erc20Api } from './Erc20Api'
+import {
+  Erc20Api,
+  UserReadOnlyParams,
+  ContractReadOnlyParams,
+  AllowanceParams,
+  ApproveParams,
+  TransferParams,
+  TransferFromParams,
+} from './Erc20Api'
 
 interface Balances {
   [userAddress: string]: { [tokenAddress: string]: BN }
@@ -41,7 +49,7 @@ export class Erc20ApiMock implements Erc20Api {
     this._tokens = tokens
   }
 
-  public async balanceOf({ tokenAddress, userAddress }: { tokenAddress: string; userAddress: string }): Promise<BN> {
+  public async balanceOf({ tokenAddress, userAddress }: UserReadOnlyParams): Promise<BN> {
     const userBalances = this._balances[userAddress]
     if (!userBalances) {
       return ZERO
@@ -51,7 +59,7 @@ export class Erc20ApiMock implements Erc20Api {
     return balance ? balance : ZERO
   }
 
-  public async name({ tokenAddress }: { tokenAddress: string }): Promise<string> {
+  public async name({ tokenAddress }: ContractReadOnlyParams): Promise<string> {
     const erc20Info = this._initTokens(tokenAddress)
 
     // Throws when token without `name` to mock contract behavior
@@ -60,7 +68,7 @@ export class Erc20ApiMock implements Erc20Api {
     return erc20Info.name
   }
 
-  public async symbol({ tokenAddress }: { tokenAddress: string }): Promise<string> {
+  public async symbol({ tokenAddress }: ContractReadOnlyParams): Promise<string> {
     const erc20Info = this._initTokens(tokenAddress)
 
     // Throws when token without `symbol` to mock contract behavior
@@ -69,7 +77,7 @@ export class Erc20ApiMock implements Erc20Api {
     return erc20Info.symbol
   }
 
-  public async decimals({ tokenAddress }: { tokenAddress: string }): Promise<number> {
+  public async decimals({ tokenAddress }: ContractReadOnlyParams): Promise<number> {
     const erc20Info = this._initTokens(tokenAddress)
 
     // Throws when token without `decimals` to mock contract behavior
@@ -78,20 +86,12 @@ export class Erc20ApiMock implements Erc20Api {
     return erc20Info.decimals
   }
 
-  public async totalSupply({ tokenAddress }: { tokenAddress: string }): Promise<BN> {
+  public async totalSupply({ tokenAddress }: ContractReadOnlyParams): Promise<BN> {
     log("Don't care about %s, just making TS shut up", tokenAddress)
     return this._totalSupply
   }
 
-  public async allowance({
-    tokenAddress,
-    userAddress,
-    spenderAddress,
-  }: {
-    tokenAddress: string
-    userAddress: string
-    spenderAddress: string
-  }): Promise<BN> {
+  public async allowance({ tokenAddress, userAddress, spenderAddress }: AllowanceParams): Promise<BN> {
     const userAllowances = this._allowances[userAddress]
     if (!userAllowances) {
       return ZERO
@@ -107,12 +107,7 @@ export class Erc20ApiMock implements Erc20Api {
   }
 
   public async approve(
-    {
-      userAddress,
-      tokenAddress,
-      spenderAddress,
-      amount,
-    }: { userAddress: string; tokenAddress: string; spenderAddress: string; amount: BN },
+    { userAddress, tokenAddress, spenderAddress, amount }: ApproveParams,
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
@@ -136,12 +131,7 @@ export class Erc20ApiMock implements Erc20Api {
    * @param txOptionalParams Optional params
    */
   public async transfer(
-    {
-      userAddress,
-      tokenAddress,
-      toAddress,
-      amount,
-    }: { userAddress: string; tokenAddress: string; toAddress: string; amount: BN },
+    { userAddress, tokenAddress, toAddress, amount }: TransferParams,
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
@@ -172,19 +162,7 @@ export class Erc20ApiMock implements Erc20Api {
    * @param txOptionalParams Optional params
    */
   public async transferFrom(
-    {
-      userAddress,
-      tokenAddress,
-      fromAddress,
-      toAddress,
-      amount,
-    }: {
-      userAddress: string
-      tokenAddress: string
-      fromAddress: string
-      toAddress: string
-      amount: BN
-    },
+    { userAddress, tokenAddress, fromAddress, toAddress, amount }: TransferFromParams,
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })

--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -14,7 +14,7 @@ export interface ExchangeApi extends DepositApi {
   addToken(tokenAddress: string, txOptionalParams?: TxOptionalParams): Promise<Receipt>
   placeOrder(orderParams: PlaceOrderParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
   cancelOrders(
-    { senderAddress, orderIds }: { senderAddress: string; orderIds: number[] },
+    { userAddress, orderIds }: { userAddress: string; orderIds: number[] },
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt>
 }
@@ -130,11 +130,11 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
   }
 
   public async cancelOrders(
-    { senderAddress, orderIds }: { senderAddress: string; orderIds: number[] },
+    { userAddress, orderIds }: { userAddress: string; orderIds: number[] },
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt> {
     const contract = await this._getContract()
-    const tx = contract.methods.cancelOrders(orderIds).send({ from: senderAddress })
+    const tx = contract.methods.cancelOrders(orderIds).send({ from: userAddress })
 
     if (txOptionalParams && txOptionalParams.onSentTransaction) {
       tx.once('transactionHash', txOptionalParams.onSentTransaction)

--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -17,12 +17,16 @@ export interface GetTokenIdByAddressParams {
   tokenAddress: string
 }
 
-export interface AddTokenParams {
+interface WithTxOptionalParams {
+  txOptionalParams?: TxOptionalParams
+}
+
+export interface AddTokenParams extends WithTxOptionalParams {
   userAddress: string
   tokenAddress: string
 }
 
-export interface PlaceOrderParams {
+export interface PlaceOrderParams extends WithTxOptionalParams {
   userAddress: string
   buyTokenId: number
   sellTokenId: number
@@ -31,7 +35,7 @@ export interface PlaceOrderParams {
   sellAmount: BN
 }
 
-export interface CancelOrdersParams {
+export interface CancelOrdersParams extends WithTxOptionalParams {
   userAddress: string
   orderIds: number[]
 }
@@ -45,9 +49,9 @@ export interface ExchangeApi extends DepositApi {
   getTokenAddressById(params: GetTokenAddressByIdParams): Promise<string> // tokenAddressToIdMap
   getTokenIdByAddress(params: GetTokenIdByAddressParams): Promise<number>
 
-  addToken(params: AddTokenParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
-  placeOrder(params: PlaceOrderParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
-  cancelOrders(params: CancelOrdersParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
+  addToken(params: AddTokenParams): Promise<Receipt>
+  placeOrder(params: PlaceOrderParams): Promise<Receipt>
+  cancelOrders(params: CancelOrdersParams): Promise<Receipt>
 }
 
 export interface AuctionElement extends Order {
@@ -115,10 +119,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     return +tokenId
   }
 
-  public async addToken(
-    { userAddress, tokenAddress }: AddTokenParams,
-    txOptionalParams?: TxOptionalParams,
-  ): Promise<Receipt> {
+  public async addToken({ userAddress, tokenAddress, txOptionalParams }: AddTokenParams): Promise<Receipt> {
     const contract = await this._getContract()
     const tx = contract.methods.addToken(tokenAddress).send({ from: userAddress })
 
@@ -131,8 +132,8 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     return tx
   }
 
-  public async placeOrder(params: PlaceOrderParams, txOptionalParams?: TxOptionalParams): Promise<Receipt> {
-    const { userAddress, buyTokenId, sellTokenId, validUntil, buyAmount, sellAmount } = params
+  public async placeOrder(params: PlaceOrderParams): Promise<Receipt> {
+    const { userAddress, buyTokenId, sellTokenId, validUntil, buyAmount, sellAmount, txOptionalParams } = params
 
     const contract = await this._getContract()
 
@@ -155,10 +156,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     return tx
   }
 
-  public async cancelOrders(
-    { userAddress, orderIds }: CancelOrdersParams,
-    txOptionalParams?: TxOptionalParams,
-  ): Promise<Receipt> {
+  public async cancelOrders({ userAddress, orderIds, txOptionalParams }: CancelOrdersParams): Promise<Receipt> {
     const contract = await this._getContract()
     const tx = contract.methods.cancelOrders(orderIds).send({ from: userAddress })
 

--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -5,6 +5,10 @@ import { log } from 'utils'
 import Web3 from 'web3'
 import { decodeAuctionElements } from './utils/decodeAuctionElements'
 
+export interface AddTokenParams {
+  tokenAddress: string
+}
+
 export interface PlaceOrderParams {
   userAddress: string
   buyTokenId: number
@@ -25,7 +29,7 @@ export interface ExchangeApi extends DepositApi {
   getFeeDenominator(): Promise<number>
   getTokenAddressById(tokenId: number): Promise<string> // tokenAddressToIdMap
   getTokenIdByAddress(tokenAddress: string): Promise<number>
-  addToken(tokenAddress: string, txOptionalParams?: TxOptionalParams): Promise<Receipt>
+  addToken(params: AddTokenParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
   placeOrder(orderParams: PlaceOrderParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
   cancelOrders(params: CancelOrdersParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
 }
@@ -95,7 +99,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     return +tokenId
   }
 
-  public async addToken(tokenAddress: string, txOptionalParams?: TxOptionalParams): Promise<Receipt> {
+  public async addToken({ tokenAddress }: AddTokenParams, txOptionalParams?: TxOptionalParams): Promise<Receipt> {
     const contract = await this._getContract()
     const tx = contract.methods.addToken(tokenAddress).send()
 

--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -6,6 +6,7 @@ import Web3 from 'web3'
 import { decodeAuctionElements } from './utils/decodeAuctionElements'
 
 export interface AddTokenParams {
+  userAddress: string
   tokenAddress: string
 }
 
@@ -99,9 +100,12 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     return +tokenId
   }
 
-  public async addToken({ tokenAddress }: AddTokenParams, txOptionalParams?: TxOptionalParams): Promise<Receipt> {
+  public async addToken(
+    { userAddress, tokenAddress }: AddTokenParams,
+    txOptionalParams?: TxOptionalParams,
+  ): Promise<Receipt> {
     const contract = await this._getContract()
-    const tx = contract.methods.addToken(tokenAddress).send()
+    const tx = contract.methods.addToken(tokenAddress).send({ from: userAddress })
 
     if (txOptionalParams && txOptionalParams.onSentTransaction) {
       tx.once('transactionHash', txOptionalParams.onSentTransaction)

--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -5,6 +5,20 @@ import { log } from 'utils'
 import Web3 from 'web3'
 import { decodeAuctionElements } from './utils/decodeAuctionElements'
 
+export interface PlaceOrderParams {
+  userAddress: string
+  buyTokenId: number
+  sellTokenId: number
+  validUntil: number
+  buyAmount: BN
+  sellAmount: BN
+}
+
+export interface CancelOrdersParams {
+  userAddress: string
+  orderIds: number[]
+}
+
 export interface ExchangeApi extends DepositApi {
   getOrders(userAddress: string): Promise<AuctionElement[]>
   getNumTokens(): Promise<number>
@@ -13,19 +27,7 @@ export interface ExchangeApi extends DepositApi {
   getTokenIdByAddress(tokenAddress: string): Promise<number>
   addToken(tokenAddress: string, txOptionalParams?: TxOptionalParams): Promise<Receipt>
   placeOrder(orderParams: PlaceOrderParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
-  cancelOrders(
-    { userAddress, orderIds }: { userAddress: string; orderIds: number[] },
-    txOptionalParams?: TxOptionalParams,
-  ): Promise<Receipt>
-}
-
-export interface PlaceOrderParams {
-  userAddress: string
-  buyTokenId: number
-  sellTokenId: number
-  validUntil: number
-  buyAmount: BN
-  sellAmount: BN
+  cancelOrders(params: CancelOrdersParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
 }
 
 export interface AuctionElement extends Order {
@@ -50,6 +52,7 @@ export interface Order {
 export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
   public constructor(web3: Web3) {
     super(web3)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(window as any).exchange = this._contractPrototype
   }
 
@@ -130,7 +133,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
   }
 
   public async cancelOrders(
-    { userAddress, orderIds }: { userAddress: string; orderIds: number[] },
+    { userAddress, orderIds }: CancelOrdersParams,
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt> {
     const contract = await this._getContract()

--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -5,6 +5,18 @@ import { log } from 'utils'
 import Web3 from 'web3'
 import { decodeAuctionElements } from './utils/decodeAuctionElements'
 
+export interface GetOrdersParams {
+  userAddress: string
+}
+
+export interface GetTokenAddressByIdParams {
+  tokenId: number
+}
+
+export interface GetTokenIdByAddressParams {
+  tokenAddress: string
+}
+
 export interface AddTokenParams {
   userAddress: string
   tokenAddress: string
@@ -25,13 +37,16 @@ export interface CancelOrdersParams {
 }
 
 export interface ExchangeApi extends DepositApi {
-  getOrders(userAddress: string): Promise<AuctionElement[]>
   getNumTokens(): Promise<number>
   getFeeDenominator(): Promise<number>
-  getTokenAddressById(tokenId: number): Promise<string> // tokenAddressToIdMap
-  getTokenIdByAddress(tokenAddress: string): Promise<number>
+
+  getOrders(params: GetOrdersParams): Promise<AuctionElement[]>
+
+  getTokenAddressById(params: GetTokenAddressByIdParams): Promise<string> // tokenAddressToIdMap
+  getTokenIdByAddress(params: GetTokenIdByAddressParams): Promise<number>
+
   addToken(params: AddTokenParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
-  placeOrder(orderParams: PlaceOrderParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
+  placeOrder(params: PlaceOrderParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
   cancelOrders(params: CancelOrdersParams, txOptionalParams?: TxOptionalParams): Promise<Receipt>
 }
 
@@ -61,7 +76,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     ;(window as any).exchange = this._contractPrototype
   }
 
-  public async getOrders(userAddress: string): Promise<AuctionElement[]> {
+  public async getOrders({ userAddress }: GetOrdersParams): Promise<AuctionElement[]> {
     const contract = await this._getContract()
     log(`[ExchangeApiImpl] Getting Orders for account ${userAddress}`)
 
@@ -89,12 +104,12 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     return +feeDenominator
   }
 
-  public async getTokenAddressById(tokenId: number): Promise<string> {
+  public async getTokenAddressById({ tokenId }: GetTokenAddressByIdParams): Promise<string> {
     const contract = await this._getContract()
     return contract.methods.tokenIdToAddressMap(tokenId).call()
   }
 
-  public async getTokenIdByAddress(tokenAddress: string): Promise<number> {
+  public async getTokenIdByAddress({ tokenAddress }: GetTokenIdByAddressParams): Promise<number> {
     const contract = await this._getContract()
     const tokenId = await contract.methods.tokenAddressToIdMap(tokenAddress).call()
     return +tokenId
@@ -116,8 +131,8 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     return tx
   }
 
-  public async placeOrder(orderParams: PlaceOrderParams, txOptionalParams?: TxOptionalParams): Promise<Receipt> {
-    const { userAddress, buyTokenId, sellTokenId, validUntil, buyAmount, sellAmount } = orderParams
+  public async placeOrder(params: PlaceOrderParams, txOptionalParams?: TxOptionalParams): Promise<Receipt> {
+    const { userAddress, buyTokenId, sellTokenId, validUntil, buyAmount, sellAmount } = params
 
     const contract = await this._getContract()
 

--- a/src/api/exchange/ExchangeApiMock.ts
+++ b/src/api/exchange/ExchangeApiMock.ts
@@ -7,7 +7,17 @@ import { Receipt, TxOptionalParams } from 'types'
 import { FEE_DENOMINATOR, ONE } from 'const'
 import { waitAndSendReceipt } from 'utils/mock'
 import { RECEIPT } from '../../../test/data'
-import { ExchangeApi, AuctionElement, PlaceOrderParams, Order, CancelOrdersParams, AddTokenParams } from './ExchangeApi'
+import {
+  ExchangeApi,
+  AuctionElement,
+  PlaceOrderParams,
+  Order,
+  CancelOrdersParams,
+  AddTokenParams,
+  GetOrdersParams,
+  GetTokenAddressByIdParams,
+  GetTokenIdByAddressParams,
+} from './ExchangeApi'
 import { Erc20Api } from 'api/erc20/Erc20Api'
 
 export interface OrdersByUser {
@@ -45,7 +55,7 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
     this.orders = ordersByUser
   }
 
-  public async getOrders(userAddress: string): Promise<AuctionElement[]> {
+  public async getOrders({ userAddress }: GetOrdersParams): Promise<AuctionElement[]> {
     this._initOrders(userAddress)
     return this.orders[userAddress].map((order, index) => ({
       ...order,
@@ -67,12 +77,12 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
     return FEE_DENOMINATOR
   }
 
-  public async getTokenAddressById(tokenId: number): Promise<string> {
+  public async getTokenAddressById({ tokenId }: GetTokenAddressByIdParams): Promise<string> {
     assert(typeof this.registeredTokens[tokenId] === 'string', 'Must have ID to get Address')
     return this.registeredTokens[tokenId]
   }
 
-  public async getTokenIdByAddress(tokenAddress: string): Promise<number> {
+  public async getTokenIdByAddress({ tokenAddress }: GetTokenIdByAddressParams): Promise<number> {
     assert(typeof this.tokenAddressToId[tokenAddress] === 'number', 'Must have Address to get ID')
     return this.tokenAddressToId[tokenAddress]
   }

--- a/src/api/exchange/ExchangeApiMock.ts
+++ b/src/api/exchange/ExchangeApiMock.ts
@@ -3,7 +3,7 @@ import BN from 'bn.js'
 import assert from 'assert'
 
 import { DepositApiMock, BalancesByUserAndToken } from '../deposit/DepositApiMock'
-import { Receipt, TxOptionalParams } from 'types'
+import { Receipt } from 'types'
 import { FEE_DENOMINATOR, ONE } from 'const'
 import { waitAndSendReceipt } from 'utils/mock'
 import { RECEIPT } from '../../../test/data'
@@ -87,7 +87,7 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
     return this.tokenAddressToId[tokenAddress]
   }
 
-  public async addToken({ tokenAddress }: AddTokenParams, txOptionalParams?: TxOptionalParams): Promise<Receipt> {
+  public async addToken({ tokenAddress, txOptionalParams }: AddTokenParams): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
 
     assert(typeof this.tokenAddressToId[tokenAddress] !== 'number', 'Token already registered')
@@ -98,28 +98,26 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
     return RECEIPT
   }
 
-  public async placeOrder(orderParams: PlaceOrderParams, txOptionalParams?: TxOptionalParams): Promise<Receipt> {
+  public async placeOrder(params: PlaceOrderParams): Promise<Receipt> {
+    const { buyTokenId, sellTokenId, validUntil, txOptionalParams } = params
     await waitAndSendReceipt({ txOptionalParams })
 
-    this._initOrders(orderParams.userAddress)
+    this._initOrders(params.userAddress)
 
-    this.orders[orderParams.userAddress].push({
-      buyTokenId: orderParams.buyTokenId,
-      sellTokenId: orderParams.sellTokenId,
+    this.orders[params.userAddress].push({
+      buyTokenId,
+      sellTokenId,
       validFrom: await this.getCurrentBatchId(),
-      validUntil: orderParams.validUntil,
-      priceNumerator: orderParams.buyAmount,
-      priceDenominator: orderParams.sellAmount,
-      remainingAmount: orderParams.sellAmount,
+      validUntil,
+      priceNumerator: params.buyAmount,
+      priceDenominator: params.sellAmount,
+      remainingAmount: params.sellAmount,
     })
 
     return RECEIPT
   }
 
-  public async cancelOrders(
-    { userAddress, orderIds }: CancelOrdersParams,
-    txOptionalParams?: TxOptionalParams,
-  ): Promise<Receipt> {
+  public async cancelOrders({ userAddress, orderIds, txOptionalParams }: CancelOrdersParams): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
 
     this._initOrders(userAddress)

--- a/src/api/exchange/ExchangeApiMock.ts
+++ b/src/api/exchange/ExchangeApiMock.ts
@@ -108,22 +108,22 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
 
   public async cancelOrders(
     {
-      senderAddress,
+      userAddress,
       orderIds,
     }: {
-      senderAddress: string
+      userAddress: string
       orderIds: number[]
     },
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
 
-    this._initOrders(senderAddress)
+    this._initOrders(userAddress)
     const batchId = await this.getCurrentBatchId()
 
     orderIds.forEach(orderId => {
-      if (this.orders[senderAddress][orderId]) {
-        this.orders[senderAddress][orderId].validUntil = batchId - 1
+      if (this.orders[userAddress][orderId]) {
+        this.orders[userAddress][orderId].validUntil = batchId - 1
       }
     })
 

--- a/src/api/exchange/ExchangeApiMock.ts
+++ b/src/api/exchange/ExchangeApiMock.ts
@@ -7,7 +7,7 @@ import { Receipt, TxOptionalParams } from 'types'
 import { FEE_DENOMINATOR, ONE } from 'const'
 import { waitAndSendReceipt } from 'utils/mock'
 import { RECEIPT } from '../../../test/data'
-import { ExchangeApi, AuctionElement, PlaceOrderParams, Order } from './ExchangeApi'
+import { ExchangeApi, AuctionElement, PlaceOrderParams, Order, CancelOrdersParams } from './ExchangeApi'
 import { Erc20Api } from 'api/erc20/Erc20Api'
 
 export interface OrdersByUser {
@@ -107,13 +107,7 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
   }
 
   public async cancelOrders(
-    {
-      userAddress,
-      orderIds,
-    }: {
-      userAddress: string
-      orderIds: number[]
-    },
+    { userAddress, orderIds }: CancelOrdersParams,
     txOptionalParams?: TxOptionalParams,
   ): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })

--- a/src/api/exchange/ExchangeApiMock.ts
+++ b/src/api/exchange/ExchangeApiMock.ts
@@ -7,7 +7,7 @@ import { Receipt, TxOptionalParams } from 'types'
 import { FEE_DENOMINATOR, ONE } from 'const'
 import { waitAndSendReceipt } from 'utils/mock'
 import { RECEIPT } from '../../../test/data'
-import { ExchangeApi, AuctionElement, PlaceOrderParams, Order, CancelOrdersParams } from './ExchangeApi'
+import { ExchangeApi, AuctionElement, PlaceOrderParams, Order, CancelOrdersParams, AddTokenParams } from './ExchangeApi'
 import { Erc20Api } from 'api/erc20/Erc20Api'
 
 export interface OrdersByUser {
@@ -77,7 +77,7 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
     return this.tokenAddressToId[tokenAddress]
   }
 
-  public async addToken(tokenAddress: string, txOptionalParams?: TxOptionalParams): Promise<Receipt> {
+  public async addToken({ tokenAddress }: AddTokenParams, txOptionalParams?: TxOptionalParams): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
 
     assert(typeof this.tokenAddressToId[tokenAddress] !== 'number', 'Token already registered')

--- a/src/components/DepositWidget/useRowActions.tsx
+++ b/src/components/DepositWidget/useRowActions.tsx
@@ -45,10 +45,13 @@ export const useRowActions = (params: Params): Result => {
 
       const { symbol: tokenDisplayName } = safeFilledToken(token)
 
-      const receipt = await erc20Api.approve(
-        { userAddress, tokenAddress, spenderAddress: contractAddress, amount: ALLOWANCE_MAX_VALUE },
+      const receipt = await erc20Api.approve({
+        userAddress,
+        tokenAddress,
+        spenderAddress: contractAddress,
+        amount: ALLOWANCE_MAX_VALUE,
         txOptionalParams,
-      )
+      })
       log(`The transaction has been mined: ${receipt.transactionHash}`)
 
       toast.success(`The token ${tokenDisplayName} has been enabled for trading`)

--- a/src/components/DepositWidget/useRowActions.tsx
+++ b/src/components/DepositWidget/useRowActions.tsx
@@ -75,7 +75,7 @@ export const useRowActions = (params: Params): Result => {
       const { symbol, decimals } = safeFilledToken<TokenBalanceDetails>(token)
 
       log(`Processing deposit of ${amount} ${symbol} from ${userAddress}`)
-      const receipt = await depositApi.deposit({ userAddress, tokenAddress, amount }, txOptionalParams)
+      const receipt = await depositApi.deposit({ userAddress, tokenAddress, amount, txOptionalParams })
       log(`The transaction has been mined: ${receipt.transactionHash}`)
 
       toast.success(`Successfully deposited ${formatAmount(amount, decimals)} ${symbol}`)
@@ -101,7 +101,7 @@ export const useRowActions = (params: Params): Result => {
       log(`Processing withdraw request of ${amount} ${symbol} from ${userAddress}`)
 
       log(`Processing withdraw request of ${amount} ${symbol} from ${userAddress}`)
-      const receipt = await depositApi.requestWithdraw({ userAddress, tokenAddress, amount }, txOptionalParams)
+      const receipt = await depositApi.requestWithdraw({ userAddress, tokenAddress, amount, txOptionalParams })
       log(`The transaction has been mined: ${receipt.transactionHash}`)
 
       toast.success(`Successfully requested withdraw of ${formatAmount(amount, decimals)} ${symbol}`)
@@ -126,7 +126,7 @@ export const useRowActions = (params: Params): Result => {
 
       dispatch(setHighlightAndClaimingAction(tokenAddress))
 
-      const receipt = await depositApi.withdraw({ userAddress, tokenAddress }, txOptionalParams)
+      const receipt = await depositApi.withdraw({ userAddress, tokenAddress, txOptionalParams })
 
       log(`The transaction has been mined: ${receipt.transactionHash}`)
       toast.success(`Withdraw of ${formatAmount(pendingWithdraw.amount, decimals)} ${symbol} completed`)

--- a/src/components/OrdersWidget/useDeleteOrders.tsx
+++ b/src/components/OrdersWidget/useDeleteOrders.tsx
@@ -36,7 +36,7 @@ export function useDeleteOrders(): Result {
 
         const orderIds = extractExchangeOrderIds(uiOrderIds)
 
-        const receipt = await exchangeApi.cancelOrders({ userAddress, orderIds }, txOptionalParams)
+        const receipt = await exchangeApi.cancelOrders({ userAddress, orderIds, txOptionalParams })
 
         log(`The transaction has been mined: ${receipt.transactionHash}`)
 

--- a/src/components/OrdersWidget/useDeleteOrders.tsx
+++ b/src/components/OrdersWidget/useDeleteOrders.tsx
@@ -36,7 +36,7 @@ export function useDeleteOrders(): Result {
 
         const orderIds = extractExchangeOrderIds(uiOrderIds)
 
-        const receipt = await exchangeApi.cancelOrders({ senderAddress: userAddress, orderIds }, txOptionalParams)
+        const receipt = await exchangeApi.cancelOrders({ userAddress, orderIds }, txOptionalParams)
 
         log(`The transaction has been mined: ${receipt.transactionHash}`)
 

--- a/src/hooks/useEnableToken.ts
+++ b/src/hooks/useEnableToken.ts
@@ -23,6 +23,7 @@ export const useEnableTokens = (params: Params): Result => {
   const { enabled: enabledInitial, address: tokenAddress } = params.tokenBalances
   const [enabled, setEnabled] = useSafeState(enabledInitial)
   const [enabling, setEnabling] = useSafeState(false)
+  const { txOptionalParams } = params
 
   async function enableToken(): Promise<Receipt> {
     assert(!enabled && isConnected, 'The token was already enabled and/or user is not connected')
@@ -34,15 +35,13 @@ export const useEnableTokens = (params: Params): Result => {
     const contractAddress = networkId ? depositApi.getContractAddress(networkId) : null
     assert(contractAddress, 'Contract address not found. Please check wallet.')
 
-    const receipt = await erc20Api.approve(
-      {
-        userAddress,
-        tokenAddress,
-        spenderAddress: contractAddress,
-        amount: ALLOWANCE_MAX_VALUE,
-      },
-      params.txOptionalParams,
-    )
+    const receipt = await erc20Api.approve({
+      userAddress,
+      tokenAddress,
+      spenderAddress: contractAddress,
+      amount: ALLOWANCE_MAX_VALUE,
+      txOptionalParams,
+    })
 
     // Update the state
     setEnabled(true)

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -34,7 +34,7 @@ export function useOrders(): AuctionElement[] {
   useEffect(() => {
     userAddress &&
       exchangeApi
-        .getOrders(userAddress)
+        .getOrders({ userAddress })
         .then(filterDeletedOrders)
         .then(setOrders)
   }, [setOrders, userAddress])

--- a/src/hooks/usePlaceOrder.ts
+++ b/src/hooks/usePlaceOrder.ts
@@ -43,8 +43,8 @@ export const usePlaceOrder = (): Result => {
 
       try {
         const [sellTokenId, buyTokenId, batchId] = await Promise.all([
-          exchangeApi.getTokenIdByAddress(sellToken.address),
-          exchangeApi.getTokenIdByAddress(buyToken.address),
+          exchangeApi.getTokenIdByAddress({ tokenAddress: sellToken.address }),
+          exchangeApi.getTokenIdByAddress({ tokenAddress: buyToken.address }),
           exchangeApi.getCurrentBatchId(),
         ])
 

--- a/src/hooks/usePlaceOrder.ts
+++ b/src/hooks/usePlaceOrder.ts
@@ -60,8 +60,9 @@ export const usePlaceOrder = (): Result => {
             validUntil,
             buyAmount,
             sellAmount,
+            txOptionalParams,
           }
-          const receipt = await exchangeApi.placeOrder(params, txOptionalParams)
+          const receipt = await exchangeApi.placeOrder(params)
           log(`The transaction has been mined: ${receipt.transactionHash}`)
 
           // TODO: get order id in a separate call

--- a/src/hooks/useWithdrawTokens.ts
+++ b/src/hooks/useWithdrawTokens.ts
@@ -18,6 +18,7 @@ export const useWithdrawTokens = (params: Params): Result => {
   const { userAddress, isConnected } = useWalletConnection()
   const {
     tokenBalances: { enabled, address: tokenAddress, claimable },
+    txOptionalParams,
   } = params
   const [claiming, setWithdrawing] = useSafeState(false)
 
@@ -30,7 +31,7 @@ export const useWithdrawTokens = (params: Params): Result => {
 
       setWithdrawing(true)
 
-      return depositApi.withdraw({ userAddress, tokenAddress }, params.txOptionalParams)
+      return depositApi.withdraw({ userAddress, tokenAddress, txOptionalParams })
     } finally {
       setWithdrawing(false)
     }

--- a/src/services/factories/addTokenToExchange.ts
+++ b/src/services/factories/addTokenToExchange.ts
@@ -12,15 +12,22 @@ interface Params {
   web3: Web3
 }
 
+interface AddTokenToExchangeParams {
+  userAddress: string
+  tokenAddress: string
+}
+
 /**
  * Factory of addTokenToExchange
  * Takes as input API instances
  * Returns async function to add tokenAddress to exchange
  */
-export function addTokenToExchangeFactory(factoryParams: Params): (tokenAddress: string) => Promise<boolean> {
+export function addTokenToExchangeFactory(
+  factoryParams: Params,
+): (params: AddTokenToExchangeParams) => Promise<boolean> {
   const { exchangeApi } = factoryParams
 
-  return async (tokenAddress: string): Promise<boolean> => {
+  return async ({ userAddress, tokenAddress }: AddTokenToExchangeParams): Promise<boolean> => {
     const erc20Info = getErc20Info({ ...factoryParams, tokenAddress })
 
     if (!erc20Info) {
@@ -29,7 +36,7 @@ export function addTokenToExchangeFactory(factoryParams: Params): (tokenAddress:
     }
 
     try {
-      await exchangeApi.addToken({ tokenAddress })
+      await exchangeApi.addToken({ userAddress, tokenAddress })
     } catch (e) {
       log('Failed to add token (%s) to exchange', tokenAddress)
       return false

--- a/src/services/factories/addTokenToExchange.ts
+++ b/src/services/factories/addTokenToExchange.ts
@@ -45,7 +45,7 @@ export function addTokenToExchangeFactory(
     // TODO: I guess we might want to return the token and leave the proxy/cache layer to deal with it.
     // Revisit once we add it to the interface
     try {
-      const id = exchangeApi.getTokenIdByAddress(tokenAddress)
+      const id = exchangeApi.getTokenIdByAddress({ tokenAddress })
 
       const token = {
         ...erc20Info,

--- a/src/services/factories/addTokenToExchange.ts
+++ b/src/services/factories/addTokenToExchange.ts
@@ -29,7 +29,7 @@ export function addTokenToExchangeFactory(factoryParams: Params): (tokenAddress:
     }
 
     try {
-      await exchangeApi.addToken(tokenAddress)
+      await exchangeApi.addToken({ tokenAddress })
     } catch (e) {
       log('Failed to add token (%s) to exchange', tokenAddress)
       return false

--- a/src/services/factories/getTokenFromExchange.ts
+++ b/src/services/factories/getTokenFromExchange.ts
@@ -69,7 +69,7 @@ function getTokenFromExchangeByAddressFactory(
 
     let tokenId: number
     try {
-      tokenId = await exchangeApi.getTokenIdByAddress(tokenAddress)
+      tokenId = await exchangeApi.getTokenIdByAddress({ tokenAddress })
     } catch (e) {
       log('Token with address %s not registered on contract', tokenAddress, e)
       return null
@@ -113,7 +113,7 @@ function getTokenFromExchangeByIdFactory(
     // Not there, get the address from the contract
     let tokenAddress: string
     try {
-      tokenAddress = await exchangeApi.getTokenAddressById(tokenId)
+      tokenAddress = await exchangeApi.getTokenAddressById({ tokenId })
     } catch (e) {
       log('Token with id %d not registered on contract', tokenId, e)
       return null

--- a/test/api/ExchangeApi/Erc20ApiMock.test.ts
+++ b/test/api/ExchangeApi/Erc20ApiMock.test.ts
@@ -152,7 +152,7 @@ describe('Write functions', () => {
       const userBalance = await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_2 })
 
       const result = await instance.transfer({
-        fromAddress: CONTRACT,
+        userAddress: CONTRACT,
         tokenAddress: TOKEN_1,
         toAddress: USER_2,
         amount,
@@ -168,7 +168,7 @@ describe('Write functions', () => {
     it('does not transfer when balance is insufficient', async () => {
       // TODO: after hours, couldn't figure out a way to check for the AssertionError using expect().toThrow()
       await instance
-        .transfer({ fromAddress: USER_2, tokenAddress: TOKEN_1, toAddress: CONTRACT, amount })
+        .transfer({ userAddress: USER_2, tokenAddress: TOKEN_1, toAddress: CONTRACT, amount })
         .then(() => fail('Should not succeed'))
         .catch(e => {
           expect(e.message).toMatch(/^The user doesn't have enough balance$/)
@@ -177,7 +177,7 @@ describe('Write functions', () => {
 
     it('calls optional callback', async () => {
       await instance.transfer(
-        { fromAddress: CONTRACT, tokenAddress: TOKEN_1, toAddress: USER_2, amount },
+        { userAddress: CONTRACT, tokenAddress: TOKEN_1, toAddress: USER_2, amount },
         optionalParams,
       )
       expect(mockFunction.mock.calls.length).toBe(1)
@@ -197,7 +197,7 @@ describe('Write functions', () => {
       await instance.approve({ userAddress: USER_1, tokenAddress: TOKEN_1, spenderAddress: USER_3, amount })
 
       const result = await instance.transferFrom({
-        senderAddress: USER_3,
+        userAddress: USER_3,
         tokenAddress: TOKEN_1,
         fromAddress: USER_1,
         toAddress: USER_2,
@@ -216,7 +216,7 @@ describe('Write functions', () => {
       await instance.approve({ userAddress: USER_2, tokenAddress: TOKEN_3, spenderAddress: USER_3, amount })
 
       await instance
-        .transferFrom({ senderAddress: USER_3, tokenAddress: TOKEN_3, fromAddress: USER_2, toAddress: USER_1, amount })
+        .transferFrom({ userAddress: USER_3, tokenAddress: TOKEN_3, fromAddress: USER_2, toAddress: USER_1, amount })
         .then(() => {
           fail('Should not succeed')
         })
@@ -227,7 +227,7 @@ describe('Write functions', () => {
 
     it('does not transfer when allowance is insufficient', async () => {
       await instance
-        .transferFrom({ senderAddress: USER_3, tokenAddress: TOKEN_3, fromAddress: USER_1, toAddress: USER_2, amount })
+        .transferFrom({ userAddress: USER_3, tokenAddress: TOKEN_3, fromAddress: USER_1, toAddress: USER_2, amount })
         .then(() => {
           fail('Should not succeed')
         })
@@ -239,7 +239,7 @@ describe('Write functions', () => {
     it('calls optional callback', async () => {
       await instance.approve({ userAddress: USER_1, tokenAddress: TOKEN_1, spenderAddress: USER_3, amount })
       await instance.transferFrom(
-        { senderAddress: USER_3, tokenAddress: TOKEN_1, fromAddress: USER_1, toAddress: USER_2, amount },
+        { userAddress: USER_3, tokenAddress: TOKEN_1, fromAddress: USER_1, toAddress: USER_2, amount },
         optionalParams,
       )
       expect(mockFunction.mock.calls.length).toBe(1)

--- a/test/api/ExchangeApi/Erc20ApiMock.test.ts
+++ b/test/api/ExchangeApi/Erc20ApiMock.test.ts
@@ -112,7 +112,7 @@ describe('Basic view functions', () => {
 
 describe('Write functions', () => {
   const mockFunction = jest.fn()
-  const optionalParams: TxOptionalParams = {
+  const txOptionalParams: TxOptionalParams = {
     onSentTransaction: mockFunction,
   }
   function resetInstance(): void {
@@ -125,10 +125,13 @@ describe('Write functions', () => {
   describe('approve', () => {
     const amount = new BN('5289375492345723')
     it('allowance is set', async () => {
-      const result = await instance.approve(
-        { userAddress: USER_1, tokenAddress: TOKEN_1, spenderAddress: USER_2, amount },
-        optionalParams,
-      )
+      const result = await instance.approve({
+        userAddress: USER_1,
+        tokenAddress: TOKEN_1,
+        spenderAddress: USER_2,
+        amount,
+        txOptionalParams,
+      })
 
       expect(await instance.allowance({ tokenAddress: TOKEN_1, userAddress: USER_1, spenderAddress: USER_2 })).toBe(
         amount,
@@ -137,10 +140,13 @@ describe('Write functions', () => {
     })
 
     it('calls optional callback', async () => {
-      await instance.approve(
-        { userAddress: USER_1, tokenAddress: TOKEN_1, spenderAddress: USER_2, amount },
-        optionalParams,
-      )
+      await instance.approve({
+        userAddress: USER_1,
+        tokenAddress: TOKEN_1,
+        spenderAddress: USER_2,
+        amount,
+        txOptionalParams,
+      })
       expect(mockFunction.mock.calls.length).toBe(1)
     })
   })
@@ -176,10 +182,13 @@ describe('Write functions', () => {
     })
 
     it('calls optional callback', async () => {
-      await instance.transfer(
-        { userAddress: CONTRACT, tokenAddress: TOKEN_1, toAddress: USER_2, amount },
-        optionalParams,
-      )
+      await instance.transfer({
+        userAddress: CONTRACT,
+        tokenAddress: TOKEN_1,
+        toAddress: USER_2,
+        amount,
+        txOptionalParams,
+      })
       expect(mockFunction.mock.calls.length).toBe(1)
     })
   })
@@ -238,10 +247,14 @@ describe('Write functions', () => {
 
     it('calls optional callback', async () => {
       await instance.approve({ userAddress: USER_1, tokenAddress: TOKEN_1, spenderAddress: USER_3, amount })
-      await instance.transferFrom(
-        { userAddress: USER_3, tokenAddress: TOKEN_1, fromAddress: USER_1, toAddress: USER_2, amount },
-        optionalParams,
-      )
+      await instance.transferFrom({
+        userAddress: USER_3,
+        tokenAddress: TOKEN_1,
+        fromAddress: USER_1,
+        toAddress: USER_2,
+        amount,
+        txOptionalParams,
+      })
       expect(mockFunction.mock.calls.length).toBe(1)
     })
   })

--- a/test/api/ExchangeApi/ExchangeApiMock.test.ts
+++ b/test/api/ExchangeApi/ExchangeApiMock.test.ts
@@ -99,7 +99,7 @@ describe('addToken', () => {
   it('adds token not registered', async () => {
     const tokenCount = await instance.getNumTokens()
 
-    await instance.addToken({ tokenAddress: TOKEN_3 })
+    await instance.addToken({ userAddress: USER_1, tokenAddress: TOKEN_3 })
 
     expect(await instance.getNumTokens()).toBe(tokenCount + 1)
     expect(await instance.getTokenIdByAddress(TOKEN_3)).toBe(tokenCount)
@@ -108,7 +108,7 @@ describe('addToken', () => {
 
   it('throws when token already registered', async () => {
     try {
-      await instance.addToken({ tokenAddress: tokens[0] })
+      await instance.addToken({ userAddress: USER_1, tokenAddress: tokens[0] })
       fail('Should not reach')
     } catch (e) {
       expect(e.message).toMatch(/^Token already registered$/)
@@ -116,7 +116,7 @@ describe('addToken', () => {
   })
   it('throws when MAX_TOKENS reached', async () => {
     try {
-      await instance.addToken({ tokenAddress: TOKEN_4 })
+      await instance.addToken({ userAddress: USER_1, tokenAddress: TOKEN_4 })
       fail('Should not reach')
     } catch (e) {
       expect(e.message).toMatch(/^Max tokens reached$/)

--- a/test/api/ExchangeApi/ExchangeApiMock.test.ts
+++ b/test/api/ExchangeApi/ExchangeApiMock.test.ts
@@ -99,7 +99,7 @@ describe('addToken', () => {
   it('adds token not registered', async () => {
     const tokenCount = await instance.getNumTokens()
 
-    await instance.addToken(TOKEN_3)
+    await instance.addToken({ tokenAddress: TOKEN_3 })
 
     expect(await instance.getNumTokens()).toBe(tokenCount + 1)
     expect(await instance.getTokenIdByAddress(TOKEN_3)).toBe(tokenCount)
@@ -108,7 +108,7 @@ describe('addToken', () => {
 
   it('throws when token already registered', async () => {
     try {
-      await instance.addToken(tokens[0])
+      await instance.addToken({ tokenAddress: tokens[0] })
       fail('Should not reach')
     } catch (e) {
       expect(e.message).toMatch(/^Token already registered$/)
@@ -116,7 +116,7 @@ describe('addToken', () => {
   })
   it('throws when MAX_TOKENS reached', async () => {
     try {
-      await instance.addToken(TOKEN_4)
+      await instance.addToken({ tokenAddress: TOKEN_4 })
       fail('Should not reach')
     } catch (e) {
       expect(e.message).toMatch(/^Max tokens reached$/)

--- a/test/api/ExchangeApi/ExchangeApiMock.test.ts
+++ b/test/api/ExchangeApi/ExchangeApiMock.test.ts
@@ -54,11 +54,11 @@ describe('Basic view functions', () => {
 
   describe('get orders', () => {
     it('returns empty when no orders placed by user', async () => {
-      expect(await instance.getOrders(USER_2)).toHaveLength(0)
+      expect(await instance.getOrders({ userAddress: USER_2 })).toHaveLength(0)
     })
 
     it('returns all placed orders', async () => {
-      expect(await instance.getOrders(USER_1)).toHaveLength(1)
+      expect(await instance.getOrders({ userAddress: USER_1 })).toHaveLength(1)
     })
   })
 })
@@ -66,12 +66,12 @@ describe('Basic view functions', () => {
 describe('Token view methods', () => {
   describe('get token id by address', () => {
     it('returns correct id when found', async () => {
-      expect(await instance.getTokenIdByAddress(tokens[1])).toBe(1)
+      expect(await instance.getTokenIdByAddress({ tokenAddress: tokens[1] })).toBe(1)
     })
 
     it('throws when id not found', async () => {
       try {
-        await instance.getTokenIdByAddress(TOKEN_4)
+        await instance.getTokenIdByAddress({ tokenAddress: TOKEN_4 })
         fail('Should not reach')
       } catch (e) {
         expect(e.message).toMatch(/^Must have Address to get ID$/)
@@ -81,12 +81,12 @@ describe('Token view methods', () => {
 
   describe('get token address by id', () => {
     it('returns correct address when found', async () => {
-      expect(await instance.getTokenAddressById(0)).toBe(tokens[0])
+      expect(await instance.getTokenAddressById({ tokenId: 0 })).toBe(tokens[0])
     })
 
     it('throws when address not found', async () => {
       try {
-        await instance.getTokenAddressById(10)
+        await instance.getTokenAddressById({ tokenId: 10 })
         fail('Should not reach')
       } catch (e) {
         expect(e.message).toMatch(/^Must have ID to get Address$/)
@@ -102,8 +102,8 @@ describe('addToken', () => {
     await instance.addToken({ userAddress: USER_1, tokenAddress: TOKEN_3 })
 
     expect(await instance.getNumTokens()).toBe(tokenCount + 1)
-    expect(await instance.getTokenIdByAddress(TOKEN_3)).toBe(tokenCount)
-    expect(await instance.getTokenAddressById(tokenCount)).toBe(TOKEN_3)
+    expect(await instance.getTokenIdByAddress({ tokenAddress: TOKEN_3 })).toBe(tokenCount)
+    expect(await instance.getTokenAddressById({ tokenId: tokenCount })).toBe(TOKEN_3)
   })
 
   it('throws when token already registered', async () => {
@@ -149,45 +149,45 @@ describe('placeOrder', () => {
     params.userAddress = USER_1
     const response = await instance.placeOrder(params)
     expect(response).toBe(RECEIPT)
-    const actual = (await instance.getOrders(USER_1)).pop()
+    const actual = (await instance.getOrders({ userAddress: USER_1 })).pop()
     expect(actual).toEqual({ ...expected, user: USER_1, id: '1' })
   })
 
   test('place first order', async () => {
-    expect((await instance.getOrders(USER_3)).length).toBe(0)
+    expect((await instance.getOrders({ userAddress: USER_3 })).length).toBe(0)
     params.userAddress = USER_2
 
     const response = await instance.placeOrder(params)
     expect(response).toBe(RECEIPT)
-    const actual = (await instance.getOrders(USER_2)).pop()
+    const actual = (await instance.getOrders({ userAddress: USER_2 })).pop()
     expect(actual).toEqual({ ...expected, user: USER_2, id: '0' })
   })
 })
 describe('cancelOrder', () => {
   test('cancel existing order', async () => {
-    const orderId = (await instance.getOrders(USER_1)).length - 1
+    const orderId = (await instance.getOrders({ userAddress: USER_1 })).length - 1
 
     await instance.cancelOrders({ userAddress: USER_1, orderIds: [orderId] })
 
-    const actual = (await instance.getOrders(USER_1))[orderId]
+    const actual = (await instance.getOrders({ userAddress: USER_1 }))[orderId]
     expect(actual.validUntil).toBe(BATCH_ID - 1)
   })
 
   test('cancel non existing order does nothing', async () => {
-    const expected = await instance.getOrders(USER_1)
+    const expected = await instance.getOrders({ userAddress: USER_1 })
 
     await instance.cancelOrders({ userAddress: USER_1, orderIds: [expected.length + 1] })
 
-    const actual = await instance.getOrders(USER_1)
+    const actual = await instance.getOrders({ userAddress: USER_1 })
     expect(actual).toEqual(expected)
   })
 
   test('cancel non existing order, user with no orders does nothing', async () => {
-    const expected = await instance.getOrders(USER_2)
+    const expected = await instance.getOrders({ userAddress: USER_2 })
 
     await instance.cancelOrders({ userAddress: USER_2, orderIds: [expected.length + 1] })
 
-    const actual = await instance.getOrders(USER_2)
+    const actual = await instance.getOrders({ userAddress: USER_2 })
     expect(actual).toEqual(expected)
   })
 })

--- a/test/api/ExchangeApi/ExchangeApiMock.test.ts
+++ b/test/api/ExchangeApi/ExchangeApiMock.test.ts
@@ -167,7 +167,7 @@ describe('cancelOrder', () => {
   test('cancel existing order', async () => {
     const orderId = (await instance.getOrders(USER_1)).length - 1
 
-    await instance.cancelOrders({ senderAddress: USER_1, orderIds: [orderId] })
+    await instance.cancelOrders({ userAddress: USER_1, orderIds: [orderId] })
 
     const actual = (await instance.getOrders(USER_1))[orderId]
     expect(actual.validUntil).toBe(BATCH_ID - 1)
@@ -176,7 +176,7 @@ describe('cancelOrder', () => {
   test('cancel non existing order does nothing', async () => {
     const expected = await instance.getOrders(USER_1)
 
-    await instance.cancelOrders({ senderAddress: USER_1, orderIds: [expected.length + 1] })
+    await instance.cancelOrders({ userAddress: USER_1, orderIds: [expected.length + 1] })
 
     const actual = await instance.getOrders(USER_1)
     expect(actual).toEqual(expected)
@@ -185,7 +185,7 @@ describe('cancelOrder', () => {
   test('cancel non existing order, user with no orders does nothing', async () => {
     const expected = await instance.getOrders(USER_2)
 
-    await instance.cancelOrders({ senderAddress: USER_2, orderIds: [expected.length + 1] })
+    await instance.cancelOrders({ userAddress: USER_2, orderIds: [expected.length + 1] })
 
     const actual = await instance.getOrders(USER_2)
     expect(actual).toEqual(expected)


### PR DESCRIPTION
Part of #329 

First step: refactoring API parameters.

### Reasons:
- Consistency across apis
- Remove inline type definitions
- Rename a few variables to be in line with other methods
- Make it easier to introduce additional parameters. Namely, `networkId`, for the next step
- Merge `txOptionalParams` for methods that accept it into a single params object


### Next step:
- Introduce `networkId` to DepositApi and ExchageApi to make them network agnostic
- Other apis (Erc20Api, TokenListApi) are network agnostic already, and Wallet api is the one providing the networkId in the first place.

