### PR TITLE
Updating dex-js to 0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/react-fontawesome": "^0.1.8",
     "@gnosis.pm/dapp-ui": "^0.5.3",
-    "@gnosis.pm/dex-js": "0.1.7",
+    "@gnosis.pm/dex-js": "0.1.8",
     "@hot-loader/react-dom": "^16.11.0",
     "@types/react": "^16.9.19",
     "@types/react-select": "^3.0.10",

--- a/test/api/ExchangeApi/TokenListApiMock.test.ts
+++ b/test/api/ExchangeApi/TokenListApiMock.test.ts
@@ -13,15 +13,15 @@ beforeEach(() => {
 })
 
 describe('MOCK: Basic view functions', () => {
-  test('Mock API Token list has length 7', () => {
+  test('Mock API Token list has length 8', () => {
     const tokens = instanceMock.getTokens(1)
-    expect(tokens.length).toBe(7)
+    expect(tokens.length).toBe(8)
   })
 })
 
 describe('REAL: Basic view functions', () => {
-  test('API Token list has length 7', () => {
+  test('API Token list has length 8', () => {
     const tokens = instanceReal.getTokens(1)
-    expect(tokens.length).toBe(7)
+    expect(tokens.length).toBe(8)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,10 +1110,10 @@
   dependencies:
     bn.js "^5.1.1"
 
-"@gnosis.pm/dex-js@0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.1.7.tgz#0db6dba2437a8e9bb2f192c63f86b7765d113847"
-  integrity sha512-0xM6QeFbMgjcv1zpeyOVKpP+8AosiiHeEeAX3x8xksvln9FeQK+V7rP1cej3BUPJSY4tYf1FE9+0Y3jRGNgWsQ==
+"@gnosis.pm/dex-js@0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.1.8.tgz#ac47c14d9f1cf6e11c3dc7d0adeed2feedc81482"
+  integrity sha512-rSXCa9Qmr3c9Swr9NuhvQX/XEngWzGOaRLfDNYvb8PSC4zx9p4iFN1xg1Mq7pQZEnpUrPai98+tNIJwkPJUJPA==
   dependencies:
     "@gnosis.pm/dex-contracts" "^0.2.0"
 


### PR DESCRIPTION
Per title.

You'll see now sUSD on deposit, trade and liquidity pages:

![screenshot_2020-01-30_10-31-25](https://user-images.githubusercontent.com/43217/73478911-c716f480-434b-11ea-9ad1-32e00e4fb050.png)

![screenshot_2020-01-30_10-31-37](https://user-images.githubusercontent.com/43217/73478898-c54d3100-434b-11ea-9d25-7347dd2a2623.png)

