### PR TITLE
329/network agnostic apis

### DIFF
--- a/src/api/deposit/DepositApiMock.ts
+++ b/src/api/deposit/DepositApiMock.ts
@@ -84,7 +84,13 @@ export class DepositApiMock implements DepositApi {
     return balanceState ? balanceState.pendingWithdraws : createFlux()
   }
 
-  public async deposit({ userAddress, tokenAddress, amount, txOptionalParams }: DepositParams): Promise<Receipt> {
+  public async deposit({
+    userAddress,
+    tokenAddress,
+    amount,
+    networkId,
+    txOptionalParams,
+  }: DepositParams): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
 
     // Create the balance state if it's the first deposit
@@ -105,6 +111,7 @@ export class DepositApiMock implements DepositApi {
       fromAddress: userAddress,
       toAddress: this.getContractAddress(),
       amount,
+      networkId,
     })
 
     log(`[DepositApiMock] Deposited ${amount.toString()} for token ${tokenAddress}. User ${userAddress}`)
@@ -131,7 +138,7 @@ export class DepositApiMock implements DepositApi {
     return RECEIPT
   }
 
-  public async withdraw({ userAddress, tokenAddress, txOptionalParams }: WithdrawParams): Promise<Receipt> {
+  public async withdraw({ userAddress, tokenAddress, networkId, txOptionalParams }: WithdrawParams): Promise<Receipt> {
     await waitAndSendReceipt({ txOptionalParams })
 
     const currentBatchId = await this.getCurrentBatchId()
@@ -155,6 +162,7 @@ export class DepositApiMock implements DepositApi {
       tokenAddress,
       toAddress: userAddress,
       amount,
+      networkId,
     })
 
     log(`[DepositApiMock] Withdraw ${amount.toString()} for token ${tokenAddress}. User ${userAddress}`)

--- a/src/api/deposit/DepositApiMock.ts
+++ b/src/api/deposit/DepositApiMock.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import BN from 'bn.js'
 import assert from 'assert'
 
@@ -38,19 +39,19 @@ export class DepositApiMock implements DepositApi {
     this._erc20Api = erc20Api
   }
 
-  public getContractAddress(): string {
+  public getContractAddress(_networkId = 0): string {
     return CONTRACT
   }
 
-  public async getBatchTime(): Promise<number> {
+  public async getBatchTime(_networkId = 0): Promise<number> {
     return BATCH_TIME
   }
 
-  public async getCurrentBatchId(): Promise<number> {
+  public async getCurrentBatchId(_networkId = 0): Promise<number> {
     return Math.floor(getEpoch() / BATCH_TIME)
   }
 
-  public async getSecondsRemainingInBatch(): Promise<number> {
+  public async getSecondsRemainingInBatch(_networkId = 0): Promise<number> {
     return BATCH_TIME - (getEpoch() % BATCH_TIME)
   }
 

--- a/src/components/DepositWidget/useRowActions.tsx
+++ b/src/components/DepositWidget/useRowActions.tsx
@@ -36,6 +36,7 @@ export const useRowActions = (params: Params): Result => {
   async function enableToken(tokenAddress: string): Promise<void> {
     try {
       assert(userAddress, 'User address missing. Aborting.')
+      assert(networkId, 'NetworkId missing. Aborting.')
       assert(contractAddress, 'Contract address missing. Aborting.')
 
       const token = getToken('address', tokenAddress, balances)
@@ -49,6 +50,7 @@ export const useRowActions = (params: Params): Result => {
         userAddress,
         tokenAddress,
         spenderAddress: contractAddress,
+        networkId,
         amount: ALLOWANCE_MAX_VALUE,
         txOptionalParams,
       })

--- a/src/components/DepositWidget/useRowActions.tsx
+++ b/src/components/DepositWidget/useRowActions.tsx
@@ -66,6 +66,7 @@ export const useRowActions = (params: Params): Result => {
   async function depositToken(amount: BN, tokenAddress: string): Promise<void> {
     try {
       assert(userAddress, ON_ERROR_MESSAGE)
+      assert(networkId, ON_ERROR_MESSAGE)
 
       const token = getToken('address', tokenAddress, balances)
       assert(token, 'No token')
@@ -75,7 +76,7 @@ export const useRowActions = (params: Params): Result => {
       const { symbol, decimals } = safeFilledToken<TokenBalanceDetails>(token)
 
       log(`Processing deposit of ${amount} ${symbol} from ${userAddress}`)
-      const receipt = await depositApi.deposit({ userAddress, tokenAddress, amount, txOptionalParams })
+      const receipt = await depositApi.deposit({ userAddress, tokenAddress, networkId, amount, txOptionalParams })
       log(`The transaction has been mined: ${receipt.transactionHash}`)
 
       toast.success(`Successfully deposited ${formatAmount(amount, decimals)} ${symbol}`)
@@ -90,6 +91,7 @@ export const useRowActions = (params: Params): Result => {
   async function requestWithdrawToken(amount: BN, tokenAddress: string): Promise<void> {
     try {
       assert(userAddress, ON_ERROR_MESSAGE)
+      assert(networkId, ON_ERROR_MESSAGE)
 
       const token = getToken('address', tokenAddress, balances)
       assert(token, 'No token')
@@ -101,7 +103,13 @@ export const useRowActions = (params: Params): Result => {
       log(`Processing withdraw request of ${amount} ${symbol} from ${userAddress}`)
 
       log(`Processing withdraw request of ${amount} ${symbol} from ${userAddress}`)
-      const receipt = await depositApi.requestWithdraw({ userAddress, tokenAddress, amount, txOptionalParams })
+      const receipt = await depositApi.requestWithdraw({
+        userAddress,
+        tokenAddress,
+        networkId,
+        amount,
+        txOptionalParams,
+      })
       log(`The transaction has been mined: ${receipt.transactionHash}`)
 
       toast.success(`Successfully requested withdraw of ${formatAmount(amount, decimals)} ${symbol}`)
@@ -116,6 +124,7 @@ export const useRowActions = (params: Params): Result => {
   async function claimToken(tokenAddress: string): Promise<void> {
     try {
       assert(userAddress, ON_ERROR_MESSAGE)
+      assert(networkId, ON_ERROR_MESSAGE)
 
       const token = getToken('address', tokenAddress, balances)
       assert(token, 'No token')
@@ -126,7 +135,7 @@ export const useRowActions = (params: Params): Result => {
 
       dispatch(setHighlightAndClaimingAction(tokenAddress))
 
-      const receipt = await depositApi.withdraw({ userAddress, tokenAddress, txOptionalParams })
+      const receipt = await depositApi.withdraw({ userAddress, tokenAddress, networkId, txOptionalParams })
 
       log(`The transaction has been mined: ${receipt.transactionHash}`)
       toast.success(`Withdraw of ${formatAmount(pendingWithdraw.amount, decimals)} ${symbol} completed`)

--- a/src/components/OrdersWidget/useDeleteOrders.tsx
+++ b/src/components/OrdersWidget/useDeleteOrders.tsx
@@ -22,7 +22,7 @@ function extractExchangeOrderIds(orderIds: string[]): number[] {
 
 export function useDeleteOrders(): Result {
   const [deleting, setDeleting] = useSafeState<boolean>(false)
-  const { userAddress } = useWalletConnection()
+  const { userAddress, networkId } = useWalletConnection()
 
   const deleteOrders = useCallback(
     async (uiOrderIds: string[]): Promise<boolean> => {
@@ -30,13 +30,14 @@ export function useDeleteOrders(): Result {
 
       try {
         assert(userAddress, 'User address is missing. Aborting.')
+        assert(networkId, 'NetworkId is missing. Aborting.')
         assert(uiOrderIds.length > 0, 'No orders to cancel. Aborting.')
 
         setDeleting(true)
 
         const orderIds = extractExchangeOrderIds(uiOrderIds)
 
-        const receipt = await exchangeApi.cancelOrders({ userAddress, orderIds, txOptionalParams })
+        const receipt = await exchangeApi.cancelOrders({ userAddress, orderIds, networkId, txOptionalParams })
 
         log(`The transaction has been mined: ${receipt.transactionHash}`)
 
@@ -53,7 +54,7 @@ export function useDeleteOrders(): Result {
         setDeleting(false)
       }
     },
-    [setDeleting, userAddress],
+    [networkId, setDeleting, userAddress],
   )
 
   return { deleteOrders, deleting }

--- a/src/hooks/useEnableToken.ts
+++ b/src/hooks/useEnableToken.ts
@@ -28,6 +28,7 @@ export const useEnableTokens = (params: Params): Result => {
   async function enableToken(): Promise<Receipt> {
     assert(!enabled && isConnected, 'The token was already enabled and/or user is not connected')
     assert(userAddress, 'User address not found. Please check wallet.')
+    assert(networkId, 'NetworkId not found. Please check wallet.')
 
     setEnabling(true)
 
@@ -40,6 +41,7 @@ export const useEnableTokens = (params: Params): Result => {
       tokenAddress,
       spenderAddress: contractAddress,
       amount: ALLOWANCE_MAX_VALUE,
+      networkId,
       txOptionalParams,
     })
 

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -28,16 +28,17 @@ function filterDeletedOrders(orders: AuctionElement[]): AuctionElement[] {
 }
 
 export function useOrders(): AuctionElement[] {
-  const { userAddress } = useWalletConnection()
+  const { userAddress, networkId } = useWalletConnection()
   const [orders, setOrders] = useSafeState<AuctionElement[]>([])
 
   useEffect(() => {
     userAddress &&
+      networkId &&
       exchangeApi
-        .getOrders({ userAddress })
+        .getOrders({ userAddress, networkId })
         .then(filterDeletedOrders)
         .then(setOrders)
-  }, [setOrders, userAddress])
+  }, [networkId, setOrders, userAddress])
 
   return orders
 }

--- a/src/hooks/usePlaceOrder.ts
+++ b/src/hooks/usePlaceOrder.ts
@@ -25,11 +25,11 @@ interface Result {
 
 export const usePlaceOrder = (): Result => {
   const [isSubmitting, setIsSubmitting] = useSafeState(false)
-  const { userAddress } = useWalletConnection()
+  const { userAddress, networkId } = useWalletConnection()
 
   const placeOrder = useCallback(
     async ({ buyAmount, buyToken, sellAmount, sellToken }: PlaceOrderParams): Promise<boolean> => {
-      if (!userAddress) {
+      if (!userAddress || !networkId) {
         toast.error('Wallet is not connected!')
         return false
       }
@@ -43,9 +43,9 @@ export const usePlaceOrder = (): Result => {
 
       try {
         const [sellTokenId, buyTokenId, batchId] = await Promise.all([
-          exchangeApi.getTokenIdByAddress({ tokenAddress: sellToken.address }),
-          exchangeApi.getTokenIdByAddress({ tokenAddress: buyToken.address }),
-          exchangeApi.getCurrentBatchId(),
+          exchangeApi.getTokenIdByAddress({ tokenAddress: sellToken.address, networkId }),
+          exchangeApi.getTokenIdByAddress({ tokenAddress: buyToken.address, networkId }),
+          exchangeApi.getCurrentBatchId(networkId),
         ])
 
         if (sellTokenId !== 0 || buyTokenId !== 0) {
@@ -60,6 +60,7 @@ export const usePlaceOrder = (): Result => {
             validUntil,
             buyAmount,
             sellAmount,
+            networkId,
             txOptionalParams,
           }
           const receipt = await exchangeApi.placeOrder(params)
@@ -93,7 +94,7 @@ export const usePlaceOrder = (): Result => {
         setIsSubmitting(false)
       }
     },
-    [setIsSubmitting, userAddress],
+    [networkId, setIsSubmitting, userAddress],
   )
 
   return { placeOrder, isSubmitting }

--- a/src/hooks/useTokenBalances.ts
+++ b/src/hooks/useTokenBalances.ts
@@ -44,8 +44,8 @@ async function fetchBalancesForToken(
     depositApi.getPendingDeposit({ userAddress, tokenAddress, networkId }),
     depositApi.getPendingWithdraw({ userAddress, tokenAddress, networkId }),
     depositApi.getCurrentBatchId(networkId),
-    erc20Api.balanceOf({ userAddress, tokenAddress }),
-    erc20Api.allowance({ userAddress, tokenAddress, spenderAddress: contractAddress }),
+    erc20Api.balanceOf({ userAddress, tokenAddress, networkId }),
+    erc20Api.allowance({ userAddress, tokenAddress, networkId, spenderAddress: contractAddress }),
   ])
 
   return {

--- a/src/hooks/useTokenBalances.ts
+++ b/src/hooks/useTokenBalances.ts
@@ -29,6 +29,7 @@ async function fetchBalancesForToken(
   token: TokenDetails,
   userAddress: string,
   contractAddress: string,
+  networkId: number,
 ): Promise<TokenBalanceDetails> {
   const tokenAddress = token.address
   const [
@@ -39,10 +40,10 @@ async function fetchBalancesForToken(
     walletBalance,
     allowance,
   ] = await Promise.all([
-    depositApi.getBalance({ userAddress, tokenAddress }),
-    depositApi.getPendingDeposit({ userAddress, tokenAddress }),
-    depositApi.getPendingWithdraw({ userAddress, tokenAddress }),
-    depositApi.getCurrentBatchId(),
+    depositApi.getBalance({ userAddress, tokenAddress, networkId }),
+    depositApi.getPendingDeposit({ userAddress, tokenAddress, networkId }),
+    depositApi.getPendingWithdraw({ userAddress, tokenAddress, networkId }),
+    depositApi.getCurrentBatchId(networkId),
     erc20Api.balanceOf({ userAddress, tokenAddress }),
     erc20Api.allowance({ userAddress, tokenAddress, spenderAddress: contractAddress }),
   ])
@@ -72,7 +73,7 @@ async function _getBalances(walletInfo: WalletInfo): Promise<TokenBalanceDetails
   const tokens = tokenListApi.getTokens(networkId)
 
   const balancePromises: Promise<TokenBalanceDetails | null>[] = tokens.map(token =>
-    fetchBalancesForToken(token, userAddress, contractAddress).catch(e => {
+    fetchBalancesForToken(token, userAddress, contractAddress, networkId).catch(e => {
       log('Error for', token, userAddress, contractAddress)
       log(e)
       return null

--- a/src/hooks/useWithdrawTokens.ts
+++ b/src/hooks/useWithdrawTokens.ts
@@ -15,7 +15,7 @@ interface Result {
 }
 
 export const useWithdrawTokens = (params: Params): Result => {
-  const { userAddress, isConnected } = useWalletConnection()
+  const { userAddress, isConnected, networkId } = useWalletConnection()
   const {
     tokenBalances: { enabled, address: tokenAddress, claimable },
     txOptionalParams,
@@ -28,10 +28,11 @@ export const useWithdrawTokens = (params: Params): Result => {
       assert(enabled, 'Token not enabled')
       assert(claimable, 'Withdraw not ready')
       assert(isConnected, "There's no connected wallet")
+      assert(networkId, 'No valid networkId found')
 
       setWithdrawing(true)
 
-      return depositApi.withdraw({ userAddress, tokenAddress, txOptionalParams })
+      return depositApi.withdraw({ userAddress, tokenAddress, networkId, txOptionalParams })
     } finally {
       setWithdrawing(false)
     }

--- a/src/services/factories/addTokenToExchange.ts
+++ b/src/services/factories/addTokenToExchange.ts
@@ -29,7 +29,7 @@ export function addTokenToExchangeFactory(
   const { exchangeApi } = factoryParams
 
   return async ({ userAddress, tokenAddress, networkId }: AddTokenToExchangeParams): Promise<boolean> => {
-    const erc20Info = getErc20Info({ ...factoryParams, tokenAddress })
+    const erc20Info = getErc20Info({ ...factoryParams, tokenAddress, networkId })
 
     if (!erc20Info) {
       log('Address %s does not contain a valid ERC20 token', tokenAddress)

--- a/src/services/factories/addTokenToExchange.ts
+++ b/src/services/factories/addTokenToExchange.ts
@@ -15,6 +15,7 @@ interface Params {
 interface AddTokenToExchangeParams {
   userAddress: string
   tokenAddress: string
+  networkId: number
 }
 
 /**
@@ -27,7 +28,7 @@ export function addTokenToExchangeFactory(
 ): (params: AddTokenToExchangeParams) => Promise<boolean> {
   const { exchangeApi } = factoryParams
 
-  return async ({ userAddress, tokenAddress }: AddTokenToExchangeParams): Promise<boolean> => {
+  return async ({ userAddress, tokenAddress, networkId }: AddTokenToExchangeParams): Promise<boolean> => {
     const erc20Info = getErc20Info({ ...factoryParams, tokenAddress })
 
     if (!erc20Info) {
@@ -36,7 +37,7 @@ export function addTokenToExchangeFactory(
     }
 
     try {
-      await exchangeApi.addToken({ userAddress, tokenAddress })
+      await exchangeApi.addToken({ userAddress, tokenAddress, networkId })
     } catch (e) {
       log('Failed to add token (%s) to exchange', tokenAddress)
       return false
@@ -45,7 +46,7 @@ export function addTokenToExchangeFactory(
     // TODO: I guess we might want to return the token and leave the proxy/cache layer to deal with it.
     // Revisit once we add it to the interface
     try {
-      const id = exchangeApi.getTokenIdByAddress({ tokenAddress })
+      const id = exchangeApi.getTokenIdByAddress({ tokenAddress, networkId })
 
       const token = {
         ...erc20Info,

--- a/src/services/factories/getTokenFromExchange.ts
+++ b/src/services/factories/getTokenFromExchange.ts
@@ -69,7 +69,7 @@ function getTokenFromExchangeByAddressFactory(
 
     let tokenId: number
     try {
-      tokenId = await exchangeApi.getTokenIdByAddress({ tokenAddress })
+      tokenId = await exchangeApi.getTokenIdByAddress({ tokenAddress, networkId })
     } catch (e) {
       log('Token with address %s not registered on contract', tokenAddress, e)
       return null
@@ -113,7 +113,7 @@ function getTokenFromExchangeByIdFactory(
     // Not there, get the address from the contract
     let tokenAddress: string
     try {
-      tokenAddress = await exchangeApi.getTokenAddressById({ tokenId })
+      tokenAddress = await exchangeApi.getTokenAddressById({ tokenId, networkId })
     } catch (e) {
       log('Token with id %d not registered on contract', tokenId, e)
       return null

--- a/src/services/factories/getTokenFromExchange.ts
+++ b/src/services/factories/getTokenFromExchange.ts
@@ -11,6 +11,7 @@ import { TokenList } from 'api/tokenList/TokenListApi'
 interface TokenFromErc20Params {
   tokenAddress: string
   tokenId: number
+  networkId: number
   erc20Api: Erc20Api
   web3: Web3
 }
@@ -82,7 +83,7 @@ function getTokenFromExchangeByAddressFactory(
     }
 
     // Not there, get it from the ERC20 contract
-    return getTokenFromErc20({ ...factoryParams, tokenAddress, tokenId })
+    return getTokenFromErc20({ ...factoryParams, tokenAddress, tokenId, networkId })
   }
 }
 
@@ -127,7 +128,7 @@ function getTokenFromExchangeByIdFactory(
     }
 
     // Not there, get it from the ERC20 contract
-    return getTokenFromErc20({ ...factoryParams, tokenId, tokenAddress })
+    return getTokenFromErc20({ ...factoryParams, tokenId, tokenAddress, networkId })
   }
 }
 

--- a/src/services/helpers/getErc20Info.ts
+++ b/src/services/helpers/getErc20Info.ts
@@ -19,6 +19,7 @@ async function wrapPromise<T>(promise: Promise<T>): Promise<T | undefined> {
 
 interface Params {
   tokenAddress: string
+  networkId: number
   erc20Api: Erc20Api
   web3: Web3
 }
@@ -26,7 +27,12 @@ interface Params {
 /**
  * Fetches info for an arbitrary ERC20 token from given address
  */
-export async function getErc20Info({ tokenAddress, erc20Api, web3 }: Params): Promise<MinimalTokenDetails | null> {
+export async function getErc20Info({
+  tokenAddress,
+  networkId,
+  erc20Api,
+  web3,
+}: Params): Promise<MinimalTokenDetails | null> {
   // First check whether given address is a contract
   const code = await web3.eth.getCode(tokenAddress)
   if (code === '0x') {
@@ -38,7 +44,7 @@ export async function getErc20Info({ tokenAddress, erc20Api, web3 }: Params): Pr
   try {
     // totalSupply is an ERC20 mandatory read only method.
     // if the call succeeds, we assume it's compliant
-    await erc20Api.totalSupply({ tokenAddress })
+    await erc20Api.totalSupply({ tokenAddress, networkId })
   } catch (e) {
     log('Address %s is not ERC20 compliant', tokenAddress, e)
     return null
@@ -46,9 +52,9 @@ export async function getErc20Info({ tokenAddress, erc20Api, web3 }: Params): Pr
 
   // Query for optional details. Do not fail in case any is missing.
   const [symbol, name, decimals] = await Promise.all([
-    wrapPromise(erc20Api.symbol({ tokenAddress })),
-    wrapPromise(erc20Api.name({ tokenAddress })),
-    wrapPromise(erc20Api.decimals({ tokenAddress })),
+    wrapPromise(erc20Api.symbol({ tokenAddress, networkId })),
+    wrapPromise(erc20Api.name({ tokenAddress, networkId })),
+    wrapPromise(erc20Api.decimals({ tokenAddress, networkId })),
   ])
   return { address: tokenAddress, symbol, name, decimals: decimals || DEFAULT_PRECISION }
 }

--- a/test/api/ExchangeApi/DepositApiMock.test.ts
+++ b/test/api/ExchangeApi/DepositApiMock.test.ts
@@ -14,6 +14,7 @@ let instance: DepositApi
 let mockErc20Api: Erc20Api
 
 const ZERO_FLUX = createFlux()
+const NETWORK_ID = 0
 
 beforeAll(() => {
   testHelpers.mockTimes()
@@ -57,17 +58,17 @@ beforeEach(() => {
 
 describe('Basic view functions', () => {
   test('Get batch time', async () => {
-    const batchTime = await instance.getBatchTime()
+    const batchTime = await instance.getBatchTime(NETWORK_ID)
     expect(batchTime).toBe(BATCH_TIME)
   })
 
   test('Get current batch id (state index)', async () => {
-    const batchId = await instance.getCurrentBatchId()
+    const batchId = await instance.getCurrentBatchId(NETWORK_ID)
     expect(batchId).toBe(testHelpers.BATCH_ID)
   })
 
   test('Get seconds remaining in batch', async () => {
-    const remainingSeconds = await instance.getSecondsRemainingInBatch()
+    const remainingSeconds = await instance.getSecondsRemainingInBatch(NETWORK_ID)
     expect(remainingSeconds).toBe(BATCH_TIME - testHelpers.BATCH_SECOND)
   })
 })
@@ -77,7 +78,7 @@ describe('Get balance', () => {
     // GIVEN: A user that doesn't have any deposits
 
     // WHEN: We get the balance
-    const balance = await instance.getBalance({ userAddress: USER_2, tokenAddress: TOKEN_1 })
+    const balance = await instance.getBalance({ userAddress: USER_2, tokenAddress: TOKEN_1, networkId: NETWORK_ID })
 
     // THEN: The balance is zero
     expect(balance).toEqual(ZERO)
@@ -87,7 +88,7 @@ describe('Get balance', () => {
     // GIVEN: A user that has deposits for some tokens, but not for TOKEN_3
 
     // WHEN: We get the balance for TOKEN_3
-    const balance = await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_3 })
+    const balance = await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_3, networkId: NETWORK_ID })
 
     // THEN: The balance is zero
     expect(balance).toEqual(ZERO)
@@ -97,7 +98,7 @@ describe('Get balance', () => {
     // GIVEN: A user that has balance zero for TOKEN_1
 
     // WHEN: We get the balance for TOKEN_1
-    const balance = await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_1 })
+    const balance = await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_1, networkId: NETWORK_ID })
 
     // THEN: The balance is zero
     expect(balance).toEqual(ZERO)
@@ -107,7 +108,7 @@ describe('Get balance', () => {
     // GIVEN: A user that has balance for TOKEN_2
 
     // WHEN: We get the balance for TOKEN_2
-    const balance = await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_2 })
+    const balance = await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_2, networkId: NETWORK_ID })
 
     // THEN: The balance is AMOUNT
     expect(balance).toEqual(AMOUNT)
@@ -120,7 +121,9 @@ describe('Get pending deposit amounts', () => {
     // WHEN: -
 
     // THEN: there's no pending deposits nor batchId
-    expect(await instance.getPendingDeposit({ userAddress: USER_2, tokenAddress: TOKEN_1 })).toEqual(ZERO_FLUX)
+    expect(
+      await instance.getPendingDeposit({ userAddress: USER_2, tokenAddress: TOKEN_1, networkId: NETWORK_ID }),
+    ).toEqual(ZERO_FLUX)
   })
 
   test('Unknown token', async () => {
@@ -128,7 +131,9 @@ describe('Get pending deposit amounts', () => {
     // WHEN: -
 
     // THEN: there's no pending deposits nor batchId
-    expect(await instance.getPendingDeposit({ userAddress: USER_1, tokenAddress: TOKEN_3 })).toEqual(ZERO_FLUX)
+    expect(
+      await instance.getPendingDeposit({ userAddress: USER_1, tokenAddress: TOKEN_3, networkId: NETWORK_ID }),
+    ).toEqual(ZERO_FLUX)
   })
 
   test('No pending balance', async () => {
@@ -136,7 +141,9 @@ describe('Get pending deposit amounts', () => {
     // WHEN: -
 
     // THEN: there's no pending deposits
-    expect(await instance.getPendingDeposit({ userAddress: USER_1, tokenAddress: TOKEN_2 })).toEqual(ZERO_FLUX)
+    expect(
+      await instance.getPendingDeposit({ userAddress: USER_1, tokenAddress: TOKEN_2, networkId: NETWORK_ID }),
+    ).toEqual(ZERO_FLUX)
   })
 })
 
@@ -146,7 +153,9 @@ describe('Get pending withdraw amounts', () => {
     // WHEN: -
 
     // THEN: there's no pending withdraws nor batchId
-    expect(await instance.getPendingWithdraw({ userAddress: USER_2, tokenAddress: TOKEN_1 })).toEqual(ZERO_FLUX)
+    expect(
+      await instance.getPendingWithdraw({ userAddress: USER_2, tokenAddress: TOKEN_1, networkId: NETWORK_ID }),
+    ).toEqual(ZERO_FLUX)
   })
 
   test('Unknown token', async () => {
@@ -154,7 +163,9 @@ describe('Get pending withdraw amounts', () => {
     // WHEN: -
 
     // THEN: there's no pending withdraws nor batchId
-    expect(await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_3 })).toEqual(ZERO_FLUX)
+    expect(
+      await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_3, networkId: NETWORK_ID }),
+    ).toEqual(ZERO_FLUX)
   })
 
   test('No pending balance', async () => {
@@ -162,74 +173,120 @@ describe('Get pending withdraw amounts', () => {
     // WHEN: -
 
     // THEN: there's no pending withdraws
-    expect(await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_2 })).toEqual(ZERO_FLUX)
+    expect(
+      await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_2, networkId: NETWORK_ID }),
+    ).toEqual(ZERO_FLUX)
   })
 })
 
 describe('Deposit', () => {
   test('Unknown token', async () => {
     // GIVEN: An user with no token balance for TOKEN_3 and no pending deposits
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_3 })).toEqual(ZERO)
-    expect(await instance.getPendingDeposit({ userAddress: USER_1, tokenAddress: TOKEN_3 })).toEqual(ZERO_FLUX)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_3, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
+    expect(
+      await instance.getPendingDeposit({ userAddress: USER_1, tokenAddress: TOKEN_3, networkId: NETWORK_ID }),
+    ).toEqual(ZERO_FLUX)
 
     // WHEN: Deposits AMOUNT
-    await instance.deposit({ userAddress: USER_1, tokenAddress: TOKEN_3, amount: AMOUNT })
+    await instance.deposit({ userAddress: USER_1, tokenAddress: TOKEN_3, networkId: NETWORK_ID, amount: AMOUNT })
 
     // THEN: There's still no balance
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_3 })).toEqual(ZERO)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_3, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
 
     // THEN: There's a pending deposit of AMOUNT
-    const { amount } = await instance.getPendingDeposit({ userAddress: USER_1, tokenAddress: TOKEN_3 })
+    const { amount } = await instance.getPendingDeposit({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_3,
+      networkId: NETWORK_ID,
+    })
     expect(amount).toEqual(AMOUNT)
   })
 
   test('No balance', async () => {
     // GIVEN: An user with no token balance for TOKEN_1 and no pending deposits
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_1 })).toEqual(ZERO)
-    expect(await instance.getPendingDeposit({ userAddress: USER_1, tokenAddress: TOKEN_1 })).toEqual(ZERO_FLUX)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_1, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
+    expect(
+      await instance.getPendingDeposit({ userAddress: USER_1, tokenAddress: TOKEN_1, networkId: NETWORK_ID }),
+    ).toEqual(ZERO_FLUX)
 
     // WHEN: Deposits AMOUNT
-    await instance.deposit({ userAddress: USER_1, tokenAddress: TOKEN_1, amount: AMOUNT })
+    await instance.deposit({ userAddress: USER_1, tokenAddress: TOKEN_1, amount: AMOUNT, networkId: NETWORK_ID })
 
     // THEN: There's still no balance
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_1 })).toEqual(ZERO)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_1, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
 
     // THEN: There's a pending deposit of AMOUNT
-    const { amount } = await instance.getPendingDeposit({ userAddress: USER_1, tokenAddress: TOKEN_1 })
+    const { amount } = await instance.getPendingDeposit({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_1,
+      networkId: NETWORK_ID,
+    })
     expect(amount).toEqual(AMOUNT)
   })
 
   test('Applicable pending balance', async () => {
     // GIVEN: An user with no balance for TOKEN_4, and applicable pending deposits
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4 })).toEqual(ZERO)
-    const { amount } = await instance.getPendingDeposit({ userAddress: USER_1, tokenAddress: TOKEN_4 })
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
+    const { amount } = await instance.getPendingDeposit({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_4,
+      networkId: NETWORK_ID,
+    })
     expect(amount).toEqual(AMOUNT)
 
     // WHEN: Deposits AMOUNT
-    await instance.deposit({ userAddress: USER_1, tokenAddress: TOKEN_4, amount: AMOUNT })
+    await instance.deposit({ userAddress: USER_1, tokenAddress: TOKEN_4, amount: AMOUNT, networkId: NETWORK_ID })
 
     // THEN: The previous pending deposit is applied
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4 })).toEqual(AMOUNT)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4, networkId: NETWORK_ID })).toEqual(
+      AMOUNT,
+    )
 
     // THEN: There's a pending deposit of AMOUNT
-    const { amount: amount2 } = await instance.getPendingDeposit({ userAddress: USER_1, tokenAddress: TOKEN_4 })
+    const { amount: amount2 } = await instance.getPendingDeposit({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_4,
+      networkId: NETWORK_ID,
+    })
     expect(amount2).toEqual(AMOUNT)
   })
 
   test('Unapplicable pending balance', async () => {
     // GIVEN: An user with an unapplicable pending deposit for TOKEN_5
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_5 })).toEqual(AMOUNT)
-    const { amount } = await instance.getPendingDeposit({ userAddress: USER_1, tokenAddress: TOKEN_5 })
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_5, networkId: NETWORK_ID })).toEqual(
+      AMOUNT,
+    )
+    const { amount } = await instance.getPendingDeposit({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_5,
+      networkId: NETWORK_ID,
+    })
     expect(amount).toEqual(AMOUNT)
 
     // WHEN: Deposits AMOUNT
-    await instance.deposit({ userAddress: USER_1, tokenAddress: TOKEN_5, amount: AMOUNT })
+    await instance.deposit({ userAddress: USER_1, tokenAddress: TOKEN_5, amount: AMOUNT, networkId: NETWORK_ID })
 
     // THEN: There's still the same balance
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_5 })).toEqual(AMOUNT)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_5, networkId: NETWORK_ID })).toEqual(
+      AMOUNT,
+    )
 
     // THEN: There's a pending deposit of AMOUNT + AMOUNT
-    const { amount: amount2 } = await instance.getPendingDeposit({ userAddress: USER_1, tokenAddress: TOKEN_5 })
+    const { amount: amount2 } = await instance.getPendingDeposit({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_5,
+      networkId: NETWORK_ID,
+    })
     expect(amount2).toEqual(AMOUNT.add(AMOUNT))
   })
 })
@@ -237,67 +294,131 @@ describe('Deposit', () => {
 describe('Request withdraw', () => {
   test('Unknown token', async () => {
     // GIVEN: An user with no token balance for TOKEN_3 and no pending withdraw
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_3 })).toEqual(ZERO)
-    expect(await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_3 })).toEqual(ZERO_FLUX)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_3, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
+    expect(
+      await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_3, networkId: NETWORK_ID }),
+    ).toEqual(ZERO_FLUX)
 
     // WHEN: Requesting a withdraw of AMOUNT
-    await instance.requestWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_3, amount: AMOUNT })
+    await instance.requestWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_3,
+      amount: AMOUNT,
+      networkId: NETWORK_ID,
+    })
 
     // THEN: There's still no balance
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_3 })).toEqual(ZERO)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_3, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
 
     // THEN: There's a pending withdraw of AMOUNT
-    const { amount } = await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_3 })
+    const { amount } = await instance.getPendingWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_3,
+      networkId: NETWORK_ID,
+    })
     expect(amount).toEqual(AMOUNT)
   })
 
   test('No balance', async () => {
     // GIVEN: An user with no token balance for TOKEN_1 and no pending withdraw
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_1 })).toEqual(ZERO)
-    expect(await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_1 })).toEqual(ZERO_FLUX)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_1, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
+    expect(
+      await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_1, networkId: NETWORK_ID }),
+    ).toEqual(ZERO_FLUX)
 
     // WHEN: Requesting a withdraw of AMOUNT
-    await instance.requestWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_1, amount: AMOUNT })
+    await instance.requestWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_1,
+      amount: AMOUNT,
+      networkId: NETWORK_ID,
+    })
 
     // THEN: There's still no balance
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_1 })).toEqual(ZERO)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_1, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
 
     // THEN: There's a pending withdraw of AMOUNT
-    const { amount } = await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_1 })
+    const { amount } = await instance.getPendingWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_1,
+      networkId: NETWORK_ID,
+    })
     expect(amount).toEqual(AMOUNT)
   })
 
   test('Increase previous withdraw request amount', async () => {
     // GIVEN: An user with no balance for TOKEN_4, and a previous pending withdraw of AMOUNT
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4 })).toEqual(ZERO)
-    const { amount } = await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_4 })
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
+    const { amount } = await instance.getPendingWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_4,
+      networkId: NETWORK_ID,
+    })
     expect(amount).toEqual(AMOUNT)
 
     // WHEN: Requesting a withdraw of 2 * AMOUNT
-    await instance.requestWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_4, amount: AMOUNT.mul(TWO) })
+    await instance.requestWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_4,
+      networkId: NETWORK_ID,
+      amount: AMOUNT.mul(TWO),
+    })
 
     // THEN: There's still no balance
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4 })).toEqual(ZERO)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
 
     // THEN: There's a pending withdraw of 2 * AMOUNT
-    const { amount: amount2 } = await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_4 })
+    const { amount: amount2 } = await instance.getPendingWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_4,
+      networkId: NETWORK_ID,
+    })
     expect(amount2).toEqual(AMOUNT.mul(TWO))
   })
 
   test('Decrease previous withdraw request amount', async () => {
     // GIVEN: An user with no balance for TOKEN_4, and a previous pending withdraw of AMOUNT
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4 })).toEqual(ZERO)
-    const { amount } = await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_4 })
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
+    const { amount } = await instance.getPendingWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_4,
+      networkId: NETWORK_ID,
+    })
     expect(amount).toEqual(AMOUNT)
 
     // WHEN: Requesting a withdraw of 2 * AMOUNT
-    await instance.requestWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_4, amount: AMOUNT.div(TWO) })
+    await instance.requestWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_4,
+      networkId: NETWORK_ID,
+      amount: AMOUNT.div(TWO),
+    })
 
     // THEN: There's still no balance
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4 })).toEqual(ZERO)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
 
     // THEN: There's a pending withdraw of 2 * AMOUNT
-    const { amount: amount2 } = await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_4 })
+    const { amount: amount2 } = await instance.getPendingWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_4,
+      networkId: NETWORK_ID,
+    })
     expect(amount2).toEqual(AMOUNT.div(TWO))
   })
 })
@@ -305,96 +426,150 @@ describe('Request withdraw', () => {
 describe('Withdraw', () => {
   test('Unknown token', async () => {
     // GIVEN: An user with no token balance for TOKEN_3 and no pending withdraw
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_3 })).toEqual(ZERO)
-    expect(await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_3 })).toEqual(ZERO_FLUX)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_3, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
+    expect(
+      await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_3, networkId: NETWORK_ID }),
+    ).toEqual(ZERO_FLUX)
 
     // WHEN: Withdraw AMOUNT
-    const withdrawPromise = instance.withdraw({ userAddress: USER_1, tokenAddress: TOKEN_3 })
+    const withdrawPromise = instance.withdraw({ userAddress: USER_1, tokenAddress: TOKEN_3, networkId: NETWORK_ID })
 
     // THEN: The withdraw fails
     await expect(withdrawPromise).rejects.toBeTruthy()
 
     // THEN: There's still no balance
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_3 })).toEqual(ZERO)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_3, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
 
     // THEN: There's still no pending withdraw
-    const { amount } = await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_3 })
+    const { amount } = await instance.getPendingWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_3,
+      networkId: NETWORK_ID,
+    })
     expect(amount).toEqual(ZERO)
   })
 
   test('No balance', async () => {
     // GIVEN: An user with no token balance for TOKEN_1 and no pending withdraw
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_1 })).toEqual(ZERO)
-    expect(await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_1 })).toEqual(ZERO_FLUX)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_1, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
+    expect(
+      await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_1, networkId: NETWORK_ID }),
+    ).toEqual(ZERO_FLUX)
 
     // WHEN: Withdraw AMOUNT
-    const withdrawPromise = instance.withdraw({ userAddress: USER_1, tokenAddress: TOKEN_1 })
+    const withdrawPromise = instance.withdraw({ userAddress: USER_1, tokenAddress: TOKEN_1, networkId: NETWORK_ID })
 
     // THEN: The withdraw fails
     await expect(withdrawPromise).rejects.toBeTruthy()
 
     // THEN: There's still no balance
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_1 })).toEqual(ZERO)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_1, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
 
     // THEN: There's still no pending withdraw
-    expect(await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_1 })).toEqual(ZERO_FLUX)
+    expect(
+      await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_1, networkId: NETWORK_ID }),
+    ).toEqual(ZERO_FLUX)
   })
 
   test('Settled withdraw request, but not balance', async () => {
     // GIVEN: An user with no balance for TOKEN_4, and a previous pending withdraw of AMOUNT
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4 })).toEqual(ZERO)
-    const { amount } = await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_4 })
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
+    const { amount } = await instance.getPendingWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_4,
+      networkId: NETWORK_ID,
+    })
     expect(amount).toEqual(AMOUNT)
 
     // WHEN: Withdraw AMOUNT
-    const withdrawPromise = instance.withdraw({ userAddress: USER_1, tokenAddress: TOKEN_4 })
+    const withdrawPromise = instance.withdraw({ userAddress: USER_1, tokenAddress: TOKEN_4, networkId: NETWORK_ID })
 
     // THEN: The withdraw fails
     await expect(withdrawPromise).rejects.toBeTruthy()
 
     // THEN: There's still no balance
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4 })).toEqual(ZERO)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_4, networkId: NETWORK_ID })).toEqual(
+      ZERO,
+    )
 
     // THEN: There's still a withdraw request
-    const { amount: amount2 } = await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_4 })
+    const { amount: amount2 } = await instance.getPendingWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_4,
+      networkId: NETWORK_ID,
+    })
     expect(amount2).toEqual(AMOUNT)
   })
 
   test('Settled withdraw request', async () => {
     // GIVEN: An user with AMOUNT balance for TOKEN_6, and a previous pending withdraw of AMOUNT_SMALL
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_6 })).toEqual(AMOUNT)
-    const { amount } = await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_6 })
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_6, networkId: NETWORK_ID })).toEqual(
+      AMOUNT,
+    )
+    const { amount } = await instance.getPendingWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_6,
+      networkId: NETWORK_ID,
+    })
     expect(amount).toEqual(AMOUNT_SMALL)
 
     // WHEN: Withdraw AMOUNT_SMALL
-    await instance.withdraw({ userAddress: USER_1, tokenAddress: TOKEN_6 })
+    await instance.withdraw({ userAddress: USER_1, tokenAddress: TOKEN_6, networkId: NETWORK_ID })
 
     // THEN: There remaining balance is AMOUNT - AMOUNT_SMALL
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_6 })).toEqual(AMOUNT.sub(AMOUNT_SMALL))
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_6, networkId: NETWORK_ID })).toEqual(
+      AMOUNT.sub(AMOUNT_SMALL),
+    )
 
     // THEN: There's no pending withdraw anymore
-    const { amount: amount2 } = await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_6 })
+    const { amount: amount2 } = await instance.getPendingWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_6,
+      networkId: NETWORK_ID,
+    })
     expect(amount2).toEqual(ZERO)
   })
 
   test('Unsettled withdraw request', async () => {
     // GIVEN: An user with a non applicable withdraw request on TOKEN_5
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_5 })).toEqual(AMOUNT)
-    const { amount, batchId } = await instance.getPendingDeposit({ userAddress: USER_1, tokenAddress: TOKEN_5 })
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_5, networkId: NETWORK_ID })).toEqual(
+      AMOUNT,
+    )
+    const { amount, batchId } = await instance.getPendingDeposit({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_5,
+      networkId: NETWORK_ID,
+    })
     expect(amount).toEqual(AMOUNT)
-    expect(await instance.getCurrentBatchId()).toBeGreaterThanOrEqual(batchId)
+    expect(await instance.getCurrentBatchId(NETWORK_ID)).toBeGreaterThanOrEqual(batchId)
 
     // WHEN: Withdraw AMOUNT
-    const withdrawPromise = instance.withdraw({ userAddress: USER_1, tokenAddress: TOKEN_5 })
+    const withdrawPromise = instance.withdraw({ userAddress: USER_1, tokenAddress: TOKEN_5, networkId: NETWORK_ID })
 
     // THEN: The withdraw fails
     await expect(withdrawPromise).rejects.toBeTruthy()
 
     // THEN: There's still the same balance
-    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_5 })).toEqual(AMOUNT)
+    expect(await instance.getBalance({ userAddress: USER_1, tokenAddress: TOKEN_5, networkId: NETWORK_ID })).toEqual(
+      AMOUNT,
+    )
 
     // THEN: There's still the same withdraw request
-    const { amount: amount2 } = await instance.getPendingWithdraw({ userAddress: USER_1, tokenAddress: TOKEN_5 })
+    const { amount: amount2 } = await instance.getPendingWithdraw({
+      userAddress: USER_1,
+      tokenAddress: TOKEN_5,
+      networkId: NETWORK_ID,
+    })
     expect(amount2).toEqual(AMOUNT)
   })
 })

--- a/test/api/ExchangeApi/Erc20ApiMock.test.ts
+++ b/test/api/ExchangeApi/Erc20ApiMock.test.ts
@@ -20,60 +20,84 @@ import { ZERO, ALLOWANCE_MAX_VALUE } from 'const'
 import BN from 'bn.js'
 import { clone } from '../../testHelpers'
 
+const NETWORK_ID = 0
+
 let instance: Erc20Api = new Erc20ApiMock({ balances: BALANCES, allowances: ALLOWANCES, tokens: unregisteredTokens })
 
 describe('Basic view functions', () => {
   describe('balanceOf', () => {
     it('returns balance', async () => {
       const token1Balance = BALANCES[USER_1][TOKEN_1]
-      expect(await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_1 })).toBe(token1Balance)
+      expect(await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_1, networkId: NETWORK_ID })).toBe(
+        token1Balance,
+      )
     })
 
     it('returns 0 when not found', async () => {
-      expect(await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_2 })).toBe(ZERO)
+      expect(await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_2, networkId: NETWORK_ID })).toBe(ZERO)
     })
   })
 
   describe('allowance', () => {
     it('returns allowance', async () => {
       const allowance = ALLOWANCES[USER_1][TOKEN_6][CONTRACT]
-      expect(await instance.allowance({ tokenAddress: TOKEN_6, userAddress: USER_1, spenderAddress: CONTRACT })).toBe(
-        allowance,
-      )
+      expect(
+        await instance.allowance({
+          tokenAddress: TOKEN_6,
+          userAddress: USER_1,
+          spenderAddress: CONTRACT,
+          networkId: NETWORK_ID,
+        }),
+      ).toBe(allowance)
     })
 
     it('user without allowance set returns 0', async () => {
-      expect(await instance.allowance({ tokenAddress: TOKEN_1, userAddress: USER_2, spenderAddress: CONTRACT })).toBe(
-        ZERO,
-      )
+      expect(
+        await instance.allowance({
+          tokenAddress: TOKEN_1,
+          userAddress: USER_2,
+          spenderAddress: CONTRACT,
+          networkId: NETWORK_ID,
+        }),
+      ).toBe(ZERO)
     })
 
     it('token without allowance set returns 0', async () => {
-      expect(await instance.allowance({ tokenAddress: TOKEN_8, userAddress: USER_1, spenderAddress: CONTRACT })).toBe(
-        ZERO,
-      )
+      expect(
+        await instance.allowance({
+          tokenAddress: TOKEN_8,
+          userAddress: USER_1,
+          spenderAddress: CONTRACT,
+          networkId: NETWORK_ID,
+        }),
+      ).toBe(ZERO)
     })
 
     it('spender allowance 0 returns 0', async () => {
-      expect(await instance.allowance({ tokenAddress: TOKEN_1, userAddress: USER_1, spenderAddress: CONTRACT })).toBe(
-        ZERO,
-      )
+      expect(
+        await instance.allowance({
+          tokenAddress: TOKEN_1,
+          userAddress: USER_1,
+          spenderAddress: CONTRACT,
+          networkId: NETWORK_ID,
+        }),
+      ).toBe(ZERO)
     })
   })
 
   describe('totalSupply', () => {
     it('returns totalSupply', async () => {
-      expect(await instance.totalSupply({ tokenAddress: TOKEN_1 })).toBe(ALLOWANCE_MAX_VALUE)
+      expect(await instance.totalSupply({ tokenAddress: TOKEN_1, networkId: NETWORK_ID })).toBe(ALLOWANCE_MAX_VALUE)
     })
   })
 
   describe('name', () => {
     it('returns name', async () => {
-      expect(await instance.name({ tokenAddress: FEE_TOKEN })).toBe('Fee token')
+      expect(await instance.name({ tokenAddress: FEE_TOKEN, networkId: NETWORK_ID })).toBe('Fee token')
     })
     it("throws when there's no name", async () => {
       try {
-        await instance.name({ tokenAddress: TOKEN_1 })
+        await instance.name({ tokenAddress: TOKEN_1, networkId: NETWORK_ID })
         fail('Should not reach')
       } catch (e) {
         expect(e.message).toMatch(/token does not implement 'name'/)
@@ -83,11 +107,11 @@ describe('Basic view functions', () => {
 
   describe('symbol', () => {
     it('returns symbol', async () => {
-      expect(await instance.symbol({ tokenAddress: FEE_TOKEN })).toBe('FEET')
+      expect(await instance.symbol({ tokenAddress: FEE_TOKEN, networkId: NETWORK_ID })).toBe('FEET')
     })
     it("throws when there's no symbol", async () => {
       try {
-        await instance.symbol({ tokenAddress: TOKEN_1 })
+        await instance.symbol({ tokenAddress: TOKEN_1, networkId: NETWORK_ID })
         fail('Should not reach')
       } catch (e) {
         expect(e.message).toMatch(/token does not implement 'symbol'/)
@@ -97,11 +121,11 @@ describe('Basic view functions', () => {
 
   describe('decimals', () => {
     it('returns decimals', async () => {
-      expect(await instance.decimals({ tokenAddress: FEE_TOKEN })).toBe(18)
+      expect(await instance.decimals({ tokenAddress: FEE_TOKEN, networkId: NETWORK_ID })).toBe(18)
     })
     it("throws when there's no decimals", async () => {
       try {
-        await instance.decimals({ tokenAddress: TOKEN_1 })
+        await instance.decimals({ tokenAddress: TOKEN_1, networkId: NETWORK_ID })
         fail('Should not reach')
       } catch (e) {
         expect(e.message).toMatch(/token does not implement 'decimals'/)
@@ -131,11 +155,17 @@ describe('Write functions', () => {
         spenderAddress: USER_2,
         amount,
         txOptionalParams,
+        networkId: NETWORK_ID,
       })
 
-      expect(await instance.allowance({ tokenAddress: TOKEN_1, userAddress: USER_1, spenderAddress: USER_2 })).toBe(
-        amount,
-      )
+      expect(
+        await instance.allowance({
+          tokenAddress: TOKEN_1,
+          userAddress: USER_1,
+          spenderAddress: USER_2,
+          networkId: NETWORK_ID,
+        }),
+      ).toBe(amount)
       expect(result).toBe(RECEIPT)
     })
 
@@ -146,6 +176,7 @@ describe('Write functions', () => {
         spenderAddress: USER_2,
         amount,
         txOptionalParams,
+        networkId: NETWORK_ID,
       })
       expect(mockFunction.mock.calls.length).toBe(1)
     })
@@ -154,27 +185,38 @@ describe('Write functions', () => {
   describe('transfer', () => {
     const amount = new BN('987542934752394')
     it('transfers', async () => {
-      const contractBalance = await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: CONTRACT })
-      const userBalance = await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_2 })
+      const contractBalance = await instance.balanceOf({
+        tokenAddress: TOKEN_1,
+        userAddress: CONTRACT,
+        networkId: NETWORK_ID,
+      })
+      const userBalance = await instance.balanceOf({
+        tokenAddress: TOKEN_1,
+        userAddress: USER_2,
+        networkId: NETWORK_ID,
+      })
 
       const result = await instance.transfer({
         userAddress: CONTRACT,
         tokenAddress: TOKEN_1,
         toAddress: USER_2,
         amount,
+        networkId: NETWORK_ID,
       })
 
-      expect(await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: CONTRACT })).toEqual(
+      expect(await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: CONTRACT, networkId: NETWORK_ID })).toEqual(
         contractBalance.sub(amount),
       )
-      expect(await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_2 })).toEqual(userBalance.add(amount))
+      expect(await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_2, networkId: NETWORK_ID })).toEqual(
+        userBalance.add(amount),
+      )
       expect(result).toBe(RECEIPT)
     })
 
     it('does not transfer when balance is insufficient', async () => {
       // TODO: after hours, couldn't figure out a way to check for the AssertionError using expect().toThrow()
       await instance
-        .transfer({ userAddress: USER_2, tokenAddress: TOKEN_1, toAddress: CONTRACT, amount })
+        .transfer({ userAddress: USER_2, tokenAddress: TOKEN_1, toAddress: CONTRACT, amount, networkId: NETWORK_ID })
         .then(() => fail('Should not succeed'))
         .catch(e => {
           expect(e.message).toMatch(/^The user doesn't have enough balance$/)
@@ -188,6 +230,7 @@ describe('Write functions', () => {
         toAddress: USER_2,
         amount,
         txOptionalParams,
+        networkId: NETWORK_ID,
       })
       expect(mockFunction.mock.calls.length).toBe(1)
     })
@@ -196,14 +239,20 @@ describe('Write functions', () => {
     const amount = new BN('78565893578')
 
     it('transfers and allowance is deduced', async () => {
-      const expectedUser1Balance = (await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_1 })).sub(
-        amount,
-      )
-      const expectedUser2Balance = (await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_2 })).add(
-        amount,
-      )
+      const expectedUser1Balance = (
+        await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_1, networkId: NETWORK_ID })
+      ).sub(amount)
+      const expectedUser2Balance = (
+        await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_2, networkId: NETWORK_ID })
+      ).add(amount)
 
-      await instance.approve({ userAddress: USER_1, tokenAddress: TOKEN_1, spenderAddress: USER_3, amount })
+      await instance.approve({
+        userAddress: USER_1,
+        tokenAddress: TOKEN_1,
+        spenderAddress: USER_3,
+        amount,
+        networkId: NETWORK_ID,
+      })
 
       const result = await instance.transferFrom({
         userAddress: USER_3,
@@ -211,21 +260,46 @@ describe('Write functions', () => {
         fromAddress: USER_1,
         toAddress: USER_2,
         amount,
+        networkId: NETWORK_ID,
       })
 
-      expect(await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_1 })).toEqual(expectedUser1Balance)
-      expect(await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_2 })).toEqual(expectedUser2Balance)
+      expect(await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_1, networkId: NETWORK_ID })).toEqual(
+        expectedUser1Balance,
+      )
+      expect(await instance.balanceOf({ tokenAddress: TOKEN_1, userAddress: USER_2, networkId: NETWORK_ID })).toEqual(
+        expectedUser2Balance,
+      )
       expect(
-        (await instance.allowance({ tokenAddress: TOKEN_1, userAddress: USER_1, spenderAddress: USER_3 })).toString(),
+        (
+          await instance.allowance({
+            tokenAddress: TOKEN_1,
+            userAddress: USER_1,
+            spenderAddress: USER_3,
+            networkId: NETWORK_ID,
+          })
+        ).toString(),
       ).toEqual(ZERO.toString())
       expect(result).toBe(RECEIPT)
     })
 
     it('does not transfer when balance is insufficient', async () => {
-      await instance.approve({ userAddress: USER_2, tokenAddress: TOKEN_3, spenderAddress: USER_3, amount })
+      await instance.approve({
+        userAddress: USER_2,
+        tokenAddress: TOKEN_3,
+        spenderAddress: USER_3,
+        amount,
+        networkId: NETWORK_ID,
+      })
 
       await instance
-        .transferFrom({ userAddress: USER_3, tokenAddress: TOKEN_3, fromAddress: USER_2, toAddress: USER_1, amount })
+        .transferFrom({
+          userAddress: USER_3,
+          tokenAddress: TOKEN_3,
+          fromAddress: USER_2,
+          toAddress: USER_1,
+          amount,
+          networkId: NETWORK_ID,
+        })
         .then(() => {
           fail('Should not succeed')
         })
@@ -236,7 +310,14 @@ describe('Write functions', () => {
 
     it('does not transfer when allowance is insufficient', async () => {
       await instance
-        .transferFrom({ userAddress: USER_3, tokenAddress: TOKEN_3, fromAddress: USER_1, toAddress: USER_2, amount })
+        .transferFrom({
+          userAddress: USER_3,
+          tokenAddress: TOKEN_3,
+          fromAddress: USER_1,
+          toAddress: USER_2,
+          amount,
+          networkId: NETWORK_ID,
+        })
         .then(() => {
           fail('Should not succeed')
         })
@@ -246,7 +327,13 @@ describe('Write functions', () => {
     })
 
     it('calls optional callback', async () => {
-      await instance.approve({ userAddress: USER_1, tokenAddress: TOKEN_1, spenderAddress: USER_3, amount })
+      await instance.approve({
+        userAddress: USER_1,
+        tokenAddress: TOKEN_1,
+        spenderAddress: USER_3,
+        amount,
+        networkId: NETWORK_ID,
+      })
       await instance.transferFrom({
         userAddress: USER_3,
         tokenAddress: TOKEN_1,
@@ -254,6 +341,7 @@ describe('Write functions', () => {
         toAddress: USER_2,
         amount,
         txOptionalParams,
+        networkId: NETWORK_ID,
       })
       expect(mockFunction.mock.calls.length).toBe(1)
     })


### PR DESCRIPTION
Part of #329 
Follow up to/depends on #388 

Making Erc20, Deposit and Exchange APIs network agnostic.
All calls that do contract interaction now require `networkId`

### Next step
Start proxy/cache layer implementation.
