### PR TITLE
ValidFrom orders have now a wait period when no value is set

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -24,6 +24,11 @@ export const UNLIMITED_ORDER_AMOUNT_BIGNUMBER = new BigNumber(UNLIMITED_ORDER_AM
 export const FEE_DENOMINATOR = 1000 // Fee is 1/fee_denominator i.e. 1/1000 = 0.1%
 export const BATCH_TIME = 300
 export const DEFAULT_ORDER_DURATION = 6 // every batch takes 5min, we want it to be valid for 30min, ∴ 30/5 == 6
+// Placing FROM orders with validFrom === currentBatchId can fail if there's a new batch before the tx is mined.
+// To address that, we are adding a small delay to guarantee it won't fail.
+// For more info, see the issue https://github.com/gnosis/dex-react/issues/459 and
+// the contract code https://github.com/gnosis/dex-contracts/blob/master/contracts/BatchExchange.sol#L557
+export const BATCHES_TO_WAIT = 3
 // Furtherst batch id possible (uint32), must be a js Number
 export const MAX_BATCH_ID = 2 ** 32 - 1
 

--- a/src/hooks/usePlaceOrder.ts
+++ b/src/hooks/usePlaceOrder.ts
@@ -10,7 +10,7 @@ import { PlaceOrderParams as ExchangeApiPlaceOrderParams } from 'api/exchange/Ex
 import { log } from 'utils'
 import { txOptionalParams as defaultTxOptionalParams } from 'utils/transaction'
 import { useWalletConnection } from './useWalletConnection'
-import { DEFAULT_ORDER_DURATION } from 'const'
+import { DEFAULT_ORDER_DURATION, BATCHES_TO_WAIT } from 'const'
 import useSafeState from './useSafeState'
 
 interface PlaceOrderParams<T> {
@@ -147,8 +147,8 @@ export const usePlaceOrder = (): Result => {
           buyTokens.push(order.buyToken)
           sellTokens.push(order.sellToken)
 
-          // if not set, order is valid from placement
-          validFroms.push(order.validFrom || currentBatchId)
+          // if not set, order is valid from placement + wait period
+          validFroms.push(order.validFrom || currentBatchId + BATCHES_TO_WAIT)
           // if not set, order is valid forever
           validUntils.push(order.validUntil || MAX_BATCH_ID)
 

--- a/src/hooks/usePlaceOrder.ts
+++ b/src/hooks/usePlaceOrder.ts
@@ -148,7 +148,7 @@ export const usePlaceOrder = (): Result => {
           sellTokens.push(order.sellToken)
 
           // if not set, order is valid from placement + wait period
-          validFroms.push(order.validFrom || currentBatchId + BATCHES_TO_WAIT)
+          validFroms.push(order.validFrom ?? currentBatchId + BATCHES_TO_WAIT)
           // if not set, order is valid forever
           validUntils.push(order.validUntil || MAX_BATCH_ID)
 


### PR DESCRIPTION
Closes #459 

## Steps to reproduce:
1. Create a new liquidity
2. Send the transaction
3. Using metamask, keep the tx confirmation window open
4. After 5 min, confirm the tx

- On a version without the fix, tx failed https://rinkeby.etherscan.io/tx/0x4df9101bf5dc15acfaaa76c8fc831820b76564c0d677dfe09aa65837b2cb1c13
- On version with the fix, tx succeeded https://rinkeby.etherscan.io/tx/0xa8258c29e1e7371f2fc8b4c1501c563bc8ac7e46beea4e8593d209eb88785e54