### PR TITLE
Comments for subscriptions helper

### DIFF
--- a/src/api/wallet/WalletApi.ts
+++ b/src/api/wallet/WalletApi.ts
@@ -83,7 +83,6 @@ const subscribeToBlockchainUpdate = ({
   const blockUpdate = (cb: (blockHeader: BlockHeader) => void): Command => {
     return subscribeToWeb3Event({
       web3,
-      interval: 8000,
       callback: cb,
       getter: web3 => web3.eth.getBlock('latest'),
       event: 'newBlockHeaders',

--- a/src/api/wallet/subscriptionHelpers.ts
+++ b/src/api/wallet/subscriptionHelpers.ts
@@ -40,13 +40,13 @@ const createWeb3Subscription = <T extends SubscribeEvent>({
         reject(e)
       }
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const params: [any, any] = (logOptions && event === 'logs'
-      ? [event, logOptions, detectValidSubCb]
-      : [event, detectValidSubCb]) as [T, Function]
-    // calls web3.eth.subscribe('pendingTransactions' | 'syncing' | 'newBlockHeaders', callback)
-    // or web3.eth.subscribe('logs', logOptions, callback)
-    const sub = web3.eth.subscribe(...params) as Subscription<Event2Data[T]>
+
+    const sub = (logOptions && event === 'logs'
+      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        web3.eth.subscribe(event as any, logOptions as any, detectValidSubCb)
+      : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        web3.eth.subscribe(event as any, detectValidSubCb)) as Subscription<Event2Data[T]>
+
     sub
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
       // @ts-ignore

--- a/src/api/wallet/subscriptionHelpers.ts
+++ b/src/api/wallet/subscriptionHelpers.ts
@@ -24,7 +24,8 @@ interface Event2Data {
   logs: Log
 }
 
-// detects if providerr supports any given subscription
+// detects if provider supports any given subscription
+// returns subscription or rejects
 const createWeb3Subscription = <T extends SubscribeEvent>({
   web3,
   event,
@@ -32,24 +33,31 @@ const createWeb3Subscription = <T extends SubscribeEvent>({
   callback,
 }: SubscribeParams<T>): Promise<() => void> => {
   return new Promise<Subscription<Event2Data[T]>>((resolve, reject) => {
+    // callback normally used as complition of on('error') and on('data') together
+    // but needed here because not all providers will call on('error')
     const detectValidSubCb = (e: Error): void => {
       if (e) {
         reject(e)
-        return
       }
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const params: [any, any] = (logOptions && event === 'logs'
       ? [event, logOptions, detectValidSubCb]
       : [event, detectValidSubCb]) as [T, Function]
+    // calls web3.eth.subscribe('pendingTransactions' | 'syncing' | 'newBlockHeaders', callback)
+    // or web3.eth.subscribe('logs', logOptions, callback)
     const sub = web3.eth.subscribe(...params) as Subscription<Event2Data[T]>
     sub
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
       // @ts-ignore
       .on('connected', id => {
+        // called with subscription id
+        // if subscribtion was created successfully
         log('Subscription id for', event, id)
         resolve(sub)
       })
+      // immediate reject on error
+      // some providers don't trigger it, only trigger error in callback
       .on('error', reject)
   }).then(sub => {
     sub.on('data', callback)
@@ -71,6 +79,7 @@ interface ConditionalIntervalCheck {
 }
 
 // calls callback inly when condition is true
+// conditionis checked on interval
 const conditionalIntervalCheck = ({
   interval = DEFAULT_BLOCK_INTERVAL,
   condition,
@@ -93,10 +102,14 @@ interface ChangedBlockState {
   error?: Error
 }
 
+// check based on current block number
+// intended to be used in polling interval
 const checkIfBlockChangedFactory = (web3: Web3): (() => Promise<ChangedBlockState>) => {
   // keep block number in closure
   let currentBlockNumber: number
 
+  // actual checking function
+  // comparison is with currentBlockNumber from parent scope
   return async (): Promise<ChangedBlockState> => {
     try {
       // quick check if new block was mined
@@ -113,13 +126,16 @@ const checkIfBlockChangedFactory = (web3: Web3): (() => Promise<ChangedBlockStat
   }
 }
 
+// subscribes to 'pendingTransactions' | 'syncing' | 'newBlockHeaders' | 'logs' event on web3.eth.seubscribe
 export const subscribeToWeb3Event = <T extends SubscribeEvent>(options: SubscribeParamsAlt<T>): Command => {
   const { web3, callback, getter, interval } = options
+  // first checks if possible to get native subscribtion (provider supports the event)
   const subscriptionPromise = createWeb3Subscription(options).catch(error => {
-    //   if subscription isn't supported
+    // if subscription isn't supported
     log('Error subscribing to', options.event, 'event:', error)
 
     // check on interval
+    // substituted in place of web3 subscription
     return conditionalIntervalCheck({
       interval,
       // factory condition to keep internal state


### PR DESCRIPTION
More comments for subscriptions helpers, as they are reportedly hard to read

In a sentence what happens is:

1. We want to sub to `newBlockHeaders`
2. We try to do it through `web3.eth.subscribe('newBlockHeaders')`
3. Works -- great
4. Doesn't -- start checking if block number changed on interval (supposed to be efficient, MMask does exactly that)
5. When changed, fetch new block

Also removes `interval`, which isn't used anyway, forgot to delete