### PR TITLE
When a token is not registered in the exchange, do not allow the order to be placed

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -33,6 +33,9 @@ export const getDefaultProvider = (): string | null =>
 function createWeb3Api(): Web3 {
   // TODO: Create an `EthereumApi` https://github.com/gnosis/dex-react/issues/331
   const web3 = new Web3(getDefaultProvider())
+  // `handleRevert = true` makes `require` failures to throw
+  // For more details see https://github.com/gnosis/dex-react/issues/511
+  web3.eth['handleRevert'] = true
 
   if (process.env.MOCK_WEB3 === 'true') {
     // Only function that needs to be mocked so far. We can add more and add extra logic as needed


### PR DESCRIPTION
Closes #511 

No longer able to place orders using tokens that are not registered in the exchange:

![screenshot_2020-02-11_13-17-54](https://user-images.githubusercontent.com/43217/74259593-e829fe80-4cd6-11ea-9094-8334ab054053.png)

Works when 1 or both tokens are not registered.