### PR TITLE
Added total amount to orders page

### DIFF
--- a/src/components/OrdersWidget/OrderRow.styled.ts
+++ b/src/components/OrdersWidget/OrderRow.styled.ts
@@ -30,10 +30,10 @@ export const OrderRowWrapper = styled.tr<{ $color?: string; $open?: boolean }>`
     display: none;
   }
 
-  .order-details {
+  .order-details,
+  .amounts {
     display: grid;
     grid-template-columns: max-content max-content;
-    grid-gap: 0 1rem;
     text-align: left;
     justify-content: space-evenly;
 
@@ -43,6 +43,11 @@ export const OrderRowWrapper = styled.tr<{ $color?: string; $open?: boolean }>`
       grid-gap: 0 0.5rem;
       justify-content: space-between;
     }
+  }
+
+  .amounts {
+    text-align: right;
+    justify-content: right;
   }
 
   .sub-columns {

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -122,10 +122,12 @@ interface AmountsProps extends Pick<Props, 'order' | 'pending'> {
 }
 
 const Amounts: React.FC<AmountsProps> = ({ sellToken, order, isUnlimited }) => {
-  const unfilledAmount = useMemo(() => formatAmount(order.remainingAmount, sellToken.decimals) || '0', [
-    order.remainingAmount,
-    sellToken.decimals,
-  ])
+  const unfilledAmount = useMemo(() => {
+    const filledAmount = order.priceDenominator.sub(order.remainingAmount)
+
+    return formatAmount(filledAmount, sellToken.decimals) || '0'
+  }, [order.priceDenominator, order.remainingAmount, sellToken.decimals])
+
   const totalAmount = useMemo(() => formatAmount(order.priceDenominator, sellToken.decimals) || '0', [
     order.priceDenominator,
     sellToken.decimals,

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -116,27 +116,31 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({ buyToken, sellToken, order 
   )
 }
 
-interface UnfilledAmountProps extends Pick<Props, 'order' | 'pending'> {
+interface AmountsProps extends Pick<Props, 'order' | 'pending'> {
   sellToken: TokenDetails
   isUnlimited: boolean
 }
 
-const UnfilledAmount: React.FC<UnfilledAmountProps> = ({ sellToken, order, isUnlimited }) => {
+const Amounts: React.FC<AmountsProps> = ({ sellToken, order, isUnlimited }) => {
   const unfilledAmount = useMemo(() => formatAmount(order.remainingAmount, sellToken.decimals) || '0', [
     order.remainingAmount,
     sellToken.decimals,
   ])
+  const totalAmount = useMemo(() => formatAmount(order.priceDenominator, sellToken.decimals) || '0', [
+    order.priceDenominator,
+    sellToken.decimals,
+  ])
 
   return (
-    <td data-label="Unfilled Amount" className={isUnlimited ? '' : 'sub-columns two-columns'}>
+    <td data-label="Unfilled Amount">
       {isUnlimited ? (
-        // <Highlight color={pending ? 'grey' : ''}>no limit</Highlight>
         <span>no limit</span>
       ) : (
         <>
-          <div>{unfilledAmount}</div>
-          <div>
-            <strong>{displayTokenSymbolOrLink(sellToken)}</strong>
+          <div className="amounts">
+            {unfilledAmount} {displayTokenSymbolOrLink(sellToken)}
+            <br />
+            {totalAmount} {displayTokenSymbolOrLink(sellToken)}
           </div>
         </>
       )}
@@ -178,17 +182,7 @@ const Expires: React.FC<Pick<Props, 'order' | 'pending'>> = ({ order }) => {
     return { isNeverExpires, expiresOn }
   }, [order.validUntil])
 
-  return (
-    <td data-label="Expires">
-      {isNeverExpires ? (
-        // <Highlight color={pending ? 'grey' : ''}>Never</Highlight>
-        <span>Never</span>
-      ) : (
-        // <Highlight color={'inherit'}>{expiresOn}</Highlight>
-        <span>{expiresOn}</span>
-      )}
-    </td>
-  )
+  return <td data-label="Expires">{isNeverExpires ? <span>Never</span> : <span>{expiresOn}</span>}</td>
 }
 
 async function fetchToken(
@@ -280,11 +274,7 @@ const OrderRow: React.FC<Props> = props => {
           ))}
         <OrderImage sellToken={sellToken} buyToken={buyToken} />
         <OrderDetails order={order} sellToken={sellToken} buyToken={buyToken} />
-        {!isPendingOrder ? (
-          <UnfilledAmount order={order} sellToken={sellToken} isUnlimited={isUnlimited} />
-        ) : (
-          <PendingLink />
-        )}
+        {!isPendingOrder ? <Amounts order={order} sellToken={sellToken} isUnlimited={isUnlimited} /> : <PendingLink />}
         {/* {!isPendingOrder ? (
           <AccountBalance order={order} isOverBalance={isOverBalance} sellToken={sellToken} isUnlimited={isUnlimited} />
         ) : (


### PR DESCRIPTION
Closes #484 

Slightly different than requirement on #484 to be inline with current design.
Rather than filled/unfilled, displaying filled/total amount:

![Screenshot from 2020-02-18 10-41-29](https://user-images.githubusercontent.com/43217/74741810-3ccffb00-523c-11ea-994d-46e485126433.png)

### Note:
- Last column is still static