### PR TITLE
Gas station

### DIFF
--- a/src/api/deposit/DepositApi.ts
+++ b/src/api/deposit/DepositApi.ts
@@ -7,6 +7,7 @@ import { getAddressForNetwork } from './batchExchangeAddresses'
 import { Receipt, TxOptionalParams } from 'types'
 
 import Web3 from 'web3'
+import fetchGasPrice from 'api/gasStation'
 
 interface ReadOnlyParams {
   userAddress: string
@@ -132,7 +133,9 @@ export class DepositApiImpl implements DepositApi {
   }: DepositParams): Promise<Receipt> {
     const contract = await this._getContract(networkId)
     // TODO: Remove temporal fix for web3. See https://github.com/gnosis/dex-react/issues/231
-    const tx = contract.methods.deposit(tokenAddress, amount.toString()).send({ from: userAddress })
+    const tx = contract.methods
+      .deposit(tokenAddress, amount.toString())
+      .send({ from: userAddress, gasPrice: await fetchGasPrice() })
 
     if (txOptionalParams && txOptionalParams.onSentTransaction) {
       tx.once('transactionHash', txOptionalParams.onSentTransaction)
@@ -151,7 +154,9 @@ export class DepositApiImpl implements DepositApi {
   }: RequestWithdrawParams): Promise<Receipt> {
     const contract = await this._getContract(networkId)
     // TODO: Remove temporal fix for web3. See https://github.com/gnosis/dex-react/issues/231
-    const tx = contract.methods.requestWithdraw(tokenAddress, amount.toString()).send({ from: userAddress })
+    const tx = contract.methods
+      .requestWithdraw(tokenAddress, amount.toString())
+      .send({ from: userAddress, gasPrice: await fetchGasPrice() })
 
     if (txOptionalParams?.onSentTransaction) {
       tx.once('transactionHash', txOptionalParams.onSentTransaction)
@@ -163,7 +168,9 @@ export class DepositApiImpl implements DepositApi {
 
   public async withdraw({ userAddress, tokenAddress, networkId, txOptionalParams }: WithdrawParams): Promise<Receipt> {
     const contract = await this._getContract(networkId)
-    const tx = contract.methods.withdraw(userAddress, tokenAddress).send({ from: userAddress })
+    const tx = contract.methods
+      .withdraw(userAddress, tokenAddress)
+      .send({ from: userAddress, gasPrice: await fetchGasPrice() })
 
     if (txOptionalParams?.onSentTransaction) {
       tx.once('transactionHash', txOptionalParams.onSentTransaction)

--- a/src/api/erc20/Erc20Api.ts
+++ b/src/api/erc20/Erc20Api.ts
@@ -9,6 +9,8 @@ import { toBN } from 'utils'
 
 import Web3 from 'web3'
 
+import fetchGasPrice from 'api/gasStation'
+
 interface BaseParams {
   tokenAddress: string
   networkId: number
@@ -143,6 +145,7 @@ export class Erc20ApiImpl implements Erc20Api {
     // TODO: Remove temporal fix for web3. See https://github.com/gnosis/dex-react/issues/231
     const tx = erc20.methods.approve(spenderAddress, amount.toString()).send({
       from: userAddress,
+      gasPrice: await fetchGasPrice(),
     })
 
     if (txOptionalParams?.onSentTransaction) {
@@ -165,6 +168,7 @@ export class Erc20ApiImpl implements Erc20Api {
     // TODO: Remove temporal fix for web3. See https://github.com/gnosis/dex-react/issues/231
     const tx = erc20.methods.transfer(toAddress, amount.toString()).send({
       from: userAddress,
+      gasPrice: await fetchGasPrice(),
     })
 
     if (txOptionalParams?.onSentTransaction) {
@@ -187,6 +191,7 @@ export class Erc20ApiImpl implements Erc20Api {
 
     const tx = erc20.methods.transferFrom(userAddress, toAddress, amount.toString()).send({
       from: fromAddress,
+      gasPrice: await fetchGasPrice(),
     })
 
     if (txOptionalParams?.onSentTransaction) {

--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -1,10 +1,9 @@
 import BN from 'bn.js'
-import { DepositApiImpl, DepositApi } from 'api/deposit/DepositApi'
+import { DepositApiImpl, DepositApi, InjectedDependencies } from 'api/deposit/DepositApi'
 import { Receipt, TxOptionalParams } from 'types'
 import { log } from 'utils'
 import Web3 from 'web3'
 import { decodeAuctionElements } from './utils/decodeAuctionElements'
-import fetchGasPrice from 'api/gasStation'
 
 interface BaseParams {
   networkId: number
@@ -79,8 +78,8 @@ export interface Order {
  * Basic implementation of Stable Coin Converter API
  */
 export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
-  public constructor(web3: Web3) {
-    super(web3)
+  public constructor(web3: Web3, injectedDependencies: InjectedDependencies) {
+    super(web3, injectedDependencies)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(window as any).exchange = this._contractPrototype
   }
@@ -126,7 +125,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
 
   public async addToken({ userAddress, tokenAddress, networkId, txOptionalParams }: AddTokenParams): Promise<Receipt> {
     const contract = await this._getContract(networkId)
-    const tx = contract.methods.addToken(tokenAddress).send({ from: userAddress, gasPrice: await fetchGasPrice() })
+    const tx = contract.methods.addToken(tokenAddress).send({ from: userAddress, gasPrice: await this.fetchGasPrice() })
 
     if (txOptionalParams && txOptionalParams.onSentTransaction) {
       tx.once('transactionHash', txOptionalParams.onSentTransaction)
@@ -154,7 +153,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     // TODO: Remove temporal fix for web3. See https://github.com/gnosis/dex-react/issues/231
     const tx = contract.methods
       .placeOrder(buyTokenId, sellTokenId, validUntil, buyAmount.toString(), sellAmount.toString())
-      .send({ from: userAddress, gasPrice: await fetchGasPrice() })
+      .send({ from: userAddress, gasPrice: await this.fetchGasPrice() })
 
     if (txOptionalParams && txOptionalParams.onSentTransaction) {
       tx.once('transactionHash', txOptionalParams.onSentTransaction)
@@ -177,7 +176,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     txOptionalParams,
   }: CancelOrdersParams): Promise<Receipt> {
     const contract = await this._getContract(networkId)
-    const tx = contract.methods.cancelOrders(orderIds).send({ from: userAddress, gasPrice: await fetchGasPrice() })
+    const tx = contract.methods.cancelOrders(orderIds).send({ from: userAddress, gasPrice: await this.fetchGasPrice() })
 
     if (txOptionalParams && txOptionalParams.onSentTransaction) {
       tx.once('transactionHash', txOptionalParams.onSentTransaction)

--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -4,6 +4,7 @@ import { Receipt, TxOptionalParams } from 'types'
 import { log } from 'utils'
 import Web3 from 'web3'
 import { decodeAuctionElements } from './utils/decodeAuctionElements'
+import fetchGasPrice from 'api/gasStation'
 
 interface BaseParams {
   networkId: number
@@ -125,7 +126,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
 
   public async addToken({ userAddress, tokenAddress, networkId, txOptionalParams }: AddTokenParams): Promise<Receipt> {
     const contract = await this._getContract(networkId)
-    const tx = contract.methods.addToken(tokenAddress).send({ from: userAddress })
+    const tx = contract.methods.addToken(tokenAddress).send({ from: userAddress, gasPrice: await fetchGasPrice() })
 
     if (txOptionalParams && txOptionalParams.onSentTransaction) {
       tx.once('transactionHash', txOptionalParams.onSentTransaction)
@@ -153,7 +154,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     // TODO: Remove temporal fix for web3. See https://github.com/gnosis/dex-react/issues/231
     const tx = contract.methods
       .placeOrder(buyTokenId, sellTokenId, validUntil, buyAmount.toString(), sellAmount.toString())
-      .send({ from: userAddress })
+      .send({ from: userAddress, gasPrice: await fetchGasPrice() })
 
     if (txOptionalParams && txOptionalParams.onSentTransaction) {
       tx.once('transactionHash', txOptionalParams.onSentTransaction)
@@ -176,7 +177,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     txOptionalParams,
   }: CancelOrdersParams): Promise<Receipt> {
     const contract = await this._getContract(networkId)
-    const tx = contract.methods.cancelOrders(orderIds).send({ from: userAddress })
+    const tx = contract.methods.cancelOrders(orderIds).send({ from: userAddress, gasPrice: await fetchGasPrice() })
 
     if (txOptionalParams && txOptionalParams.onSentTransaction) {
       tx.once('transactionHash', txOptionalParams.onSentTransaction)

--- a/src/api/gasStation.ts
+++ b/src/api/gasStation.ts
@@ -1,0 +1,65 @@
+import { walletApi } from './'
+
+const GAS_STATIONS = {
+  1: 'https://safe-relay.gnosis.pm/api/v1/gas-station/',
+  4: 'https://safe-relay.staging.gnosisdev.com/api/v1/gas-station/',
+}
+
+const GAS_PRICE_LEVEL: Exclude<keyof GasStationResponse, 'lastUpdate'> = 'standard'
+
+let cacheKey = ''
+let cachedGasPrice: undefined | string
+
+const constructKey = ({ blockNumber, chainId }: GasPriceCacheDeps): string => chainId + '@' + blockNumber
+
+interface GasPriceCacheDeps {
+  blockNumber: number | null
+  chainId: number
+}
+
+interface GasStationResponse {
+  lastUpdate: string
+  lowest: string
+  safeLow: string
+  standard: string
+  fast: string
+  fastest: string
+}
+
+const fetchGasPrice = async (): Promise<string | undefined> => {
+  const { blockchainState } = walletApi
+
+  if (!blockchainState) return undefined
+
+  const { chainId, blockHeader } = blockchainState
+
+  // only fetch new gasPrice when chainId or blockNumber changed
+  const key = constructKey({ chainId, blockNumber: blockHeader && blockHeader.number })
+  if (key === cacheKey) {
+    console.log('gasPrice from cache', cachedGasPrice)
+    return cachedGasPrice
+  }
+
+  const gasStationURL = GAS_STATIONS[chainId]
+
+  if (!gasStationURL) return undefined
+
+  try {
+    const response = await fetch(gasStationURL)
+    const json: GasStationResponse = await response.json()
+
+    const gasPrice = json[GAS_PRICE_LEVEL]
+    if (gasPrice) {
+      cacheKey = key
+      cachedGasPrice = gasPrice
+      console.log('new gasPrice', gasPrice)
+
+      return gasPrice
+    }
+  } catch (error) {
+    console.error('Error fetching gasPrice from', gasStationURL, error)
+  }
+  return undefined
+}
+
+export default fetchGasPrice

--- a/src/api/gasStation.ts
+++ b/src/api/gasStation.ts
@@ -1,4 +1,4 @@
-import { walletApi } from './'
+import { WalletApi } from './wallet/WalletApi'
 
 const GAS_STATIONS = {
   1: 'https://safe-relay.gnosis.pm/api/v1/gas-station/',
@@ -26,7 +26,7 @@ interface GasStationResponse {
   fastest: string
 }
 
-const fetchGasPrice = async (): Promise<string | undefined> => {
+const fetchGasPriceFactory = (walletApi: WalletApi) => async (): Promise<string | undefined> => {
   const { blockchainState } = walletApi
 
   if (!blockchainState) return undefined
@@ -62,4 +62,4 @@ const fetchGasPrice = async (): Promise<string | undefined> => {
   return undefined
 }
 
-export default fetchGasPrice
+export default fetchGasPriceFactory

--- a/src/api/wallet/WalletApi.ts
+++ b/src/api/wallet/WalletApi.ts
@@ -37,6 +37,7 @@ export interface WalletApi {
   addOnChangeWalletInfo(callback: (walletInfo: WalletInfo) => void, trigger?: boolean): Command
   removeOnChangeWalletInfo(callback: (walletInfo: WalletInfo) => void): void
   getProviderInfo(): ProviderInfo
+  blockchainState: BlockchainUpdatePrompt
 }
 
 export interface WalletInfo {
@@ -160,6 +161,8 @@ export class WalletApiImpl implements WalletApi {
   private _provider: Provider | null
   private _web3: Web3
 
+  public blockchainState: BlockchainUpdatePrompt
+
   private _unsubscribe: Command = () => {
     // Empty comment to indicate this is on purpose: https://github.com/eslint/eslint/commit/c1c4f4d
   }
@@ -191,7 +194,18 @@ export class WalletApiImpl implements WalletApi {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(window as any).web3c = this._web3
 
-    await this._notifyListeners()
+    const {
+      accounts: [account],
+      chainId,
+    } = getProviderState(provider)
+
+    this.blockchainState = {
+      account,
+      chainId,
+      blockHeader: null,
+    }
+
+    await this._notifyListeners(this.blockchainState)
 
     const subscriptions = createSubscriptions(provider)
 
@@ -279,7 +293,9 @@ export class WalletApiImpl implements WalletApi {
 
   /* ****************      Private Functions      **************** */
 
-  private async _notifyListeners(): Promise<void> {
+  private async _notifyListeners(blockchainUpdate?: BlockchainUpdatePrompt): Promise<void> {
+    if (blockchainUpdate) this.blockchainState = blockchainUpdate
+
     await Promise.resolve()
     const walletInfo: WalletInfo = this.getWalletInfo()
     this._listeners.forEach(listener => listener(walletInfo))

--- a/src/api/wallet/WalletApiMock.ts
+++ b/src/api/wallet/WalletApiMock.ts
@@ -18,6 +18,12 @@ export class WalletApiMock implements WalletApi {
   private _balance: BN
   private _listeners: ((walletInfo: WalletInfo) => void)[]
 
+  public blockchainState = {
+    account: USER_1,
+    chainId: 1,
+    blockHeader: null,
+  }
+
   public constructor() {
     this._connected = process.env.AUTOCONNECT === 'true'
     this._user = USER_1


### PR DESCRIPTION
fetch **gasPrice** from gas station
only fetch when network or block has changed, cache otherwise

Maybe a better place for this logic would be in the upcoming Cache Layer. Then it could add `gasPrice` to `txOptionalParams` and pass onto the real `api.method`:


```ts
// in cache layer method
// only if method will send tx, not a call method

const txOptions = {
...txOptionalParams,
gasPrice: await fetchGasPrice(),
}

api.realMethod(args, txOptions)
```

Closes #348 
