### PR TITLE
526/time remaining in batch

### DIFF
--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -10,6 +10,8 @@ import useNavigation from './useNavigation'
 import useOpenCloseNav from './useOpenCloseNav'
 
 import { APP_NAME } from 'const'
+import { formatSecondsToMinutes } from 'utils'
+import { useTimeRemainingInBatch } from 'hooks/useTimeRemainingInBatch'
 
 export interface HeaderProps {
   [key: string]: {
@@ -38,6 +40,8 @@ const Header: React.FC<HeaderProps> = ({ navigation: initialState }: HeaderProps
   const { isResponsive, openNav, setOpenNav } = useOpenCloseNav()
   const navigationArray = useNavigation(initialState, isResponsive)
 
+  const timeRemainingInBatch = useTimeRemainingInBatch()
+
   const handleOpenNav = (): void | false => isResponsive && setOpenNav(!openNav)
 
   return (
@@ -51,7 +55,9 @@ const Header: React.FC<HeaderProps> = ({ navigation: initialState }: HeaderProps
           {/* USER WALLET */}
           <UserWallet />
           {/* Global Batch Countdown */}
-          <BatchCountDown>Next batch in: <strong>4m 12s</strong></BatchCountDown>
+          <BatchCountDown>
+            Next batch in: <strong>{formatSecondsToMinutes(timeRemainingInBatch)}</strong>
+          </BatchCountDown>
         </TopWrapper>
         {/* HEADER LINKS */}
         <NavigationLinks

--- a/src/hooks/useTimeRemainingInBatch.ts
+++ b/src/hooks/useTimeRemainingInBatch.ts
@@ -1,0 +1,15 @@
+import useSafeState from './useSafeState'
+import { getSecondsRemainingInBatch } from 'utils'
+import { useEffect } from 'react'
+
+export function useTimeRemainingInBatch(): number {
+  const [timeRemaining, setTimeRemaining] = useSafeState(getSecondsRemainingInBatch())
+
+  useEffect(() => {
+    const interval = setInterval(() => setTimeRemaining(getSecondsRemainingInBatch()), 1000)
+
+    return (): void => clearInterval(interval)
+  }, [setTimeRemaining])
+
+  return timeRemaining
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -35,6 +35,32 @@ export function formatDateFromBatchId(batchId: number): string {
   return formatDistanceToNow(date, { addSuffix: true })
 }
 
+/**
+ * Calculates seconds remaining in current batch
+ * Assumes local time is accurate and can be used as source of truth
+ */
+export function getSecondsRemainingInBatch(): number {
+  return BATCH_TIME - (getEpoch() % BATCH_TIME)
+}
+
+export function formatSecondsToMinutes(seconds: number): string {
+  const minutes = Math.floor(seconds / 60)
+  const remainderSeconds = seconds % 60
+  let s = ''
+
+  if (minutes > 0) {
+    s += `${minutes}m `
+  }
+  if (remainderSeconds > 0) {
+    s += `${remainderSeconds}s`
+  }
+  if (minutes === 0 && remainderSeconds === 0) {
+    s = '0s'
+  }
+
+  return s
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
 async function noop(_milliseconds = 0): Promise<void> {}
 


### PR DESCRIPTION
Closes #526 

- Uses local time to calculate time remaining in batch
- Code on `feature/ui-redesign` branch since it has the time already on the UI
- NOT passing tests/build due to linter issues. Will be addressed on https://github.com/gnosis/dex-react/issues/534
- Able to run locally with `yarn mock` and see the clock ticking :)

### Note:
Not sure there's a smarter way to format seconds into XXm XXs from seconds rather than from a Date or timestamp. Open to suggestions.