### PR TITLE
Calculate price

### DIFF
--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -19,7 +19,7 @@ import {
   isBatchIdFarInTheFuture,
   formatDateFromBatchId,
   isOrderActive,
-  formatPriceBigNumber,
+  formatPrice,
 } from 'utils'
 import { onErrorFactory } from 'utils/onError'
 import { MIN_UNLIMITED_SELL_ORDER } from 'const'
@@ -108,7 +108,7 @@ function calculatePrice(numeratorString?: string | null, denominatorString?: str
     const numerator = new BigNumber(numeratorString)
     const denominator = new BigNumber(denominatorString)
 
-    price = formatPriceBigNumber(numerator, denominator)
+    price = formatPrice(numerator, denominator)
   }
 
   return price || 'N/A'

--- a/src/components/TradeWidget/OrderDetails.tsx
+++ b/src/components/TradeWidget/OrderDetails.tsx
@@ -4,6 +4,8 @@ import styled from 'styled-components'
 import { FEE_PERCENTAGE } from 'const'
 import Highlight from 'components/Highlight'
 
+const DECIMALS_FOR_PRICE = 4
+
 const Wrapper = styled.dl`
   margin: 2em 0 0 0;
   font-size: 0.8em;
@@ -18,8 +20,7 @@ const Wrapper = styled.dl`
   }
 `
 
-// TODO: move to utils?
-function calculatePrice(sellAmount: number, receiveAmount: number): number {
+function _calculatePrice(sellAmount: number, receiveAmount: number): number {
   return sellAmount > 0 ? receiveAmount / sellAmount : 0
 }
 
@@ -38,9 +39,7 @@ const OrderDetails: React.FC<Props> = ({ sellAmount, sellTokenName, receiveAmoun
     return null
   }
 
-  function _calculatePrice(): string {
-    return calculatePrice(sellAmountNumber, receiveAmountNumber).toFixed(2)
-  }
+  const price = _calculatePrice(sellAmountNumber, receiveAmountNumber).toFixed(DECIMALS_FOR_PRICE)
 
   return (
     <Wrapper>
@@ -52,7 +51,7 @@ const OrderDetails: React.FC<Props> = ({ sellAmount, sellTokenName, receiveAmoun
         </Highlight>{' '}
         at a price{' '}
         <Highlight>
-          1 {sellTokenName} = {_calculatePrice()} {receiveTokenName}
+          1 {sellTokenName} = {price} {receiveTokenName}
         </Highlight>{' '}
         or better. <br />
         Your order might be partially filled.

--- a/src/components/TradeWidget/OrderDetails.tsx
+++ b/src/components/TradeWidget/OrderDetails.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
+import BigNumber from 'bignumber.js'
 
 import { FEE_PERCENTAGE } from 'const'
 import Highlight from 'components/Highlight'
-
-const DECIMALS_FOR_PRICE = 4
+import { formatPrice } from 'utils'
 
 const Wrapper = styled.dl`
   margin: 2em 0 0 0;
@@ -20,10 +20,6 @@ const Wrapper = styled.dl`
   }
 `
 
-function _calculatePrice(sellAmount: number, receiveAmount: number): number {
-  return sellAmount > 0 ? receiveAmount / sellAmount : 0
-}
-
 interface Props {
   sellAmount: string
   sellTokenName: string
@@ -31,15 +27,19 @@ interface Props {
   receiveTokenName: string
 }
 
-const OrderDetails: React.FC<Props> = ({ sellAmount, sellTokenName, receiveAmount, receiveTokenName }) => {
-  const sellAmountNumber = Number(sellAmount)
-  const receiveAmountNumber = Number(receiveAmount)
+const OrderDetails: React.FC<Props> = ({
+  sellAmount: sellAmountString,
+  sellTokenName,
+  receiveAmount: receiveAmountString,
+  receiveTokenName,
+}) => {
+  const sellAmount = new BigNumber(sellAmountString)
+  const receiveAmount = new BigNumber(receiveAmountString)
 
-  if (!(sellAmountNumber > 0 && receiveAmountNumber > 0)) {
+  const price = formatPrice(sellAmount, receiveAmount)
+  if (!price) {
     return null
   }
-
-  const price = _calculatePrice(sellAmountNumber, receiveAmountNumber).toFixed(DECIMALS_FOR_PRICE)
 
   return (
     <Wrapper>
@@ -47,7 +47,7 @@ const OrderDetails: React.FC<Props> = ({ sellAmount, sellTokenName, receiveAmoun
       <dt>
         Sell up to{' '}
         <Highlight>
-          {sellAmount} {sellTokenName}
+          {sellAmountString} {sellTokenName}
         </Highlight>{' '}
         at a price{' '}
         <Highlight>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,6 +1,7 @@
 import BN from 'bn.js'
 import { TEN, DEFAULT_PRECISION } from 'const'
 import { TokenDetails } from 'types'
+import BigNumber from 'bignumber.js'
 
 const DEFAULT_DECIMALS = 4
 const ELLIPSIS = '...'
@@ -139,4 +140,22 @@ export function safeFilledToken<T extends TokenDetails>(token: T): T {
     name: token.name || token.symbol || abbreviateString(token.address, 6, 4),
     symbol: token.symbol || token.name || abbreviateString(token.address, 6, 4),
   }
+}
+
+export function calculatePriceBigNumber(numerator?: BigNumber, denominator?: BigNumber): BigNumber | null {
+  if (!numerator || !denominator) {
+    return null
+  }
+
+  return numerator.dividedBy(denominator)
+}
+
+export function formatPriceBigNumber(
+  numerator?: BigNumber,
+  denominator?: BigNumber,
+  decimals = DEFAULT_DECIMALS,
+): string | null {
+  const price = calculatePriceBigNumber(numerator, denominator)
+
+  return price ? price.toFixed(decimals) : 'N/A'
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -150,12 +150,12 @@ export function calculatePriceBigNumber(numerator?: BigNumber, denominator?: Big
   return numerator.dividedBy(denominator)
 }
 
-export function formatPriceBigNumber(
+export function formatPrice(
   numerator?: BigNumber,
   denominator?: BigNumber,
   decimals = DEFAULT_DECIMALS,
 ): string | null {
   const price = calculatePriceBigNumber(numerator, denominator)
 
-  return price ? price.toFixed(decimals) : 'N/A'
+  return price ? price.toFixed(decimals) : null
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -143,7 +143,7 @@ export function safeFilledToken<T extends TokenDetails>(token: T): T {
 }
 
 export function calculatePriceBigNumber(numerator?: BigNumber, denominator?: BigNumber): BigNumber | null {
-  if (!numerator || !denominator) {
+  if (!numerator || !denominator || denominator.isZero()) {
     return null
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1462,15 +1462,6 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.13.0":
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.13.0.tgz#958614faa6f77599ee2b241740e0ea402482533d"
-  integrity sha512-+Hss3clwa6aNiC8ZjA45wEm4FutDV5HsVXPl/rDug1THq6gEtOYRGLqS3JlTk7mSnL5TbJz0LpEbzbPnKvY6sw==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.13.0"
-    eslint-scope "^5.0.0"
-
 "@typescript-eslint/experimental-utils@2.14.0", "@typescript-eslint/experimental-utils@^2.5.0":
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.14.0.tgz#e9179fa3c44e00b3106b85d7b69342901fb43e3b"
@@ -1489,19 +1480,6 @@
     "@typescript-eslint/experimental-utils" "2.14.0"
     "@typescript-eslint/typescript-estree" "2.14.0"
     eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/typescript-estree@2.13.0":
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.13.0.tgz#a2e746867da772c857c13853219fced10d2566bc"
-  integrity sha512-t21Mg5cc8T3ADEUGwDisHLIubgXKjuNRbkpzDMLb7/JMmgCe/gHM9FaaujokLey+gwTuLF5ndSQ7/EfQqrQx4g==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash.unescape "4.0.1"
-    semver "^6.3.0"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@2.14.0":
   version "2.14.0"


### PR DESCRIPTION
* Creates a format price function
* Refactor between orders and trade details regarding the format of the price
* It leaves for decimals as a default
* Improves https://github.com/gnosis/dex-react/pull/397 

Doesn't include: any styling. With more decimals, the rows are a big broken. I can easily fix this, but @W3stside is working on the styling of the orders and I want to separate the 2 PRs to avoid any conflict.