### PR TITLE
482/define validity date

### DIFF
--- a/src/components/TradeWidget/OrderDetails.tsx
+++ b/src/components/TradeWidget/OrderDetails.tsx
@@ -4,8 +4,7 @@ import BigNumber from 'bignumber.js'
 
 import { FEE_PERCENTAGE } from 'const'
 import Highlight from 'components/Highlight'
-import { formatPrice } from 'utils'
-import { leadingAndTrailingZeros, trailingZerosAfterDot } from './TokenRow'
+import { formatPrice, formatValidity } from 'utils'
 
 const Wrapper = styled.dl`
   margin: 2em 0 0 0;
@@ -67,16 +66,7 @@ const OrderDetails: React.FC<Props> = ({
 
       <dd>Expiration date:</dd>
       <dt>
-        <Highlight>
-          {+validUntil == 0
-            ? 'Unlimited'
-            : `~
-          ${(+validUntil / 60)
-            .toFixed(2)
-            .replace(leadingAndTrailingZeros, '')
-            .replace(trailingZerosAfterDot, '$1')}
-          hours`}
-        </Highlight>
+        <Highlight>{formatValidity(validUntil)}</Highlight>
       </dt>
     </Wrapper>
   )

--- a/src/components/TradeWidget/OrderDetails.tsx
+++ b/src/components/TradeWidget/OrderDetails.tsx
@@ -8,7 +8,7 @@ import { formatPrice } from 'utils'
 
 const Wrapper = styled.dl`
   margin: 2em 0 0 0;
-  font-size: 0.8em;
+  font-size: 1rem;
 
   dd {
     font-weight: bold;

--- a/src/components/TradeWidget/OrderDetails.tsx
+++ b/src/components/TradeWidget/OrderDetails.tsx
@@ -68,12 +68,14 @@ const OrderDetails: React.FC<Props> = ({
       <dd>Expiration date:</dd>
       <dt>
         <Highlight>
-          ~
-          {(+validUntil / 60)
+          {+validUntil == 0
+            ? 'Unlimited'
+            : `~
+          ${(+validUntil / 60)
             .toFixed(2)
             .replace(leadingAndTrailingZeros, '')
-            .replace(trailingZerosAfterDot, '$1')}{' '}
-          hours
+            .replace(trailingZerosAfterDot, '$1')}
+          hours`}
         </Highlight>
       </dt>
     </Wrapper>

--- a/src/components/TradeWidget/OrderDetails.tsx
+++ b/src/components/TradeWidget/OrderDetails.tsx
@@ -5,6 +5,7 @@ import BigNumber from 'bignumber.js'
 import { FEE_PERCENTAGE } from 'const'
 import Highlight from 'components/Highlight'
 import { formatPrice } from 'utils'
+import { leadingAndTrailingZeros, trailingZerosAfterDot } from './TokenRow'
 
 const Wrapper = styled.dl`
   margin: 2em 0 0 0;
@@ -25,6 +26,7 @@ interface Props {
   sellTokenName: string
   receiveAmount: string
   receiveTokenName: string
+  validUntil: string
 }
 
 const OrderDetails: React.FC<Props> = ({
@@ -32,6 +34,7 @@ const OrderDetails: React.FC<Props> = ({
   sellTokenName,
   receiveAmount: receiveAmountString,
   receiveTokenName,
+  validUntil,
 }) => {
   const sellAmount = new BigNumber(sellAmountString)
   const receiveAmount = new BigNumber(receiveAmountString)
@@ -64,7 +67,14 @@ const OrderDetails: React.FC<Props> = ({
 
       <dd>Expiration date:</dd>
       <dt>
-        <Highlight>30 min</Highlight>
+        <Highlight>
+          ~
+          {(+validUntil / 60)
+            .toFixed(2)
+            .replace(leadingAndTrailingZeros, '')
+            .replace(trailingZerosAfterDot, '$1')}{' '}
+          hours
+        </Highlight>
       </dt>
     </Wrapper>
   )

--- a/src/components/TradeWidget/OrderValidity.tsx
+++ b/src/components/TradeWidget/OrderValidity.tsx
@@ -118,7 +118,7 @@ const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex, isUnlim
 
   return (
     <Wrapper>
-      <h3>Expiration time:</h3>
+      <h3>Expiration time (in min):</h3>
       <InputBox>
         <div className="main-input-container">
           <input
@@ -138,7 +138,7 @@ const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex, isUnlim
           />
           <div className="radio-container">
             <input type="checkbox" disabled={isDisabled} defaultChecked={isUnlimited} onClick={handleUnlimitedClick} />
-            <small>Unlimited</small>
+            <small>Never</small>
           </div>
         </div>
         {errorOrWarning}

--- a/src/components/TradeWidget/OrderValidity.tsx
+++ b/src/components/TradeWidget/OrderValidity.tsx
@@ -82,7 +82,7 @@ const WalletDetail = styled.div`
 const validInputPattern = new RegExp(/^\d+\.?\d*$/) // allows leading and trailing zeros
 
 function validatePositive(value: string): true | string {
-  return Number(value) >= 0 || 'Invalid expiration time'
+  return Number(value) == 0 || Number(value) >= 5 || 'Invalid expiration time'
 }
 
 interface Props {

--- a/src/components/TradeWidget/OrderValidity.tsx
+++ b/src/components/TradeWidget/OrderValidity.tsx
@@ -6,6 +6,7 @@ import { ZERO } from 'const'
 
 import { TradeFormTokenId, TradeFormData } from './'
 import { adjustPrecision } from '@gnosis.pm/dex-js'
+import { validInputPattern } from 'utils'
 
 const Wrapper = styled.div`
   display: flex;
@@ -79,8 +80,6 @@ const WalletDetail = styled.div`
   }
 `
 
-const validInputPattern = new RegExp(/^\d+\.?\d*$/) // allows leading and trailing zeros
-
 function validatePositive(value: string): true | string {
   return Number(value) == 0 || Number(value) >= 5 || 'Invalid expiration time'
 }
@@ -136,6 +135,7 @@ const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex, isUnlim
               validate: { positive: validatePositive },
             })}
             onChange={handleChange}
+            onFocus={(e): void => e.target.select()}
             tabIndex={tabIndex + 2}
           />
           <div className="radio-container">

--- a/src/components/TradeWidget/OrderValidity.tsx
+++ b/src/components/TradeWidget/OrderValidity.tsx
@@ -89,12 +89,13 @@ interface Props {
   inputId: TradeFormTokenId
   isDisabled: boolean
   tabIndex: number
+  isUnlimited: boolean
 }
 
 // const UNLIMITED_ORDER_VALIDITY_LENGTH = 'Infinity'
 
-const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex }) => {
-  const [unlimited, setUnlimited] = useState(false)
+const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex, isUnlimited }) => {
+  const [unlimited, setUnlimited] = useState(isUnlimited)
   const { register, errors, setValue, watch } = useFormContext<TradeFormData>()
   const error = errors[inputId]
   const inputValue = watch(inputId)
@@ -127,7 +128,7 @@ const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex }) => {
             className={className}
             name={inputId}
             type="number"
-            step="30"
+            step="5"
             disabled={isDisabled || unlimited}
             required
             ref={register({
@@ -138,7 +139,7 @@ const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex }) => {
             tabIndex={tabIndex + 2}
           />
           <div className="radio-container">
-            <input type="checkbox" onClick={handleUnlimitedClick} />
+            <input type="checkbox" defaultChecked={isUnlimited} onClick={handleUnlimitedClick} />
             <small>Unlimited</small>
           </div>
         </div>

--- a/src/components/TradeWidget/OrderValidity.tsx
+++ b/src/components/TradeWidget/OrderValidity.tsx
@@ -113,7 +113,7 @@ const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex, isUnlim
 
   function handleUnlimitedClick(): void {
     setUnlimited(!isUnlimited)
-    !isUnlimited && setValue(inputId, '', true)
+    !isUnlimited ? setValue(inputId, '', true) : setValue(inputId, '30', true)
   }
 
   return (

--- a/src/components/TradeWidget/OrderValidity.tsx
+++ b/src/components/TradeWidget/OrderValidity.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react'
+import React, { useEffect, useCallback, useState } from 'react'
 import styled from 'styled-components'
 import { useFormContext } from 'react-hook-form'
 
@@ -22,8 +22,22 @@ const InputBox = styled.div`
 
   margin-left: 1em;
 
+  > div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    > input[type='radio'] {
+      width: 20%;
+    }
+  }
+
+  .radio-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
   input {
-    margin: 0 0 0.5em 0;
+    margin: 0;
     width: 100%;
 
     &.error {
@@ -68,7 +82,7 @@ const WalletDetail = styled.div`
 const validInputPattern = new RegExp(/^\d+\.?\d*$/) // allows leading and trailing zeros
 
 function validatePositive(value: string): true | string {
-  return Number(value) > 0 || 'Invalid amount'
+  return Number(value) >= 0 || 'Invalid expiration time'
 }
 
 interface Props {
@@ -77,7 +91,10 @@ interface Props {
   tabIndex: number
 }
 
+// const UNLIMITED_ORDER_VALIDITY_LENGTH = 'Infinity'
+
 const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex }) => {
+  const [unlimited, setUnlimited] = useState(false)
   const { register, errors, setValue, watch } = useFormContext<TradeFormData>()
   const error = errors[inputId]
   const inputValue = watch(inputId)
@@ -96,23 +113,35 @@ const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex }) => {
     handleChange()
   }, [handleChange])
 
+  function handleUnlimitedClick(): void {
+    setUnlimited(!unlimited)
+    !unlimited && setValue(inputId, '', true)
+  }
+
   return (
     <Wrapper>
+      <h3>Expiration time:</h3>
       <InputBox>
-        <input
-          className={className}
-          placeholder="0"
-          name={inputId}
-          type="text"
-          disabled={isDisabled}
-          required
-          ref={register({
-            pattern: { value: validInputPattern, message: 'Expiration time cannot be zero' },
-            validate: { positive: validatePositive },
-          })}
-          onChange={handleChange}
-          tabIndex={tabIndex + 2}
-        />
+        <div className="main-input-container">
+          <input
+            className={className}
+            name={inputId}
+            type="number"
+            step="30"
+            disabled={isDisabled || unlimited}
+            required
+            ref={register({
+              pattern: { value: validInputPattern, message: 'Expiration time cannot be negative' },
+              validate: { positive: validatePositive },
+            })}
+            onChange={handleChange}
+            tabIndex={tabIndex + 2}
+          />
+          <div className="radio-container">
+            <input type="checkbox" onClick={handleUnlimitedClick} />
+            <small>Unlimited</small>
+          </div>
+        </div>
         {errorOrWarning}
       </InputBox>
     </Wrapper>

--- a/src/components/TradeWidget/OrderValidity.tsx
+++ b/src/components/TradeWidget/OrderValidity.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useCallback } from 'react'
+import styled from 'styled-components'
+import { useFormContext } from 'react-hook-form'
+
+import { ZERO } from 'const'
+
+import { TradeFormTokenId, TradeFormData } from './'
+import { adjustPrecision } from '@gnosis.pm/dex-js'
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  height: 6em;
+`
+
+const InputBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  flex-grow: 1;
+
+  margin-left: 1em;
+
+  input {
+    margin: 0 0 0.5em 0;
+    width: 100%;
+
+    &.error {
+      // box-shadow: 0 0 0.1875rem #cc0000;
+      border-color: #ff0000a3;
+    }
+
+    &.warning {
+      // box-shadow: 0 0 0.1875rem #ff7500;
+      border-color: orange;
+    }
+
+    &:disabled {
+      box-shadow: none;
+    }
+  }
+`
+
+const WalletDetail = styled.div`
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75em;
+
+  .success {
+    color: green;
+    text-decoration: none;
+  }
+
+  &.error,
+  &.warning {
+    margin: 0 0 1em 0;
+  }
+
+  &.error {
+    color: red;
+  }
+  &.warning {
+    color: orange;
+  }
+`
+
+const validInputPattern = new RegExp(/^\d+\.?\d*$/) // allows leading and trailing zeros
+
+function validatePositive(value: string): true | string {
+  return Number(value) > 0 || 'Invalid amount'
+}
+
+interface Props {
+  inputId: TradeFormTokenId
+  isDisabled: boolean
+  tabIndex: number
+}
+
+const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex }) => {
+  const { register, errors, setValue, watch } = useFormContext<TradeFormData>()
+  const error = errors[inputId]
+  const inputValue = watch(inputId)
+  const overMax = ZERO
+  const className = error ? 'error' : overMax.gt(ZERO) ? 'warning' : ''
+  const errorOrWarning = error && <WalletDetail className="error">{error.message}</WalletDetail>
+
+  const handleChange = useCallback(() => {
+    const newValue = adjustPrecision(inputValue, 0)
+    if (inputValue !== newValue) {
+      setValue(inputId, newValue, true)
+    }
+  }, [inputValue, setValue, inputId])
+
+  useEffect(() => {
+    handleChange()
+  }, [handleChange])
+
+  return (
+    <Wrapper>
+      <InputBox>
+        <input
+          className={className}
+          placeholder="0"
+          name={inputId}
+          type="text"
+          disabled={isDisabled}
+          required
+          ref={register({
+            pattern: { value: validInputPattern, message: 'Expiration time cannot be zero' },
+            validate: { positive: validatePositive },
+          })}
+          onChange={handleChange}
+          tabIndex={tabIndex + 2}
+        />
+        {errorOrWarning}
+      </InputBox>
+    </Wrapper>
+  )
+}
+
+export default OrderValidity

--- a/src/components/TradeWidget/OrderValidity.tsx
+++ b/src/components/TradeWidget/OrderValidity.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useState } from 'react'
+import React, { useEffect, useCallback, Dispatch, SetStateAction } from 'react'
 import styled from 'styled-components'
 import { useFormContext } from 'react-hook-form'
 
@@ -89,12 +89,10 @@ interface Props {
   isDisabled: boolean
   tabIndex: number
   isUnlimited: boolean
+  setUnlimited: Dispatch<SetStateAction<boolean>>
 }
 
-// const UNLIMITED_ORDER_VALIDITY_LENGTH = 'Infinity'
-
-const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex, isUnlimited }) => {
-  const [unlimited, setUnlimited] = useState(isUnlimited)
+const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex, isUnlimited, setUnlimited }) => {
   const { register, errors, setValue, watch } = useFormContext<TradeFormData>()
   const error = errors[inputId]
   const inputValue = watch(inputId)
@@ -114,8 +112,8 @@ const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex, isUnlim
   }, [handleChange])
 
   function handleUnlimitedClick(): void {
-    setUnlimited(!unlimited)
-    !unlimited && setValue(inputId, '', true)
+    setUnlimited(!isUnlimited)
+    !isUnlimited && setValue(inputId, '', true)
   }
 
   return (
@@ -128,7 +126,7 @@ const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex, isUnlim
             name={inputId}
             type="number"
             step="5"
-            disabled={isDisabled || unlimited}
+            disabled={isDisabled || isUnlimited}
             required
             ref={register({
               pattern: { value: validInputPattern, message: 'Expiration time cannot be negative' },
@@ -139,7 +137,7 @@ const OrderValidity: React.FC<Props> = ({ inputId, isDisabled, tabIndex, isUnlim
             tabIndex={tabIndex + 2}
           />
           <div className="radio-container">
-            <input type="checkbox" defaultChecked={isUnlimited} onClick={handleUnlimitedClick} />
+            <input type="checkbox" disabled={isDisabled} defaultChecked={isUnlimited} onClick={handleUnlimitedClick} />
             <small>Unlimited</small>
           </div>
         </div>

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -88,8 +88,8 @@ function displayBalance<K extends keyof TokenBalanceDetails>(
 }
 
 const validInputPattern = new RegExp(/^\d+\.?\d*$/) // allows leading and trailing zeros
-const leadingAndTrailingZeros = new RegExp(/(^0*(?=\d)|\.0*$)/, 'g') // removes leading zeros and trailing '.' followed by zeros
-const trailingZerosAfterDot = new RegExp(/(.*\.\d+?)0*$/) // selects valid input without leading zeros after '.'
+export const leadingAndTrailingZeros = new RegExp(/(^0*(?=\d)|\.0*$)/, 'g') // removes leading zeros and trailing '.' followed by zeros
+export const trailingZerosAfterDot = new RegExp(/(.*\.\d+?)0*$/) // selects valid input without leading zeros after '.'
 
 function preventInvalidChars(event: React.KeyboardEvent<HTMLInputElement>): void {
   if (!validInputPattern.test(event.currentTarget.value + event.key)) {
@@ -155,6 +155,7 @@ const TokenRow: React.FC<Props> = ({
   const enforcePrecision = useCallback(() => {
     const newValue = adjustPrecision(inputValue, selectedToken.decimals)
     if (inputValue !== newValue) {
+      console.debug('TCL: enforcePrecision -> inputValue', inputValue, inputId)
       setValue(inputId, newValue, true)
     }
   }, [inputValue, selectedToken.decimals, setValue, inputId])

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -7,7 +7,16 @@ import LinkWithPastLocation from 'components/LinkWithPastLocation'
 import TokenImg from 'components/TokenImg'
 import TokenSelector from 'components/TokenSelector'
 import { TokenDetails, TokenBalanceDetails } from 'types'
-import { formatAmount, formatAmountFull, parseAmount, adjustPrecision } from 'utils'
+import {
+  formatAmount,
+  formatAmountFull,
+  parseAmount,
+  adjustPrecision,
+  validInputPattern,
+  leadingAndTrailingZeros,
+  trailingZerosAfterDot,
+  validatePositive,
+} from 'utils'
 import { ZERO } from 'const'
 
 import { TradeFormTokenId, TradeFormData } from './'
@@ -87,18 +96,10 @@ function displayBalance<K extends keyof TokenBalanceDetails>(
   return formatAmount(balance[key] as BN, balance.decimals) || '0'
 }
 
-const validInputPattern = new RegExp(/^\d+\.?\d*$/) // allows leading and trailing zeros
-export const leadingAndTrailingZeros = new RegExp(/(^0*(?=\d)|\.0*$)/, 'g') // removes leading zeros and trailing '.' followed by zeros
-export const trailingZerosAfterDot = new RegExp(/(.*\.\d+?)0*$/) // selects valid input without leading zeros after '.'
-
 function preventInvalidChars(event: React.KeyboardEvent<HTMLInputElement>): void {
   if (!validInputPattern.test(event.currentTarget.value + event.key)) {
     event.preventDefault()
   }
-}
-
-function validatePositive(value: string): true | string {
-  return Number(value) > 0 || 'Invalid amount'
 }
 
 interface Props {
@@ -155,7 +156,6 @@ const TokenRow: React.FC<Props> = ({
   const enforcePrecision = useCallback(() => {
     const newValue = adjustPrecision(inputValue, selectedToken.decimals)
     if (inputValue !== newValue) {
-      console.debug('TCL: enforcePrecision -> inputValue', inputValue, inputId)
       setValue(inputId, newValue, true)
     }
   }, [inputValue, selectedToken.decimals, setValue, inputId])

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -167,7 +167,7 @@ const TradeWidget: React.FC = () => {
     // Minutes - then divided by 5min for batch length to get validity time
     // 0 validUntil time  = unlimited order
     // TODO: review this line
-    const validUntil = +data[validUntilId] / 5 || MAX_BATCH_ID
+    const validUntil = +data[validUntilId] / 5
     const cachedBuyToken = getToken('symbol', receiveToken.symbol, tokens)
     const cachedSellToken = getToken('symbol', sellToken.symbol, tokens)
 

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -221,7 +221,12 @@ const TradeWidget: React.FC = () => {
             isDisabled={isSubmitting}
             tabIndex={2}
           />
-          <OrderValidity inputId={validUntilId} isDisabled={isSubmitting} tabIndex={3} />
+          <OrderValidity
+            inputId={validUntilId}
+            isDisabled={isSubmitting}
+            isUnlimited={!validUntil || !Number(validUntil)}
+            tabIndex={3}
+          />
           <OrderDetails
             sellAmount={watch(sellInputId)}
             sellTokenName={safeTokenName(sellToken)}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -74,7 +74,7 @@ export type TradeFormData = {
 const DEFAULT_FORM_STATE = {
   sellToken: '0',
   receiveToken: '0',
-  validUntil: '30',
+  validUntil: '0',
 }
 
 const TradeWidget: React.FC = () => {

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -69,6 +69,12 @@ export type TradeFormData = {
   [K in keyof typeof TradeFormTokenId]: string
 }
 
+const DEFAULT_FORM_STATE = {
+  sellToken: '0',
+  receiveToken: '0',
+  validUntil: '30',
+}
+
 const TradeWidget: React.FC = () => {
   const { networkId, isConnected } = useWalletConnection()
   // Avoid displaying an empty list of tokens when the wallet is not connected
@@ -87,6 +93,7 @@ const TradeWidget: React.FC = () => {
     () =>
       getToken('symbol', receiveTokenSymbol, tokens) || (getToken('symbol', 'USDC', tokens) as Required<TokenDetails>),
   )
+  const [unlimited, setUnlimited] = useState(!validUntil || !Number(validUntil))
   const sellInputId = TradeFormTokenId.sellToken
   const receiveInputId = TradeFormTokenId.receiveToken
   const validUntilId = TradeFormTokenId.validUntil
@@ -184,7 +191,8 @@ const TradeWidget: React.FC = () => {
       })
       if (success) {
         // reset form on successful order placing
-        reset()
+        reset(DEFAULT_FORM_STATE)
+        setUnlimited(false)
       }
     } else {
       const from = history.location.pathname + history.location.search
@@ -224,7 +232,8 @@ const TradeWidget: React.FC = () => {
           <OrderValidity
             inputId={validUntilId}
             isDisabled={isSubmitting}
-            isUnlimited={!validUntil || !Number(validUntil)}
+            isUnlimited={unlimited}
+            setUnlimited={setUnlimited}
             tabIndex={3}
           />
           <OrderDetails

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -23,7 +23,7 @@ import { tokenListApi } from 'api'
 import { Network, TokenDetails } from 'types'
 
 import { getToken, safeTokenName, parseAmount } from 'utils'
-import { ZERO } from 'const'
+import { ZERO, MAX_BATCH_ID } from 'const'
 
 const WrappedWidget = styled(Widget)`
   overflow-x: visible;
@@ -164,7 +164,10 @@ const TradeWidget: React.FC = () => {
   async function onSubmit(data: FieldValues): Promise<void> {
     const buyAmount = parseAmount(data[receiveInputId], receiveToken.decimals)
     const sellAmount = parseAmount(data[sellInputId], sellToken.decimals)
-    const validUntil = +data[validUntilId]
+    // Minutes - then divided by 5min for batch length to get validity time
+    // 0 validUntil time  = unlimited order
+    // TODO: review this line
+    const validUntil = +data[validUntilId] / 5 || MAX_BATCH_ID
     const cachedBuyToken = getToken('symbol', receiveToken.symbol, tokens)
     const cachedSellToken = getToken('symbol', sellToken.symbol, tokens)
 

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -183,9 +183,9 @@ const TradeWidget: React.FC = () => {
     const cachedSellToken = getToken('symbol', sellToken.symbol, tokens)
 
     // Do not let potential null values through
-    if (!buyAmount || !sellAmount || !cachedBuyToken || !cachedSellToken || !networkId || !userAddress) return
+    if (!buyAmount || !sellAmount || !cachedBuyToken || !cachedSellToken || !networkId) return
 
-    if (isConnected) {
+    if (isConnected && userAddress) {
       let pendingTxHash: string | undefined = undefined
       const { success } = await placeOrder({
         buyAmount,

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -23,7 +23,7 @@ import { tokenListApi } from 'api'
 import { Network, TokenDetails } from 'types'
 
 import { getToken, safeTokenName, parseAmount } from 'utils'
-import { ZERO, MAX_BATCH_ID } from 'const'
+import { ZERO } from 'const'
 
 const WrappedWidget = styled(Widget)`
   overflow-x: visible;

--- a/src/hooks/usePlaceOrder.ts
+++ b/src/hooks/usePlaceOrder.ts
@@ -10,7 +10,7 @@ import { PlaceOrderParams as ExchangeApiPlaceOrderParams } from 'api/exchange/Ex
 import { log } from 'utils'
 import { txOptionalParams as defaultTxOptionalParams } from 'utils/transaction'
 import { useWalletConnection } from './useWalletConnection'
-import { DEFAULT_ORDER_DURATION, BATCHES_TO_WAIT } from 'const'
+import { BATCHES_TO_WAIT } from 'const'
 import useSafeState from './useSafeState'
 
 interface PlaceOrderParams<T> {
@@ -81,7 +81,8 @@ export const usePlaceOrder = (): Result => {
             userAddress,
             buyTokenId,
             sellTokenId,
-            validUntil: validUntil || batchId + DEFAULT_ORDER_DURATION,
+            // validUntil time or max time
+            validUntil: validUntil ? batchId + validUntil : MAX_BATCH_ID, //batchId + DEFAULT_ORDER_DURATION,
             buyAmount,
             sellAmount,
             networkId,

--- a/src/hooks/usePlaceOrder.ts
+++ b/src/hooks/usePlaceOrder.ts
@@ -82,7 +82,7 @@ export const usePlaceOrder = (): Result => {
             buyTokenId,
             sellTokenId,
             // validUntil time or max time
-            validUntil: validUntil ? batchId + validUntil : MAX_BATCH_ID, //batchId + DEFAULT_ORDER_DURATION,
+            validUntil: validUntil ? batchId + validUntil : MAX_BATCH_ID,
             buyAmount,
             sellAmount,
             networkId,

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -6,21 +6,24 @@ import { useMemo } from 'react'
  *
  * @param value Input from URL
  */
-function sanitizeInput(value?: string | null): string {
-  return value && Number(value) ? value : '0'
+function sanitizeInput(value?: string | null, defaultValue = '0'): string {
+  return value && Number(value) ? value : defaultValue
 }
 
-export function useQuery(): { sellAmount: string; buyAmount: string } {
+export function useQuery(): { sellAmount: string; buyAmount: string; validUntil: string } {
   const query = new URLSearchParams(useLocation().search)
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const sellAmount = useMemo(() => sanitizeInput(query.get('sell')), [])
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const buyAmount = useMemo(() => sanitizeInput(query.get('buy')), [])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const validUntil = useMemo(() => sanitizeInput(query.get('expires'), '30'), [])
 
   return {
     sellAmount,
     buyAmount,
+    validUntil,
   }
 }
 

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -16,7 +16,7 @@ function sanitizeInput(value?: string | null, defaultValue = '0'): string {
  * @param value Input from URL
  */
 function sanitizeNegativeInput(value?: string | null, defaultValue = '0'): string | null | undefined {
-  return (Number(value) === 0 && Number(value) >= 5) ?? value ? value : defaultValue
+  return (Number(value) === 0 || Number(value) >= 5) ?? value ? value : defaultValue
 }
 
 export function useQuery(): { sellAmount: string; buyAmount: string; validUntil?: string | null } {

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -1,6 +1,6 @@
 import { useLocation } from 'react-router'
 import { useMemo } from 'react'
-import { multOfFive } from 'utils'
+import { makeMultipleOf } from 'utils'
 
 /**
  * Prevents invalid numbers from being inserted by hand in the URL
@@ -13,11 +13,12 @@ function sanitizeInput(value?: string | null, defaultValue = '0'): string {
 
 /**
  * Prevents invalid NEGATIVE numbers from being inserted by hand in the URL
+ * Pushes number to nearest multiple of 5 (batch time)
  *
  * @param value Input from URL
  */
 function sanitizeNegativeInput(value?: string | null, defaultValue = '0'): string {
-  return (Number(value) === 0 || Number(value) >= 5) && value ? multOfFive(value).toString() : defaultValue
+  return Number(value) >= 0 ? makeMultipleOf(5, value).toString() : defaultValue
 }
 
 export function useQuery(): { sellAmount: string; buyAmount: string; validUntil?: string } {

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -15,11 +15,11 @@ function sanitizeInput(value?: string | null, defaultValue = '0'): string {
  *
  * @param value Input from URL
  */
-function sanitizeNegativeInput(value?: string | null, defaultValue = '0'): string | null | undefined {
-  return (Number(value) === 0 || Number(value) >= 5) ?? value ? value : defaultValue
+function sanitizeNegativeInput(value?: string | null, defaultValue = '0'): string {
+  return (Number(value) === 0 || Number(value) >= 5) && value ? value : defaultValue
 }
 
-export function useQuery(): { sellAmount: string; buyAmount: string; validUntil?: string | null } {
+export function useQuery(): { sellAmount: string; buyAmount: string; validUntil?: string } {
   const query = new URLSearchParams(useLocation().search)
 
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -1,25 +1,6 @@
 import { useLocation } from 'react-router'
 import { useMemo } from 'react'
-import { makeMultipleOf } from 'utils'
-
-/**
- * Prevents invalid numbers from being inserted by hand in the URL
- *
- * @param value Input from URL
- */
-function sanitizeInput(value?: string | null, defaultValue = '0'): string {
-  return value && Number(value) ? value : defaultValue
-}
-
-/**
- * Prevents invalid NEGATIVE numbers from being inserted by hand in the URL
- * Pushes number to nearest multiple of 5 (batch time)
- *
- * @param value Input from URL
- */
-function sanitizeNegativeInput(value?: string | null, defaultValue = '0'): string {
-  return Number(value) >= 0 ? makeMultipleOf(5, value).toString() : defaultValue
-}
+import { sanitizeInput, sanitizeNegativeAndMakeMultipleOf } from 'utils'
 
 export function useQuery(): { sellAmount: string; buyAmount: string; validUntil?: string } {
   const { search } = useLocation()
@@ -30,7 +11,7 @@ export function useQuery(): { sellAmount: string; buyAmount: string; validUntil?
     return {
       sellAmount: sanitizeInput(query.get('sell')),
       buyAmount: sanitizeInput(query.get('buy')),
-      validUntil: sanitizeNegativeInput(query.get('expires'), '30'),
+      validUntil: sanitizeNegativeAndMakeMultipleOf(query.get('expires'), '30'),
     }
   }, [search])
 }

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -10,7 +10,16 @@ function sanitizeInput(value?: string | null, defaultValue = '0'): string {
   return value && Number(value) ? value : defaultValue
 }
 
-export function useQuery(): { sellAmount: string; buyAmount: string; validUntil: string } {
+/**
+ * Prevents invalid NEGATIVE numbers from being inserted by hand in the URL
+ *
+ * @param value Input from URL
+ */
+function sanitizeNegativeInput(value?: string | null, defaultValue = '0'): string | null | undefined {
+  return (Number(value) === 0 && Number(value) >= 5) ?? value ? value : defaultValue
+}
+
+export function useQuery(): { sellAmount: string; buyAmount: string; validUntil?: string | null } {
   const query = new URLSearchParams(useLocation().search)
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -18,7 +27,7 @@ export function useQuery(): { sellAmount: string; buyAmount: string; validUntil:
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const buyAmount = useMemo(() => sanitizeInput(query.get('buy')), [])
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const validUntil = useMemo(() => sanitizeInput(query.get('expires'), '30'), [])
+  const validUntil = useMemo(() => sanitizeNegativeInput(query.get('expires'), '30'), [])
 
   return {
     sellAmount,

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -20,20 +20,17 @@ function sanitizeNegativeInput(value?: string | null, defaultValue = '0'): strin
 }
 
 export function useQuery(): { sellAmount: string; buyAmount: string; validUntil?: string } {
-  const query = new URLSearchParams(useLocation().search)
+  const { search } = useLocation()
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const sellAmount = useMemo(() => sanitizeInput(query.get('sell')), [])
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const buyAmount = useMemo(() => sanitizeInput(query.get('buy')), [])
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const validUntil = useMemo(() => sanitizeNegativeInput(query.get('expires'), '30'), [])
+  return useMemo(() => {
+    const query = new URLSearchParams(search)
 
-  return {
-    sellAmount,
-    buyAmount,
-    validUntil,
-  }
+    return {
+      sellAmount: sanitizeInput(query.get('sell')),
+      buyAmount: sanitizeInput(query.get('buy')),
+      validUntil: sanitizeNegativeInput(query.get('expires'), '30'),
+    }
+  }, [search])
 }
 
 /**

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -1,5 +1,6 @@
 import { useLocation } from 'react-router'
 import { useMemo } from 'react'
+import { multOfFive } from 'utils'
 
 /**
  * Prevents invalid numbers from being inserted by hand in the URL
@@ -16,7 +17,7 @@ function sanitizeInput(value?: string | null, defaultValue = '0'): string {
  * @param value Input from URL
  */
 function sanitizeNegativeInput(value?: string | null, defaultValue = '0'): string {
-  return (Number(value) === 0 || Number(value) >= 5) && value ? value : defaultValue
+  return (Number(value) === 0 || Number(value) >= 5) && value ? multOfFive(value).toString() : defaultValue
 }
 
 export function useQuery(): { sellAmount: string; buyAmount: string; validUntil?: string } {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -194,3 +194,22 @@ export function makeMultipleOf(mult = 5, value?: number | string | null): number
 
   return finalVal
 }
+
+/**
+ * Prevents invalid numbers from being inserted by hand in the URL
+ *
+ * @param value Input from URL
+ */
+export function sanitizeInput(value?: string | null, defaultValue = '0'): string {
+  return value && Number(value) ? value : defaultValue
+}
+
+/**
+ * Prevents invalid NEGATIVE numbers from being inserted by hand in the URL
+ * Pushes number to nearest multiple of 5 (batch time)
+ *
+ * @param value Input from URL
+ */
+export function sanitizeNegativeAndMakeMultipleOf(value?: string | null, defaultValue = '0'): string {
+  return Number(value) >= 0 ? makeMultipleOf(5, value).toString() : defaultValue
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -174,17 +174,19 @@ export function formatPrice(
   return price ? price.toFixed(decimals) : null
 }
 
-export function multOfFive(value: number | string): number {
+export function makeMultipleOf(mult = 5, value?: number | string | null): number {
   const cache = {}
   const numValue = Number(value)
-  if (!(numValue % 5) || cache[numValue]) return numValue
 
-  const remainder = numValue % 5
+  if (numValue === 0 || !value || isNaN(numValue)) return 0
+  if (!(numValue % mult) || cache[numValue]) return numValue
+
+  const remainder = numValue % mult
 
   let finalVal
-  if (remainder > 5 / 2) {
+  if (remainder > mult / 2) {
     cache[numValue] = numValue
-    finalVal = numValue - remainder + 5
+    finalVal = numValue - remainder + mult
   } else {
     cache[numValue] = numValue
     finalVal = numValue - remainder

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -213,3 +213,22 @@ export function sanitizeInput(value?: string | null, defaultValue = '0'): string
 export function sanitizeNegativeAndMakeMultipleOf(value?: string | null, defaultValue = '0'): string {
   return Number(value) >= 0 ? makeMultipleOf(5, value).toString() : defaultValue
 }
+
+export function validatePositive(value: string): true | string {
+  return Number(value) > 0 || 'Invalid amount'
+}
+export const validInputPattern = new RegExp(/^\d+\.?\d*$/) // allows leading and trailing zeros
+export const leadingAndTrailingZeros = new RegExp(/(^0*(?=\d)|\.0*$)/, 'g') // removes leading zeros and trailing '.' followed by zeros
+export const trailingZerosAfterDot = new RegExp(/(.*\.\d+?)0*$/) // selects valid input without leading zeros after '.'
+
+export const formatValidity = (validTime: string | number): string =>
+  +validTime == 0
+    ? 'Unlimited'
+    : +validTime < 0
+    ? 'Invalid time - time cannot be negative'
+    : `~
+${(+validTime / 60)
+  .toFixed(2)
+  .replace(leadingAndTrailingZeros, '')
+  .replace(trailingZerosAfterDot, '$1')}
+hours`

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -173,3 +173,22 @@ export function formatPrice(
 
   return price ? price.toFixed(decimals) : null
 }
+
+export function multOfFive(value: number | string): number {
+  const cache = {}
+  const numValue = Number(value)
+  if (!(numValue % 5) || cache[numValue]) return numValue
+
+  const remainder = numValue % 5
+
+  let finalVal
+  if (remainder > 5 / 2) {
+    cache[numValue] = numValue
+    finalVal = numValue - remainder + 5
+  } else {
+    cache[numValue] = numValue
+    finalVal = numValue - remainder
+  }
+
+  return finalVal
+}


### PR DESCRIPTION
Closes #482 

Allows user to define validity date
`expires=0 or expires=` triggers unlimited order
negative values excluded, antthing below 5 and above 0 defaulted back to 30

Has fixes from 482.5 that fixed the form bug and checkbox bug