### PR TITLE
Tooltips sample integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@hot-loader/react-dom": "^16.11.0",
     "@popperjs/core": "^2.0.6",
     "@types/react": "^16.9.19",
+    "@types/react-is": "^16.7.1",
     "@types/react-select": "^3.0.10",
     "@walletconnect/web3-provider": "^1.0.0-beta.46",
     "bignumber.js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@gnosis.pm/dapp-ui": "^0.5.3",
     "@gnosis.pm/dex-js": "0.1.12-RC.0",
     "@hot-loader/react-dom": "^16.11.0",
+    "@popperjs/core": "^2.0.6",
     "@types/react": "^16.9.19",
     "@types/react-select": "^3.0.10",
     "@walletconnect/web3-provider": "^1.0.0-beta.46",

--- a/src/components/Portal.tsx
+++ b/src/components/Portal.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { createPortal } from 'react-dom'
+
+// mounts children in the body
+// which isolates them from the overall App styles
+// imported for inherited styles
+// usual use cases -- tooltips, popups, modals
+const Portal: React.FC = ({ children }) => {
+  return createPortal(children, document.body)
+}
+
+export default Portal

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -109,7 +109,10 @@ WrapperPropsAll<C> & { children?: ReactNode }): React.ReactElement => {
   // can attach ref to element
   // if children is a single element, not just text, and `as` tag|Component not specified
   if (chilrenNumber === 1 && typeof as === 'undefined' && isElement(children) && !isFragment(children)) {
-    let finalTargetProps
+    let finalTargetProps:
+      | typeof targetProps
+      | Omit<typeof targetProps, 'onMouseEnter' | 'onMouseLeave'>
+      | Omit<typeof targetProps, 'onFocus' | 'onBlur'>
     if (focus && hover) {
       // pass all targetProps by default
       finalTargetProps = targetProps
@@ -118,6 +121,7 @@ WrapperPropsAll<C> & { children?: ReactNode }): React.ReactElement => {
       finalTargetProps = {
         onFocus: targetProps.onFocus,
         onBlur: targetProps.onBlur,
+        ref: targetProps.ref,
       }
     } else if (hover) {
       // <TooltipWrapper focus={false}> --> only show tooltip on hover
@@ -126,6 +130,7 @@ WrapperPropsAll<C> & { children?: ReactNode }): React.ReactElement => {
       finalTargetProps = {
         onMouseEnter: targetProps.onMouseEnter,
         onMouseLeave: targetProps.onMouseLeave,
+        ref: targetProps.ref,
       }
     }
     const TargetComponent = React.cloneElement(children, finalTargetProps)

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -3,6 +3,7 @@ import Portal from './Portal'
 import { usePopperDefault, TOOLTIP_OFFSET } from 'hooks/usePopper'
 import { State, Placement } from '@popperjs/core'
 import styled from 'styled-components'
+import { isElement, isFragment } from 'react-is'
 
 const TooltipOuter = styled.div<Pick<TooltipBaseProps, 'isShown'>>`
   visibility: ${(props): string | false => !props.isShown && 'hidden'};
@@ -79,16 +80,36 @@ export const Tooltip = React.memo(React.forwardRef<HTMLDivElement, TooltipProps>
 interface WrapperProps {
   tooltip: ReactNode
   placement?: Placement
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>
 }
 
-export const TooltipWrapper: React.FC<WrapperProps> = ({ children, tooltip, placement }) => {
+const Wrapper: React.FC<WrapperProps> = ({ children, tooltip, placement, as }) => {
   const { targetProps, tooltipProps } = usePopperDefault<HTMLDivElement>(placement)
 
+  const chilrenNumber = React.Children.count(children)
+
+  // can attach ref to element
+  // if children is a single element, not just text, and `as` tag|Component not specified
+  if (chilrenNumber === 1 && typeof as === 'undefined' && isElement(children) && !isFragment(children)) {
+    const TargetComponent = React.cloneElement(children, targetProps)
+    return (
+      <>
+        {TargetComponent}
+        <Tooltip {...tooltipProps}>{tooltip}</Tooltip>
+      </>
+    )
+  }
+
+  //  if as not provided and can't clone single element
+  //  use div
+  const TargetComponent = as || 'div'
+
   return (
-    <div {...targetProps}>
+    <TargetComponent {...targetProps}>
       {children}
       <Tooltip {...tooltipProps}>{tooltip}</Tooltip>
-    </div>
+    </TargetComponent>
   )
 }
 

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, CSSProperties } from 'react'
 import Portal from './Portal'
 import { usePopperDefault, TOOLTIP_OFFSET } from 'hooks/usePopper'
 import { State, Placement } from '@popperjs/core'
-import styled from 'styled-components'
+import styled, { StyledComponent, StyledComponentProps } from 'styled-components'
 import { isElement, isFragment } from 'react-is'
 
 // visibility necessary for correct boundingRect calculation by popper
@@ -81,13 +81,22 @@ export const Tooltip = React.memo(React.forwardRef<HTMLDivElement, TooltipProps>
 interface WrapperProps {
   tooltip: ReactNode
   placement?: Placement
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  as?: keyof JSX.IntrinsicElements | React.ComponentType<any>
   focus?: boolean
   hover?: boolean
 }
 
-const Wrapper: React.FC<WrapperProps> = ({ children, tooltip, placement, as, focus = true, hover = true }) => {
+// using StyledComponent type since it properly types as={Component}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Wrapper: StyledComponent<'div', any, WrapperProps> = (({
+  children,
+  tooltip,
+  placement,
+  as,
+  focus = true,
+  hover = true,
+  ...props
+}: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+WrapperProps & StyledComponentProps<'div', any, {}, any>): any => {
   const { targetProps, tooltipProps } = usePopperDefault<HTMLDivElement>(placement)
 
   const chilrenNumber = React.Children.count(children)
@@ -128,15 +137,12 @@ const Wrapper: React.FC<WrapperProps> = ({ children, tooltip, placement, as, foc
   const TargetComponent = as || 'div'
 
   return (
-    <TargetComponent {...targetProps}>
+    <TargetComponent {...targetProps} {...props}>
       {children}
       <Tooltip {...tooltipProps}>{tooltip}</Tooltip>
     </TargetComponent>
   )
-}
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+}) as StyledComponent<'div', any, WrapperProps>
 
-interface MemoizedWrapperProps extends WrapperProps {
-  children?: ReactNode
-}
-
-export const TooltipWrapper = React.memo<MemoizedWrapperProps>(Wrapper)
+export const TooltipWrapper = (React.memo(Wrapper) as unknown) as typeof Wrapper

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,31 +1,71 @@
 import React, { ReactNode, CSSProperties } from 'react'
 import Portal from './Portal'
-import { usePopperDefault } from 'hooks/usePopper'
+import { usePopperDefault, TOOLTIP_OFFSET } from 'hooks/usePopper'
 import { State, Placement } from '@popperjs/core'
+import styled from 'styled-components'
+
+const TooltipOuter = styled.div<Pick<TooltipBaseProps, 'isShown'>>`
+  visibility: ${(props): string | false => !props.isShown && 'hidden'};
+`
+
+const TooltipArrow = styled.div`
+  &,
+  ::before {
+    position: absolute;
+    width: ${TOOLTIP_OFFSET}px;
+    height: ${TOOLTIP_OFFSET}px;
+    z-index: -1;
+  }
+
+  ::before {
+    content: '';
+    transform: rotate(45deg);
+    background: #333;
+  }
+`
+
+const TooltipInner = styled.div`
+  background: #333;
+  color: white;
+  font-weight: bold;
+  padding: 4px 8px;
+  font-size: 13px;
+  border-radius: 4px;
+
+  &[data-popper-placement^='top'] > ${TooltipArrow} {
+    bottom: -${TOOLTIP_OFFSET / 2}px;
+  }
+
+  &[data-popper-placement^='bottom'] > ${TooltipArrow} {
+    top: -${TOOLTIP_OFFSET / 2}px;
+  }
+
+  &[data-popper-placement^='left'] > ${TooltipArrow} {
+    right: -${TOOLTIP_OFFSET / 2}px;
+  }
+
+  &[data-popper-placement^='right'] > ${TooltipArrow} {
+    left: -${TOOLTIP_OFFSET / 2}px;
+  }
+`
 
 interface TooltipBaseProps {
   isShown: boolean
   state: Partial<Pick<State, 'placement' | 'styles'>>
 }
 
-const TooltipBase: React.FC<TooltipProps> = ({ children, isShown, state }, ref) => {
+const TooltipBase: React.FC<TooltipBaseProps> = ({ children, isShown, state }, ref) => {
   const { placement, styles = {} } = state
 
   return (
     // Portal isolates popup styles from the App styles
     <Portal>
-      <div style={isShown ? undefined : { visibility: 'hidden' }}>
-        <div
-          className="tooltip"
-          role="tooltip"
-          ref={ref}
-          style={styles.popper as CSSProperties}
-          data-popper-placement={placement}
-        >
-          <div className="arrow" data-popper-arrow style={styles.arrow as CSSProperties} />
+      <TooltipOuter isShown={isShown}>
+        <TooltipInner role="tooltip" ref={ref} style={styles.popper as CSSProperties} data-popper-placement={placement}>
+          <TooltipArrow data-popper-arrow style={styles.arrow as CSSProperties} />
           {isShown && children}
-        </div>
-      </div>
+        </TooltipInner>
+      </TooltipOuter>
     </Portal>
   )
 }

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,53 @@
+import React, { ReactNode, CSSProperties } from 'react'
+import Portal from './Portal'
+import { usePopperDefault } from 'hooks/usePopper'
+import { State, Placement } from '@popperjs/core'
+
+interface TooltipBaseProps {
+  isShown: boolean
+  state: Partial<Pick<State, 'placement' | 'styles'>>
+}
+
+const TooltipBase: React.FC<TooltipProps> = ({ children, isShown, state }, ref) => {
+  const { placement, styles = {} } = state
+
+  return (
+    // Portal isolates popup styles from the App styles
+    <Portal>
+      <div style={isShown ? undefined : { visibility: 'hidden' }}>
+        <div
+          className="tooltip"
+          role="tooltip"
+          ref={ref}
+          style={styles.popper as CSSProperties}
+          data-popper-placement={placement}
+        >
+          <div className="arrow" data-popper-arrow style={styles.arrow as CSSProperties} />
+          {isShown && children}
+        </div>
+      </div>
+    </Portal>
+  )
+}
+
+interface TooltipProps extends TooltipBaseProps {
+  children?: ReactNode
+}
+
+export const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(TooltipBase)
+
+interface WrapperProps {
+  tooltip: ReactNode
+  placement?: Placement
+}
+
+export const TooltipWrapper: React.FC<WrapperProps> = ({ children, tooltip, placement }) => {
+  const { targetProps, tooltipProps } = usePopperDefault<HTMLDivElement>(placement)
+
+  return (
+    <div {...targetProps}>
+      {children}
+      <Tooltip {...tooltipProps}>{tooltip}</Tooltip>
+    </div>
+  )
+}

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -104,11 +104,11 @@ const Wrapper = <C extends keyof JSX.IntrinsicElements | React.ComponentType = '
 WrapperPropsAll<C> & { children?: ReactNode }): React.ReactElement => {
   const { targetProps, tooltipProps } = usePopperDefault<HTMLDivElement>(placement)
 
-  const chilrenNumber = React.Children.count(children)
+  const childrenNumber = React.Children.count(children)
 
   // can attach ref to element
   // if children is a single element, not just text, and `as` tag|Component not specified
-  if (chilrenNumber === 1 && typeof as === 'undefined' && isElement(children) && !isFragment(children)) {
+  if (childrenNumber === 1 && typeof as === 'undefined' && isElement(children) && !isFragment(children)) {
     let finalTargetProps:
       | typeof targetProps
       | Omit<typeof targetProps, 'onMouseEnter' | 'onMouseLeave'>

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -5,10 +5,11 @@ import { State, Placement } from '@popperjs/core'
 import styled from 'styled-components'
 import { isElement, isFragment } from 'react-is'
 
+// visibility necessary for correct boundingRect calculation by popper
 const TooltipOuter = styled.div<Pick<TooltipBaseProps, 'isShown'>>`
-  visibility: ${(props): string | false => !props.isShown && 'hidden'};
+  visibility: ${(props): 'hidden' | false => !props.isShown && 'hidden'};
 `
-
+// can style anything but TOOLTIP_OFFSET fields, position and transform: rotate
 const TooltipArrow = styled.div`
   &,
   ::before {

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -90,8 +90,13 @@ interface WrapperProps<C> {
 type WrapperPropsAll<T extends keyof JSX.IntrinsicElements | React.ComponentType = 'div'> = WrapperProps<T> &
   React.ComponentProps<T>
 
-// using StyledComponent type since it properly types as={Component}
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// can be used as
+// <Wrapper tooltip={}><button onClick={handler}/></Wrapper>
+// <Wrapper as="button" onClick={handler} tooltip={}><button/></Wrapper>
+// <Wrapper tooltip={} focus={false}><input onFocus={special_handler}/></Wrapper> --> don't touch onFocus
+// single child component gets cloned and ref assigned
+// <Wrapper onClick={handler} tooltip={}><button/><span/></Wrapper>
+// multiple children get wrapped in div
 const Wrapper = <C extends keyof JSX.IntrinsicElements | React.ComponentType = 'div'>({
   children,
   tooltip,
@@ -100,8 +105,7 @@ const Wrapper = <C extends keyof JSX.IntrinsicElements | React.ComponentType = '
   focus = true,
   hover = true,
   ...props
-}: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-WrapperPropsAll<C> & { children?: ReactNode }): React.ReactElement => {
+}: WrapperPropsAll<C> & { children?: ReactNode }): React.ReactElement => {
   const { targetProps, tooltipProps } = usePopperDefault<HTMLDivElement>(placement)
 
   const childrenNumber = React.Children.count(children)
@@ -113,6 +117,7 @@ WrapperPropsAll<C> & { children?: ReactNode }): React.ReactElement => {
       | typeof targetProps
       | Omit<typeof targetProps, 'onMouseEnter' | 'onMouseLeave'>
       | Omit<typeof targetProps, 'onFocus' | 'onBlur'>
+      | {} = {}
     if (focus && hover) {
       // pass all targetProps by default
       finalTargetProps = targetProps
@@ -148,6 +153,7 @@ WrapperPropsAll<C> & { children?: ReactNode }): React.ReactElement => {
   const TargetComponent = (as || 'div') as keyof JSX.IntrinsicElements | React.ComponentType<any>
 
   return (
+    // extra props on <TooltipWrapper {...props}/> get passed onto TargteComponent
     <TargetComponent {...targetProps} {...props}>
       {children}
       <Tooltip {...tooltipProps}>{tooltip}</Tooltip>

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -74,7 +74,7 @@ interface TooltipProps extends TooltipBaseProps {
   children?: ReactNode
 }
 
-export const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(TooltipBase)
+export const Tooltip = React.memo(React.forwardRef<HTMLDivElement, TooltipProps>(TooltipBase))
 
 interface WrapperProps {
   tooltip: ReactNode
@@ -91,3 +91,9 @@ export const TooltipWrapper: React.FC<WrapperProps> = ({ children, tooltip, plac
     </div>
   )
 }
+
+interface MemoizedWrapperProps extends WrapperProps {
+  children?: ReactNode
+}
+
+export const TooltipWrapper = React.memo<MemoizedWrapperProps>(Wrapper)

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -308,7 +308,7 @@ const TokenRow: React.FC<Props> = ({
         <strong>{selectLabel}</strong>
         <span>
           {/* can pass props to as={Component} */}
-          <TooltipWrapper as="a" tooltip="Deposit" onClick={console.log}>
+          <TooltipWrapper as="button" tooltip="Deposit" onClick={console.log}>
             + Deposit
           </TooltipWrapper>
           {/* <button>+ Deposit</button> */}

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -18,6 +18,8 @@ import { ZERO } from 'const'
 
 import { TradeFormTokenId, TradeFormData } from './'
 
+import { TooltipWrapper } from 'components/Tooltip'
+
 const Wrapper = styled.div`
   display: flex;
   justify-content: space-between;
@@ -305,36 +307,42 @@ const TokenRow: React.FC<Props> = ({
       <div>
         <strong>{selectLabel}</strong>
         <span>
-          <button>+ Deposit</button>
+          <TooltipWrapper as="button" tooltip="Deposit">
+            + Deposit
+          </TooltipWrapper>
+          {/* <button>+ Deposit</button> */}
           <span>
             Balance:
-            <WalletDetail>
+            <TooltipWrapper as={WalletDetail} tooltip="Fill maximum">
               {' '}
               {balance ? formatAmount(balance.totalExchangeBalance, balance.decimals) : '0'}
               {validateMaxAmount && <a onClick={useMax}>max</a>}
-            </WalletDetail>
+            </TooltipWrapper>
             <i aria-label="Tooltip"></i>
           </span>
         </span>
       </div>
       <InputBox>
-        <input
-          className={className}
-          placeholder="0"
-          name={inputId}
-          type="text"
-          disabled={isDisabled}
-          required
-          ref={register({
-            pattern: { value: validInputPattern, message: 'Invalid amount' },
-            validate: { positive: validatePositive },
-          })}
-          onKeyPress={onKeyPress}
-          onChange={enforcePrecision}
-          onBlur={removeExcessZeros}
-          tabIndex={tabIndex + 2}
-          onFocus={(e): void => e.target.select()}
-        />
+        <TooltipWrapper tooltip="input amount">
+          <input
+            className={className}
+            placeholder="0"
+            name={inputId}
+            type="text"
+            disabled={isDisabled}
+            required
+            ref={register({
+              pattern: { value: validInputPattern, message: 'Invalid amount' },
+              validate: { positive: validatePositive },
+            })}
+            onKeyPress={onKeyPress}
+            onChange={enforcePrecision}
+            onBlur={removeExcessZeros}
+            tabIndex={tabIndex + 2}
+            onFocus={(e): void => e.target.select()}
+          />
+        </TooltipWrapper>
+
         {/* <WalletDetail>
           <div>
             <strong>Wallet:</strong> {displayBalance(balance, 'walletBalance')}

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -323,7 +323,8 @@ const TokenRow: React.FC<Props> = ({
         </span>
       </div>
       <InputBox>
-        <TooltipWrapper tooltip="input amount">
+        {/* focus = false as we already do stuff onFocus; to combine tooltips better use hook */}
+        <TooltipWrapper tooltip="input amount" focus={false}>
           <input
             className={className}
             placeholder="0"

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -307,7 +307,8 @@ const TokenRow: React.FC<Props> = ({
       <div>
         <strong>{selectLabel}</strong>
         <span>
-          <TooltipWrapper as="button" tooltip="Deposit">
+          {/* can pass props to as={Component} */}
+          <TooltipWrapper as="a" tooltip="Deposit" onClick={console.log}>
             + Deposit
           </TooltipWrapper>
           {/* <button>+ Deposit</button> */}

--- a/src/hooks/usePopper.ts
+++ b/src/hooks/usePopper.ts
@@ -11,7 +11,7 @@ const defaultConfig: Partial<Options> & Pick<Options, 'modifiers'> = {
       // move slightly to make space for the arrow element
       name: 'offset',
       options: {
-        offset: [0, 8],
+        offset: [0, TOOLTIP_OFFSET],
       },
     },
   ],

--- a/src/hooks/usePopper.ts
+++ b/src/hooks/usePopper.ts
@@ -1,6 +1,8 @@
 import { useRef, useEffect, RefObject, useState, useMemo, useLayoutEffect } from 'react'
 import { createPopper, Instance, Options, State, Placement } from '@popperjs/core'
 
+export const TOOLTIP_OFFSET = 8 // px
+
 const defaultConfig: Partial<Options> & Pick<Options, 'modifiers'> = {
   // default tooltip placement
   placement: 'top',

--- a/src/hooks/usePopper.ts
+++ b/src/hooks/usePopper.ts
@@ -66,7 +66,8 @@ const usePopper = <T extends HTMLElement, U extends HTMLElement = HTMLDivElement
     return (): void => {
       popper.destroy()
     }
-  }, [config])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // memoize what doesn't change between rerenders
   const stableProps = useMemo(
@@ -111,7 +112,7 @@ interface PopperDefaultHookResult<T extends HTMLElement> {
 }
 
 // Popper hook using default triggers
-export const usePopperDefault = <T extends HTMLElement>(placement?: Placement): PopperDefaultHookResult<T> => {
+export const usePopperDefault = <T extends HTMLElement>(placement: Placement = 'top'): PopperDefaultHookResult<T> => {
   const { target, show, hide, ...tooltipProps } = usePopper<T>({
     placement,
   })

--- a/src/hooks/usePopper.ts
+++ b/src/hooks/usePopper.ts
@@ -38,7 +38,7 @@ const createConfig = (
   return finalConfig
 }
 
-interface PopperHookResult<T extends HTMLElement, U extends HTMLElement = HTMLDivElement> {
+interface Result<T extends HTMLElement, U extends HTMLElement = HTMLDivElement> {
   show(): void
   hide(): void
   target: RefObject<T>
@@ -49,7 +49,7 @@ interface PopperHookResult<T extends HTMLElement, U extends HTMLElement = HTMLDi
 
 const usePopper = <T extends HTMLElement, U extends HTMLElement = HTMLDivElement>(
   config?: Partial<Options>,
-): PopperHookResult<T, U> => {
+): Result<T, U> => {
   const [isShown, setIsShown] = useState(false)
   const popupRef = useRef<U>(null)
   const targetRef = useRef<T>(null)
@@ -104,15 +104,15 @@ interface PopperDefaultHookResult<T extends HTMLElement> {
   // default triggers for the tooltip
   // can spread over target element
   targetProps: {
-    onMouseEnter: PopperHookResult<T>['show']
-    onMouseLeave: PopperHookResult<T>['hide']
-    onFocus: PopperHookResult<T>['show']
-    onBlur: PopperHookResult<T>['hide']
-    ref: PopperHookResult<T>['target']
+    onMouseEnter: Result<T>['show']
+    onMouseLeave: Result<T>['hide']
+    onFocus: Result<T>['show']
+    onBlur: Result<T>['hide']
+    ref: Result<T>['target']
   }
   // tooltip state
   // can spread over Tooltip component
-  tooltipProps: Pick<PopperHookResult<T>, 'ref' | 'isShown' | 'state'>
+  tooltipProps: Pick<Result<T>, 'ref' | 'isShown' | 'state'>
 }
 
 // Popper hook using default triggers

--- a/src/hooks/usePopper.ts
+++ b/src/hooks/usePopper.ts
@@ -1,5 +1,5 @@
 import { useRef, useEffect, RefObject, useState, useMemo, useLayoutEffect } from 'react'
-import { createPopper, Instance, Options, State, Placement } from '@popperjs/core'
+import { Instance, Options, State, Placement } from '@popperjs/core'
 
 export const TOOLTIP_OFFSET = 8 // px
 
@@ -59,12 +59,16 @@ const usePopper = <T extends HTMLElement, U extends HTMLElement = HTMLDivElement
   useEffect(() => {
     if (!targetRef.current || !popupRef.current) return
 
-    const popper = createPopper(targetRef.current, popupRef.current, createConfig(config, setState))
-
-    popperRef.current = popper
+    import(
+      /* webpackChunkName: "popper_chunk"*/
+      '@popperjs/core'
+    ).then(({ createPopper }) => {
+      if (!targetRef.current || !popupRef.current) return
+      popperRef.current = createPopper(targetRef.current, popupRef.current, createConfig(config, setState))
+    })
 
     return (): void => {
-      popper.destroy()
+      popperRef.current?.destroy()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -83,7 +87,7 @@ const usePopper = <T extends HTMLElement, U extends HTMLElement = HTMLDivElement
   // LayoutEffect gets applied before browser paint
   // avoids unnecessary restyling
   useLayoutEffect(() => {
-    isShown && popperRef.current && popperRef.current.forceUpdate()
+    isShown && popperRef.current?.forceUpdate()
   }, [isShown])
 
   return useMemo(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,6 +1413,11 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@popperjs/core@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.0.6.tgz#5a39ac118811ca844155b0ad5190b8c24f35e533"
+  integrity sha512-zj7Gw8QC4jmR92eKUvtrZUEpl2ypRbq+qlE4pwf9n2hnUO9BOAcWUs4/Ht+gNIbFt98xtqhLvccdCfD469MzpQ==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1723,24 +1728,6 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.19.0":
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.19.0.tgz#d5ca732f22c009e515ba09fcceb5f2127d841568"
-  integrity sha512-zwpg6zEOPbhB3+GaQfufzlMUOO6GXCNZq6skk+b2ZkZAIoBhVoanWK255BS1g5x9bMwHpLhX0Rpn5Fc3NdCZdg==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.19.0"
-    eslint-scope "^5.0.0"
-
-"@typescript-eslint/experimental-utils@2.19.2", "@typescript-eslint/experimental-utils@^2.5.0":
-  version "2.19.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.19.2.tgz#4611d44cf0f0cb460c26aa7676fc0a787281e233"
-  integrity sha512-B88QuwT1wMJR750YvTJBNjMZwmiPpbmKYLm1yI7PCc3x0NariqPwqaPsoJRwU9DmUi0cd9dkhz1IqEnwfD+P1A==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.19.2"
-    eslint-scope "^5.0.0"
-
 "@typescript-eslint/experimental-utils@2.19.0", "@typescript-eslint/experimental-utils@^2.5.0":
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.19.0.tgz#d5ca732f22c009e515ba09fcceb5f2127d841568"
@@ -1748,6 +1735,15 @@
   dependencies:
     "@types/json-schema" "^7.0.3"
     "@typescript-eslint/typescript-estree" "2.19.0"
+    eslint-scope "^5.0.0"
+
+"@typescript-eslint/experimental-utils@2.19.2":
+  version "2.19.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.19.2.tgz#4611d44cf0f0cb460c26aa7676fc0a787281e233"
+  integrity sha512-B88QuwT1wMJR750YvTJBNjMZwmiPpbmKYLm1yI7PCc3x0NariqPwqaPsoJRwU9DmUi0cd9dkhz1IqEnwfD+P1A==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.19.2"
     eslint-scope "^5.0.0"
 
 "@typescript-eslint/parser@^2.18.0":
@@ -1777,19 +1773,6 @@
   version "2.19.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.19.2.tgz#67485b00172f400474d243c6c0be27581a579350"
   integrity sha512-Xu/qa0MDk6upQWqE4Qy2X16Xg8Vi32tQS2PR0AvnT/ZYS4YGDvtn2MStOh5y8Zy2mg4NuL06KUHlvCh95j9C6Q==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^6.3.0"
-    tsutils "^3.17.1"
-
-"@typescript-eslint/typescript-estree@2.19.0":
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.19.0.tgz#6bd7310b9827e04756fe712909f26956aac4b196"
-  integrity sha512-n6/Xa37k0jQdwpUszffi19AlNbVCR0sdvCs3DmSKMD7wBttKY31lhD2fug5kMD91B2qW4mQldaTEc1PEzvGu8w==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1635,6 +1635,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-is@^16.7.1":
+  version "16.7.1"
+  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-16.7.1.tgz#d3f1c68c358c00ce116b55ef5410cf486dd08539"
+  integrity sha512-dMLFD2cCsxtDgMkTydQCM0PxDq8vwc6uN5M/jRktDfYvH3nQj6pjC9OrCXS2lKlYoYTNJorI/dI8x9dpLshexQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-native@*":
   version "0.61.7"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.61.7.tgz#e0315b5f627d61470c7f58d7298e732aab90b2c5"


### PR DESCRIPTION
Adds

- Hook for Popper.js
- Hook with reasonable defaults ready to plug-n-play
- TooltipComponent for easy plug-n-play tooltips
- Sample tooltips on `/trade` page (style pending)

![localhost_8080_trade_DAI-USDC_sell=0 buy=0 expires=2880](https://user-images.githubusercontent.com/5121491/74742697-17f57b00-5270-11ea-9596-fce426bda761.png)

Tooltips don't have to look like that or like anything really, can be whole components inside