### PR TITLE
455/paginating orders page

### DIFF
--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -130,7 +130,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     const contract = await this._getContract(networkId)
 
     log(
-      `[ExchangeApiImpl] Getting Orders Paginated for account ${userAddress} with offset ${offset} and pageSize ${pageSize}`,
+      `[ExchangeApiImpl] Getting Orders Paginated for account ${userAddress} on network ${networkId} with offset ${offset} and pageSize ${pageSize}`,
     )
 
     // query 1 more than required to check whether there's a next page

--- a/src/api/exchange/ExchangeApiMock.ts
+++ b/src/api/exchange/ExchangeApiMock.ts
@@ -22,6 +22,7 @@ import {
   GetOrdersPaginatedResult,
 } from './ExchangeApi'
 import { Erc20Api } from 'api/erc20/Erc20Api'
+import { wait } from 'utils'
 
 export interface OrdersByUser {
   [userAddress: string]: Order[]
@@ -69,6 +70,8 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
     pageSize = DEFAULT_ORDERS_PAGE_SIZE,
   }: GetOrdersPaginatedParams): Promise<GetOrdersPaginatedResult> {
     this._initOrders(userAddress)
+
+    await wait(5000)
 
     const nextIndex = offset + pageSize
 

--- a/src/api/proxy/CacheMixin.ts
+++ b/src/api/proxy/CacheMixin.ts
@@ -1,8 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import NodeCache from 'node-cache'
 
-import { log } from 'utils'
-
 interface CacheOptions<T> {
   method: keyof T
   ttl?: number
@@ -74,8 +72,6 @@ export class CacheMixin {
       return
     }
 
-    // TODO: remove when done testing
-    log(`cache hit for ${hash}`)
     return obj
   }
 

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -37,7 +37,7 @@ const ShowOrdersButton: React.FC<ShowOrdersButtonProps> = ({ type, isActive, sho
 }
 
 const OrdersWidget: React.FC = () => {
-  const allOrders = useOrders()
+  const { orders: allOrders, forceOrdersRefresh } = useOrders()
 
   const [orders, setOrders] = useSafeState<AuctionElement[]>(allOrders)
 
@@ -99,6 +99,9 @@ const OrdersWidget: React.FC = () => {
         // reset selections
         setOrders(orders.filter(order => !markedForDeletion.has(order.id)))
         setMarkedForDeletion(new Set<string>())
+
+        // update the list of orders
+        forceOrdersRefresh()
       }
     },
     [deleteOrders, markedForDeletion, orders, setMarkedForDeletion, setOrders],

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -104,7 +104,7 @@ const OrdersWidget: React.FC = () => {
         forceOrdersRefresh()
       }
     },
-    [deleteOrders, markedForDeletion, orders, setMarkedForDeletion, setOrders],
+    [deleteOrders, forceOrdersRefresh, markedForDeletion, orders, setMarkedForDeletion, setOrders],
   )
 
   return (

--- a/src/const.ts
+++ b/src/const.ts
@@ -33,7 +33,7 @@ export const BATCHES_TO_WAIT = 3
 export const MAX_BATCH_ID = 2 ** 32 - 1
 
 // How many orders should we query per call, when invoking https://github.com/gnosis/dex-contracts/blob/master/contracts/BatchExchange.sol#L479
-export const DEFAULT_ORDERS_PAGE_SIZE = 10
+export const DEFAULT_ORDERS_PAGE_SIZE = 50
 
 // UI constants
 export const HIGHLIGHT_TIME = 5000

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -70,7 +70,7 @@ export function useOrders(): Result {
             setOrders(filteredOrders)
           } else if (filteredOrders.length) {
             // incremental update: append
-            setOrders(curr => [...curr, ...filteredOrders])
+            setOrders(curr => curr.concat(filteredOrders))
           }
 
           // Save the last seen order

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -94,7 +94,7 @@ export function useOrders(): Result {
       }
 
       await exchangeApi.getOrdersPaginated({ userAddress, networkId, offset }).then(({ orders, nextIndex }) => {
-        if (orders.length) {
+        if (orders.length > 0) {
           // Apply filters (remove deleted orders)
           const filteredOrders = filterDeletedOrders(orders)
 
@@ -102,7 +102,7 @@ export function useOrders(): Result {
           if (offset === 0) {
             // fresh start/refresh: replace whatever is stored
             setOrdersState(curr => updateOrdersState(networkId, userAddress, curr, filteredOrders, false))
-          } else if (filteredOrders.length) {
+          } else if (filteredOrders.length > 0) {
             // incremental update: append
             setOrdersState(curr => updateOrdersState(networkId, userAddress, curr, filteredOrders, true))
           }

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -6,6 +6,12 @@ import { exchangeApi } from 'api'
 import { AuctionElement } from 'api/exchange/ExchangeApi'
 import { ZERO } from 'const'
 
+interface Result {
+  orders: AuctionElement[]
+  forceOrdersRefresh: () => void
+  isLoading: boolean
+}
+
 /**
  * Filter out deleted orders.
  *
@@ -26,12 +32,6 @@ function filterDeletedOrders(orders: AuctionElement[]): AuctionElement[] {
         order.validUntil === 0
       ),
   )
-}
-
-interface Result {
-  orders: AuctionElement[]
-  forceOrdersRefresh: () => void
-  isLoading: boolean
 }
 
 export function useOrders(): Result {

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -56,13 +56,13 @@ export function useOrders(): Result {
     userAddress &&
     networkId &&
     offset !== undefined && // stop querying for new orders when there are no more pages
-      exchangeApi.getOrdersPaginated({ userAddress, networkId, offset }).then(({ orders, nextIndex }) => {
-        if (orders.length) {
+      exchangeApi.getOrdersPaginated({ userAddress, networkId, offset }).then(({ orders: newOrders, nextIndex }) => {
+        if (newOrders.length) {
           // Save the id of last order before filtering
-          const orderId = +orders[orders.length - 1].id
+          const orderId = +newOrders[newOrders.length - 1].id
 
           // Apply filters (remove deleted orders)
-          const filteredOrders = filterDeletedOrders(orders)
+          const filteredOrders = filterDeletedOrders(newOrders)
 
           // Store new orders, if any
           if (offset === 0) {
@@ -75,6 +75,9 @@ export function useOrders(): Result {
 
           // Save the last seen order
           setLastSeenOrderId(orderId)
+        } else if (offset === 0 && orders.length > 0) {
+          // there were orders. we fetched again from the beginning, and now there are none (in the first page)
+          setOrders([])
         }
 
         // `nextIndex` can be `undefined`, which means there are no more pages


### PR DESCRIPTION
Part of #455 

Querying orders in pages.

- Increased page size to `50`
- Orders are queried on load until done.
- On new block, address/network change, query only from last order
- After confirming the cancellation/deletion of an order, refresh all orders from 0

## Warning

This is still a bit dumb. When switching pages, the orders are fetched from 0 again.
I'll address that in the next PR.

## Fetching from start, then updating only the top on new block

![screenshot_2020-01-31_12-47-56](https://user-images.githubusercontent.com/43217/73574066-9e652c80-4429-11ea-9778-10d944e9f02a.png)

## Deleting order and updating everything from start

![screenshot_2020-01-31_12-49-03](https://user-images.githubusercontent.com/43217/73574069-a0c78680-4429-11ea-91ad-cee18ca22249.png)
