### PR TITLE
Detect <doman>.eth.link  as IPFS

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -5,20 +5,20 @@
   <%if (htmlWebpackPlugin.options.ipfsHack) { %>
   <script>
     (function () {
-      const { pathname } = window.location
+      const { pathname, hostname } = window.location
       const ipfsMatch = /.*\/Qm\w{44}/.exec(pathname)
       const base = document.createElement('base')
       let baseHref
       if (ipfsMatch) {
 
         baseHref = ipfsMatch[0]
-        if (!baseHref.endsWith('/')) baseHref += '/'
-
-        window.IS_IPFS = true
-        
+        if (!baseHref.endsWith('/')) baseHref += '/'        
       } else {
         baseHref = '/'
       }
+
+      window.IS_IPFS = !!ipfsMatch || hostname.endsWith('.eth.link')
+
       base.href = baseHref
       document.head.append(base)
     })();


### PR DESCRIPTION
Currently when `window.location` is detected as belonging to IPFS we use HashRouter instead of BrowserRouter

Detection relies on matching `Qm<hash>` with `location.pathname`

If the app is hosted on EthDNS at `<domain>.eth.link` that detection fails and we can't start browsing at a non-index route, also can't refresh the page at a subroute

This PR adds detection for `location.hostname`