### PR TITLE
fixes default validity order time bug

### DIFF
--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -74,7 +74,8 @@ export type TradeFormData = {
 export const DEFAULT_FORM_STATE = {
   sellToken: '0',
   receiveToken: '0',
-  validUntil: '30',
+  // 2 days
+  validUntil: '2880',
 }
 
 const TradeWidget: React.FC = () => {

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -71,10 +71,10 @@ export type TradeFormData = {
   [K in keyof typeof TradeFormTokenId]: string
 }
 
-const DEFAULT_FORM_STATE = {
+export const DEFAULT_FORM_STATE = {
   sellToken: '0',
   receiveToken: '0',
-  validUntil: '0',
+  validUntil: '30',
 }
 
 const TradeWidget: React.FC = () => {

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -1,6 +1,7 @@
 import { useLocation } from 'react-router'
 import { useMemo } from 'react'
 import { sanitizeInput, sanitizeNegativeAndMakeMultipleOf } from 'utils'
+import { DEFAULT_FORM_STATE } from 'components/TradeWidget'
 
 export function useQuery(): { sellAmount: string; buyAmount: string; validUntil?: string } {
   const { search } = useLocation()
@@ -11,7 +12,7 @@ export function useQuery(): { sellAmount: string; buyAmount: string; validUntil?
     return {
       sellAmount: sanitizeInput(query.get('sell')),
       buyAmount: sanitizeInput(query.get('buy')),
-      validUntil: sanitizeNegativeAndMakeMultipleOf(query.get('expires'), '30'),
+      validUntil: sanitizeNegativeAndMakeMultipleOf(query.get('expires'), DEFAULT_FORM_STATE.validUntil),
     }
   }, [search])
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -47,7 +47,9 @@ export function sanitizeInput(value?: string | null, defaultValue = '0'): string
  * @param value Input from URL
  */
 export function sanitizeNegativeAndMakeMultipleOf(value?: string | null, defaultValue = '0'): string {
-  return Number(value) >= 0 ? makeMultipleOf(5, value).toString() : defaultValue
+  return typeof value === 'number' || (typeof value === 'string' && Number(value) >= 0)
+    ? makeMultipleOf(5, value).toString()
+    : defaultValue
 }
 
 export function validatePositive(value: string): true | string {


### PR DESCRIPTION
1. Order validity time default. Can be set in Trade Widgets

Defaults to 2880 (2 days)
Maybe best to move Order form defaults somewhere else