### PR TITLE
Add balance for an unapproved token

### DIFF
--- a/src/components/DepositWidget/Row.tsx
+++ b/src/components/DepositWidget/Row.tsx
@@ -113,29 +113,31 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
         </td>
         <td data-label="Actions">
           {enabled ? (
+            <button onClick={(): void => showForm('deposit')} disabled={isDepositFormVisible}>
+              <FontAwesomeIcon icon={faPlus} />
+              &nbsp; Deposit
+            </button>
+          ) : (
             <>
-              <button onClick={(): void => showForm('deposit')} disabled={isDepositFormVisible}>
-                <FontAwesomeIcon icon={faPlus} />
-                &nbsp; Deposit
-              </button>
-              <button onClick={(): void => showForm('withdraw')} disabled={isWithdrawFormVisible} className="danger">
-                <FontAwesomeIcon icon={faMinus} />
-                &nbsp; Withdraw
+              <button className="success" onClick={onEnableToken} disabled={enabling.has(address)}>
+                {enabling.has(address) ? (
+                  <>
+                    <FontAwesomeIcon icon={faSpinner} spin />
+                    &nbsp; Enabling {symbol}
+                  </>
+                ) : (
+                  <>
+                    <FontAwesomeIcon icon={faCheck} />
+                    &nbsp; Enable {symbol}
+                  </>
+                )}
               </button>
             </>
-          ) : (
-            <button className="success" onClick={onEnableToken} disabled={enabling.has(address)}>
-              {enabling.has(address) ? (
-                <>
-                  <FontAwesomeIcon icon={faSpinner} spin />
-                  &nbsp; Enabling {symbol}
-                </>
-              ) : (
-                <>
-                  <FontAwesomeIcon icon={faCheck} />
-                  &nbsp; Enable {symbol}
-                </>
-              )}
+          )}
+          {!totalExchangeBalance.isZero() && (
+            <button onClick={(): void => showForm('withdraw')} disabled={isWithdrawFormVisible} className="danger">
+              <FontAwesomeIcon icon={faMinus} />
+              &nbsp; Withdraw
             </button>
           )}
         </td>

--- a/test/components/DepositWidget.components.test.tsx
+++ b/test/components/DepositWidget.components.test.tsx
@@ -76,7 +76,31 @@ describe('<Row /> enabled token', () => {
     expect(wrapper.find('td')).toHaveLength(5)
   })
 
-  it('contains 2 <button> elements (deposit and withdraw)', () => {
+  it('contains 1 <button> elements (deposit)', () => {
+    const wrapper = render(_createRow(tokenBalanceDetails))
+    expect(wrapper.find('button')).toHaveLength(1)
+  })
+})
+
+describe('<Row /> enabled token and wallet balance', () => {
+  const tokenBalanceDetails: Partial<TokenBalanceDetails> = {
+    enabled: true,
+    totalExchangeBalance: ONE,
+  }
+
+  it('contains 2 <button> elements (deposit + withdraw)', () => {
+    const wrapper = render(_createRow(tokenBalanceDetails))
+    expect(wrapper.find('button')).toHaveLength(2)
+  })
+})
+
+describe('<Row /> disabled token and wallet balance', () => {
+  const tokenBalanceDetails: Partial<TokenBalanceDetails> = {
+    enabled: false,
+    totalExchangeBalance: ONE,
+  }
+
+  it('contains 2 <button> elements (enable + withdraw)', () => {
     const wrapper = render(_createRow(tokenBalanceDetails))
     expect(wrapper.find('button')).toHaveLength(2)
   })
@@ -86,6 +110,7 @@ describe('<Row /> claimable token', () => {
   const tokenBalanceDetails: Partial<TokenBalanceDetails> = {
     enabled: true,
     claimable: true,
+    totalExchangeBalance: ONE,
     pendingWithdraw: createFlux(ONE),
   }
 

--- a/test/data/exchangeBalanceStates.ts
+++ b/test/data/exchangeBalanceStates.ts
@@ -39,7 +39,12 @@ export const exchangeBalanceStates: BalancesByUserAndToken = {
       },
     },
     [TOKEN_4]: STATE_ZERO, // 0. USDC: decimals=6
-    [TOKEN_5]: STATE_ZERO, // 0. PAX: decimals=18
+    [TOKEN_5]: {
+      // 0. PAX: decimals=18
+      balance: new BN('100144563322323'), // 50,048.29
+      pendingDeposits: createFlux(),
+      pendingWithdraws: createFlux(),
+    },
     [TOKEN_6]: {
       // 0. GUSD: decimals=2
       balance: new BN('5004829'), // 50,048.29


### PR DESCRIPTION
Closes #407 

* Allows to withdraw even if the token was not enabled.
* The "Withdraw" button is only shown if the user has a balance (no other condition is required)