### PR TITLE
Fix refetch from 0 on mount

### DIFF
--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -117,18 +117,14 @@ export function useOrders(): Result {
 
   // allow to fresh start/refresh on demand
   const forceOrdersRefresh = useCallback((): void => {
-    unstable_batchedUpdates(() => {
-      dispatch(updateOffset({ offset: 0 }))
-      setIsLoading(true)
-    })
-  }, [setIsLoading])
+    dispatch(updateOffset({ offset: 0 }))
+    setIsLoading(true)
+  }, [dispatch, setIsLoading])
 
   useEffect(() => {
-    unstable_batchedUpdates(() => {
-      forceOrdersRefresh()
-      dispatch(overwriteOrders({ orders: [] }))
-    })
-  }, [userAddress, networkId, forceOrdersRefresh])
+    forceOrdersRefresh()
+    dispatch(overwriteOrders({ orders: [] }))
+  }, [userAddress, networkId, forceOrdersRefresh, dispatch])
 
   return { orders, isLoading, forceOrdersRefresh }
 }

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react'
+import { useEffect, useCallback, useRef } from 'react'
 // eslint-disable-next-line @typescript-eslint/camelcase
 import { unstable_batchedUpdates } from 'react-dom'
 
@@ -121,10 +121,17 @@ export function useOrders(): Result {
     setIsLoading(true)
   }, [dispatch, setIsLoading])
 
+  const runEffect = useRef(false)
+
   useEffect(() => {
+    if (!runEffect.current) return
     forceOrdersRefresh()
     dispatch(overwriteOrders({ orders: [] }))
   }, [userAddress, networkId, forceOrdersRefresh, dispatch])
+
+  useEffect(() => {
+    runEffect.current = true
+  }, [])
 
   return { orders, isLoading, forceOrdersRefresh }
 }

--- a/src/reducers-actions/orders.ts
+++ b/src/reducers-actions/orders.ts
@@ -12,17 +12,17 @@ export interface OrdersState {
   offset: number
 }
 
-export const overwriteOrders = (payload: Omit<OrdersState, 'offset'>) => ({
+export const overwriteOrders = (payload: Pick<OrdersState, 'orders'>) => ({
   type: ActionTypes.OVERWRITE_ORDERS,
   payload,
 })
 
-export const appendOrders = (payload: Omit<OrdersState, 'offset'>) => ({
+export const appendOrders = (payload: Pick<OrdersState, 'orders'>) => ({
   type: ActionTypes.APPEND_ORDERS,
   payload,
 })
 
-export const updateOffset = (payload: Omit<OrdersState, 'orders'>) => ({
+export const updateOffset = (payload: Pick<OrdersState, 'offset'>) => ({
   type: ActionTypes.UPDATE_OFFSET,
   payload,
 })


### PR DESCRIPTION
`useEffect` is run when deps changes
That includes on mount/unmount
So 
```
useEffect(() => {
    forceOrdersRefresh()
    dispatch(overwriteOrders({ orders: [] }))
  }, [userAddress, networkId, forceOrdersRefresh, dispatch])

```

Would run and `forceRefresh` whenever we mount `OrdersRow`

One solution is to skip first run.
Another could be to centralize forceRefresh somewhere in global state near Provider, but then we would fetch even when we don't need to display orders

aside: setState is batched by default inside `useEffect` and in sync event handlers. some time in the future, with concurrent mode, will be batched everywhere