### PR TITLE
Fix auto dark mode

### DIFF
--- a/src/components/ThemeToggler.tsx
+++ b/src/components/ThemeToggler.tsx
@@ -50,6 +50,8 @@ const ThemeToggler: React.FC = () => {
     if (className) {
       document.body.classList.add(className)
       localStorage.setItem(FUSE_APP_THEME, active)
+    } else {
+      localStorage.removeItem(FUSE_APP_THEME)
     }
   }, [active])
 


### PR DESCRIPTION
localStorage stick around across page refresh, as a result dark mode stays even when auto is chosen

To reproduce:

1. Select dark mode
2. Select auto
3. Refresh page