### PR TITLE
fix useQuery updates

### DIFF
--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -20,20 +20,17 @@ function sanitizeNegativeInput(value?: string | null, defaultValue = '0'): strin
 }
 
 export function useQuery(): { sellAmount: string; buyAmount: string; validUntil?: string } {
-  const query = new URLSearchParams(useLocation().search)
+  const { search } = useLocation()
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const sellAmount = useMemo(() => sanitizeInput(query.get('sell')), [])
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const buyAmount = useMemo(() => sanitizeInput(query.get('buy')), [])
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const validUntil = useMemo(() => sanitizeNegativeInput(query.get('expires'), '30'), [])
+  return useMemo(() => {
+    const query = new URLSearchParams(search)
 
-  return {
-    sellAmount,
-    buyAmount,
-    validUntil,
-  }
+    return {
+      sellAmount: sanitizeInput(query.get('sell')),
+      buyAmount: sanitizeInput(query.get('buy')),
+      validUntil: sanitizeNegativeInput(query.get('expires'), '30'),
+    }
+  }, [search])
 }
 
 /**


### PR DESCRIPTION
`useQuery` doesn't update when `location.search` changes
Luckily it doesn't break anything as the source of truth after the first load is the form, but it potentially could

See reproduction gif where `sellAmount` stays the initial value
![useQuery](https://user-images.githubusercontent.com/5121491/74323547-baa48a00-4d96-11ea-91a1-786a98b7673e.gif)
