### PR TITLE
Adding getOrdersPaginated method to ExchangeApi

### DIFF
--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -145,9 +145,11 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
       // no more pages left, indicate by not returning `nextIndex`
       return { orders }
     } else {
-      // there is at least 1 item in the next page,
-      // pop the extra element, get its id as nextIndex
-      const nextIndex = Number((orders.pop() as AuctionElement).id)
+      // there is at least 1 item in the next page
+      // pop the extra element
+      const nextPageOrder = orders.pop() as AuctionElement
+      // get its id as nextIndex
+      const nextIndex = Number(nextPageOrder.id)
       return { orders, nextIndex }
     }
   }

--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -125,16 +125,15 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     userAddress,
     networkId,
     offset,
-    pageSize,
+    pageSize = DEFAULT_ORDERS_PAGE_SIZE,
   }: GetOrdersPaginatedParams): Promise<GetOrdersPaginatedResult> {
     const contract = await this._getContract(networkId)
-    const _pageSize = pageSize || DEFAULT_ORDERS_PAGE_SIZE
 
     log(
-      `[ExchangeApiImpl] Getting Orders Paginated for account ${userAddress} with offset ${offset} and pageSize ${_pageSize}`,
+      `[ExchangeApiImpl] Getting Orders Paginated for account ${userAddress} with offset ${offset} and pageSize ${pageSize}`,
     )
 
-    const encodedOrders = await contract.methods.getEncodedUserOrdersPaginated(userAddress, offset, _pageSize).call()
+    const encodedOrders = await contract.methods.getEncodedUserOrdersPaginated(userAddress, offset, pageSize).call()
 
     // is null if Contract returns empty bytes
     if (!encodedOrders) return { orders: [] }
@@ -142,7 +141,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     const orders = decodeAuctionElements(encodedOrders, offset)
 
     let nextIndex: number | undefined
-    if (orders.length < _pageSize) {
+    if (orders.length < pageSize) {
       // no more pages left, indicate by not returning `nextIndex`
       nextIndex = undefined
     } else {

--- a/src/api/exchange/ExchangeApiMock.ts
+++ b/src/api/exchange/ExchangeApiMock.ts
@@ -66,18 +66,17 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
   public async getOrdersPaginated({
     userAddress,
     offset,
-    pageSize,
+    pageSize = DEFAULT_ORDERS_PAGE_SIZE,
   }: GetOrdersPaginatedParams): Promise<GetOrdersPaginatedResult> {
     this._initOrders(userAddress)
 
-    const _pageSize = pageSize || DEFAULT_ORDERS_PAGE_SIZE
-    const nextIndex = offset + _pageSize
+    const nextIndex = offset + pageSize
 
     const orders = this.orders[userAddress]
       .slice(offset, nextIndex)
       .map((order, index) => this.orderToAuctionElement(order, index + offset, userAddress))
 
-    if (orders.length < _pageSize) {
+    if (!this.orders[userAddress][nextIndex]) {
       return { orders }
     } else {
       return { orders, nextIndex }

--- a/src/api/exchange/ExchangeApiMock.ts
+++ b/src/api/exchange/ExchangeApiMock.ts
@@ -4,7 +4,7 @@ import assert from 'assert'
 
 import { DepositApiMock, BalancesByUserAndToken } from '../deposit/DepositApiMock'
 import { Receipt } from 'types'
-import { FEE_DENOMINATOR, ONE } from 'const'
+import { FEE_DENOMINATOR, ONE, DEFAULT_ORDERS_PAGE_SIZE } from 'const'
 import { waitAndSendReceipt } from 'utils/mock'
 import { RECEIPT } from '../../../test/data'
 import {
@@ -18,6 +18,8 @@ import {
   GetTokenAddressByIdParams,
   GetTokenIdByAddressParams,
   PlaceValidFromOrdersParams,
+  GetOrdersPaginatedParams,
+  GetOrdersPaginatedResult,
 } from './ExchangeApi'
 import { Erc20Api } from 'api/erc20/Erc20Api'
 
@@ -58,12 +60,28 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
 
   public async getOrders({ userAddress }: GetOrdersParams): Promise<AuctionElement[]> {
     this._initOrders(userAddress)
-    return this.orders[userAddress].map((order, index) => ({
-      ...order,
-      user: userAddress,
-      sellTokenBalance: new BN('1500000000000000000000').add(ONE),
-      id: index.toString(),
-    }))
+    return this.orders[userAddress].map((order, index) => this.orderToAuctionElement(order, index, userAddress))
+  }
+
+  public async getOrdersPaginated({
+    userAddress,
+    offset,
+    pageSize,
+  }: GetOrdersPaginatedParams): Promise<GetOrdersPaginatedResult> {
+    this._initOrders(userAddress)
+
+    const _pageSize = pageSize || DEFAULT_ORDERS_PAGE_SIZE
+    const nextIndex = offset + _pageSize
+
+    const orders = this.orders[userAddress]
+      .slice(offset, nextIndex)
+      .map((order, index) => this.orderToAuctionElement(order, index + offset, userAddress))
+
+    if (orders.length < _pageSize) {
+      return { orders }
+    } else {
+      return { orders, nextIndex }
+    }
   }
 
   public async getNumTokens(): Promise<number> {
@@ -174,6 +192,15 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
     const userOrders = this.orders[userAddress]
     if (!userOrders) {
       this.orders[userAddress] = []
+    }
+  }
+
+  private orderToAuctionElement(order: Order, index: number, userAddress: string): AuctionElement {
+    return {
+      ...order,
+      user: userAddress,
+      sellTokenBalance: new BN('1500000000000000000000').add(ONE),
+      id: index.toString(),
     }
   }
 }

--- a/src/api/exchange/utils/decodeAuctionElements.ts
+++ b/src/api/exchange/utils/decodeAuctionElements.ts
@@ -16,11 +16,13 @@ const orderPattern = `(${hn(ADDRESS_WIDTH)})(${hn(UINT256_WIDTH)})(${hn(UINT16_W
 )})(${hn(UINT32_WIDTH)})(${hn(UINT128_WIDTH)})(${hn(UINT128_WIDTH)})(${hn(UINT128_WIDTH)})`
 
 // decodes Orders
-export function decodeAuctionElements(bytes: string): AuctionElement[] {
+export function decodeAuctionElements(bytes: string, startingIndex?: number): AuctionElement[] {
   const result: AuctionElement[] = []
   const oneOrder = new RegExp(orderPattern, 'g')
   let order
-  let index = 0 // order ID is given by position and it's not part of the encoded data
+  // Order ID is given by position and it's not part of the encoded data
+  // Thus, we use the `startingIndex` if given, for using with paginated queries
+  let index = startingIndex || 0
 
   while ((order = oneOrder.exec(bytes))) {
     const [

--- a/src/const.ts
+++ b/src/const.ts
@@ -32,6 +32,9 @@ export const BATCHES_TO_WAIT = 3
 // Furtherst batch id possible (uint32), must be a js Number
 export const MAX_BATCH_ID = 2 ** 32 - 1
 
+// How many orders should we query per call, when invoking https://github.com/gnosis/dex-contracts/blob/master/contracts/BatchExchange.sol#L479
+export const DEFAULT_ORDERS_PAGE_SIZE = 10
+
 // UI constants
 export const HIGHLIGHT_TIME = 5000
 export const FEE_PERCENTAGE = (1 / FEE_DENOMINATOR) * 100 // syntactic sugar for displaying purposes

--- a/test/api/ExchangeApi/ExchangeApiMock.test.ts
+++ b/test/api/ExchangeApi/ExchangeApiMock.test.ts
@@ -88,7 +88,7 @@ describe('Basic view functions', () => {
       let ordersResult
 
       // Fetch orders, 1 by 1
-      for (let offset = 0; offset < 3; offset++) {
+      for (let offset = 0; offset < 2; offset++) {
         ordersResult = await instance.getOrdersPaginated({
           userAddress: USER_1,
           networkId: NETWORK_ID,
@@ -103,13 +103,14 @@ describe('Basic view functions', () => {
       ordersResult = await instance.getOrdersPaginated({
         userAddress: USER_1,
         networkId: NETWORK_ID,
-        offset: 3,
+        offset: 2,
         pageSize: 1,
       })
 
       // Check when no next, nextIndex is undefined
       expect(ordersResult.nextIndex).toBeUndefined()
-      expect(ordersResult.orders.length).toBe(0)
+      expect(ordersResult.orders.length).toBe(1)
+      expect(ordersResult.orders[0].id).toBe('2')
     })
   })
 })

--- a/test/api/ExchangeApi/ExchangeApiMock.test.ts
+++ b/test/api/ExchangeApi/ExchangeApiMock.test.ts
@@ -17,6 +17,16 @@ let mockErc20Api: Erc20Api
 const tokens = [FEE_TOKEN, TOKEN_1, TOKEN_2]
 const NETWORK_ID = 0
 
+const baseOrder = {
+  buyTokenId: 1,
+  sellTokenId: 2,
+  validFrom: 0,
+  validUntil: 6,
+  priceNumerator: ONE,
+  priceDenominator: ZERO,
+  remainingAmount: ONE,
+}
+
 beforeAll(() => {
   testHelpers.mockTimes()
 })
@@ -28,17 +38,7 @@ beforeEach(() => {
     erc20Api: mockErc20Api,
     registeredTokens: tokens,
     ordersByUser: {
-      [USER_1]: [
-        {
-          buyTokenId: 1,
-          sellTokenId: 2,
-          validFrom: 0,
-          validUntil: 6,
-          priceNumerator: ONE,
-          priceDenominator: ZERO,
-          remainingAmount: ONE,
-        },
-      ],
+      [USER_1]: [baseOrder],
     },
     maxTokens: 4,
   })
@@ -60,6 +60,56 @@ describe('Basic view functions', () => {
 
     it('returns all placed orders', async () => {
       expect(await instance.getOrders({ userAddress: USER_1, networkId: NETWORK_ID })).toHaveLength(1)
+    })
+  })
+
+  describe('get orders paginated', () => {
+    it('paginates offset=0 pageSize=undefined', async () => {
+      const ordersResult = await instance.getOrdersPaginated({ userAddress: USER_1, networkId: NETWORK_ID, offset: 0 })
+
+      expect(ordersResult.nextIndex).toBeUndefined()
+      expect(ordersResult.orders.length).toBe(1)
+    })
+
+    it('paginates offset=0 pageSize=1', async () => {
+      const orders = [baseOrder, { ...baseOrder, id: 1 }, { ...baseOrder, id: 2 }]
+
+      instance = new ExchangeApiMock({
+        balanceStates: {},
+        erc20Api: mockErc20Api,
+        registeredTokens: tokens,
+        ordersByUser: {
+          [USER_1]: orders,
+        },
+        maxTokens: 4,
+      })
+
+      const pageSize = 1
+      let ordersResult
+
+      // Fetch orders, 1 by 1
+      for (let offset = 0; offset < 3; offset++) {
+        ordersResult = await instance.getOrdersPaginated({
+          userAddress: USER_1,
+          networkId: NETWORK_ID,
+          offset,
+          pageSize,
+        })
+
+        expect(ordersResult.nextIndex).toBe(offset + pageSize)
+        expect(ordersResult.orders.length).toBe(pageSize)
+        expect(ordersResult.orders[0].id).toBe(offset.toString())
+      }
+      ordersResult = await instance.getOrdersPaginated({
+        userAddress: USER_1,
+        networkId: NETWORK_ID,
+        offset: 3,
+        pageSize: 1,
+      })
+
+      // Check when no next, nextIndex is undefined
+      expect(ordersResult.nextIndex).toBeUndefined()
+      expect(ordersResult.orders.length).toBe(0)
     })
   })
 })


### PR DESCRIPTION
Part of #455 

Implemented `getOrdersPaginated` corresponding to the contract's https://github.com/gnosis/dex-contracts/blob/master/contracts/BatchExchange.sol#L479

- `pageSize` is optional defaulting to `10`
- returns an object with `orders` and -- when there might be a next page -- `nextIndex`
