### PR TITLE
483/liquidity orders tab

### DIFF
--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -122,7 +122,7 @@ interface AmountsProps extends Pick<Props, 'order' | 'pending'> {
 }
 
 const Amounts: React.FC<AmountsProps> = ({ sellToken, order, isUnlimited }) => {
-  const unfilledAmount = useMemo(() => {
+  const filledAmount = useMemo(() => {
     const filledAmount = order.priceDenominator.sub(order.remainingAmount)
 
     return formatAmount(filledAmount, sellToken.decimals) || '0'
@@ -140,7 +140,7 @@ const Amounts: React.FC<AmountsProps> = ({ sellToken, order, isUnlimited }) => {
       ) : (
         <>
           <div className="amounts">
-            {unfilledAmount} {displayTokenSymbolOrLink(sellToken)}
+            {filledAmount} {displayTokenSymbolOrLink(sellToken)}
             <br />
             {totalAmount} {displayTokenSymbolOrLink(sellToken)}
           </div>

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -31,8 +31,7 @@ interface ShowOrdersButtonProps {
 
 const ShowOrdersButton: React.FC<ShowOrdersButtonProps> = ({ type, isActive, count, onClick }) => (
   <button className={type} disabled={isActive} onClick={onClick}>
-    {!isActive ? <Highlight>{count}</Highlight> : <>{count}</>}
-    <> {type}</>
+    {!isActive ? <Highlight>{count}</Highlight> : { count }} {type}
   </button>
 )
 

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -3,6 +3,7 @@ import React, { useMemo, useCallback, useEffect } from 'react'
 import { unstable_batchedUpdates } from 'react-dom'
 import { faTrashAlt } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { isOrderUnlimited } from '@gnosis.pm/dex-js'
 
 import { useOrders } from 'hooks/useOrders'
 import useSafeState from 'hooks/useSafeState'
@@ -19,23 +20,32 @@ import Highlight from 'components/Highlight'
 import OrderRow from './OrderRow'
 import { OrdersWrapper, ButtonWithIcon, OrdersForm, CreateButtons } from './OrdersWidget.styled'
 
+type OrderTabs = 'active' | 'liquidity' | 'expired'
+
 interface ShowOrdersButtonProps {
-  type: 'active' | 'expired'
+  type: OrderTabs
   isActive: boolean
-  shownCount: number
-  hiddenCount: number
-  onClick: () => void
+  count: number
+  onClick: (event: React.SyntheticEvent<HTMLButtonElement | HTMLFormElement>) => void
 }
 
-const ShowOrdersButton: React.FC<ShowOrdersButtonProps> = ({ type, isActive, shownCount, hiddenCount, onClick }) => {
-  const count = isActive ? shownCount : hiddenCount
+const ShowOrdersButton: React.FC<ShowOrdersButtonProps> = ({ type, isActive, count, onClick }) => (
+  <button className={type} disabled={isActive} onClick={onClick}>
+    {!isActive ? <Highlight>{count}</Highlight> : <>{count}</>}
+    <> {type}</>
+  </button>
+)
 
-  return (
-    <button className={type} disabled={isActive} onClick={onClick}>
-      {!isActive ? <Highlight>{count}</Highlight> : <>{count}</>}
-      <> {type}</>
-    </button>
-  )
+type FilteredOrdersState = {
+  [key in OrderTabs]: { orders: AuctionElement[]; markedForDeletion: Set<string> }
+}
+
+function emptyState(): FilteredOrdersState {
+  return {
+    active: { orders: [], markedForDeletion: new Set() },
+    expired: { orders: [], markedForDeletion: new Set() },
+    liquidity: { orders: [], markedForDeletion: new Set() },
+  }
 }
 
 const OrdersWidget: React.FC = () => {
@@ -44,49 +54,104 @@ const OrdersWidget: React.FC = () => {
   // this page is behind login wall so networkId should always be set
   const { networkId } = useWalletConnection()
 
-  const [orders, setOrders] = useSafeState<AuctionElement[]>(allOrders)
-  const [showActive, setShowActive] = useSafeState<boolean>(true)
+  // allOrders and markedForDeletion, split by tab
+  const [filteredOrders, setFilteredOrders] = useSafeState<FilteredOrdersState>(emptyState())
+  const [selectedTab, setSelectedTab] = useSafeState<OrderTabs>('active')
 
-  const toggleShowActive = useCallback(() => {
-    setShowActive(isActive => !isActive)
-  }, [setShowActive])
+  // syntactic sugar
+  const { displayedOrders, markedForDeletion } = useMemo(
+    () => ({
+      displayedOrders: filteredOrders[selectedTab].orders,
+      markedForDeletion: filteredOrders[selectedTab].markedForDeletion,
+    }),
+    [filteredOrders, selectedTab],
+  )
 
+  const setSelectedTabFactory = useCallback(
+    (type: OrderTabs): ((event: React.SyntheticEvent<HTMLButtonElement | HTMLFormElement>) => void) => (
+      event: React.SyntheticEvent<HTMLButtonElement | HTMLFormElement>,
+    ): void => {
+      // form is being submitted when clicking on tab buttons, thus preventing default
+      event.preventDefault()
+
+      setSelectedTab(type)
+    },
+    [setSelectedTab],
+  )
+
+  // Update filteredOrders state whenever there's a change to allOrders
+  // splitting orders into respective tabs
   useEffect(() => {
     const now = new Date()
-    const filtered = allOrders.filter(order => showActive === isOrderActive(order, now))
-    setOrders(filtered)
-  }, [allOrders, setOrders, showActive])
 
-  const shownOrdersCount = orders.length
+    const filteredOrders = emptyState()
+
+    allOrders.forEach(order => {
+      if (!isOrderActive(order, now)) {
+        filteredOrders.expired.orders.push(order)
+      } else if (isOrderUnlimited(order.priceDenominator, order.priceNumerator)) {
+        filteredOrders.liquidity.orders.push(order)
+      } else {
+        filteredOrders.active.orders.push(order)
+      }
+    })
+
+    setFilteredOrders(curr => {
+      // copy markedForDeletion
+      Object.keys(filteredOrders).forEach(
+        type => (filteredOrders[type].markedForDeletion = curr[type].markedForDeletion),
+      )
+      return filteredOrders
+    })
+  }, [allOrders, setFilteredOrders])
+
   const pendingShownOrdersCount = pendingOrders.length
-  const hiddenOrdersCount = allOrders.length - shownOrdersCount
 
   const noOrders = allOrders.length === 0
 
   const overBalanceOrders = useMemo(
     () =>
-      new Set<string>(orders.filter(order => order.remainingAmount.gt(order.sellTokenBalance)).map(order => order.id)),
-    [orders],
+      new Set<string>(
+        displayedOrders.filter(order => order.remainingAmount.gt(order.sellTokenBalance)).map(order => order.id),
+      ),
+    [displayedOrders],
   )
 
-  const [markedForDeletion, setMarkedForDeletion] = useSafeState<Set<string>>(new Set())
-
   const toggleMarkForDeletionFactory = useCallback(
-    (orderId: string): (() => void) => (): void =>
-      setMarkedForDeletion(curr => {
-        const newSet = new Set(curr)
+    (orderId: string, selectedTab: OrderTabs): (() => void) => (): void =>
+      setFilteredOrders(curr => {
+        const state = emptyState()
+
+        // copy full state
+        Object.keys(curr).forEach(tab => (state[tab] = curr[tab]))
+
+        // copy markedForDeletion set
+        const newSet = new Set(curr[selectedTab].markedForDeletion)
+        // toggle order
         newSet.has(orderId) ? newSet.delete(orderId) : newSet.add(orderId)
-        return newSet
+        // store new set
+        state[selectedTab].markedForDeletion = newSet
+
+        return state
       }),
-    [setMarkedForDeletion],
+    [setFilteredOrders],
   )
 
   const toggleSelectAll = useCallback(
-    ({ currentTarget: { checked } }: React.SyntheticEvent<HTMLInputElement>) => {
-      const newSet: Set<string> = checked ? new Set(orders.map(order => order.id)) : new Set()
-      setMarkedForDeletion(newSet)
-    },
-    [orders, setMarkedForDeletion],
+    ({ currentTarget: { checked } }: React.SyntheticEvent<HTMLInputElement>) =>
+      setFilteredOrders(curr => {
+        const state = emptyState()
+
+        // copy full state
+        Object.keys(curr).forEach(tab => (state[tab] = curr[tab]))
+
+        state[selectedTab].markedForDeletion = checked
+          ? new Set(filteredOrders[selectedTab].orders.map(order => order.id))
+          : new Set()
+
+        return state
+      }),
+    [filteredOrders, selectedTab, setFilteredOrders],
   )
 
   const { deleteOrders, deleting } = useDeleteOrders()
@@ -100,157 +165,168 @@ const OrdersWidget: React.FC = () => {
       if (success) {
         unstable_batchedUpdates(() => {
           // reset selections
-          setOrders(orders.filter(order => !markedForDeletion.has(order.id)))
-          setMarkedForDeletion(new Set<string>())
+
+          setFilteredOrders(curr => {
+            const state = emptyState()
+
+            // copy full state
+            Object.keys(curr).forEach(tab => (state[tab] = curr[tab]))
+
+            // remove checked orders
+            state[selectedTab].orders = curr[selectedTab].orders.filter(
+              order => !curr[selectedTab].markedForDeletion.has(order.id),
+            )
+            // clear orders to delete
+            state[selectedTab].markedForDeletion = new Set<string>()
+            return state
+          })
 
           // update the list of orders
           forceOrdersRefresh()
         })
       }
     },
-    [deleteOrders, forceOrdersRefresh, markedForDeletion, orders, setMarkedForDeletion, setOrders],
+    [deleteOrders, forceOrdersRefresh, markedForDeletion, selectedTab, setFilteredOrders],
   )
 
   return (
     <OrdersWrapper>
       {noOrders && (
         <div>
-          {/* <h2>Your orders</h2> */}
           <CreateButtons className={noOrders ? 'withoutOrders' : 'withOrders'}>
             {noOrders && (
               <p className="noOrdersInfo">
                 It appears you haven&apos;t placed any order yet. <br /> Create one!
               </p>
             )}
-            {/*
-          <a href="/" className="strategyInfo">
-            <small>Learn more about liquidity</small>
-          </a>
-          */}
           </CreateButtons>
         </div>
       )}
       {!noOrders && networkId && (
         <OrdersForm>
-          <div className="infoContainer">
-            <div className="countContainer">
-              {/* <div className="total">
-                You have <Highlight>{allOrders.length}</Highlight> standing orders:
-              </div> */}
-              <ShowOrdersButton
-                type="active"
-                isActive={showActive}
-                shownCount={shownOrdersCount}
-                hiddenCount={hiddenOrdersCount}
-                onClick={toggleShowActive}
-              />
-              <ShowOrdersButton
-                type="expired"
-                isActive={!showActive}
-                shownCount={shownOrdersCount}
-                hiddenCount={hiddenOrdersCount}
-                onClick={toggleShowActive}
-              />
-            </div>
-            {/* {overBalanceOrders.size > 0 && showActive && (
-              <div className="warning">
-                <FontAwesomeIcon icon={faExclamationTriangle} />
-                <strong> Low balance</strong>
+          <form action="submit" onSubmit={onSubmit}>
+            <div className="infoContainer">
+              <div className="countContainer">
+                <ShowOrdersButton
+                  type="active"
+                  isActive={selectedTab === 'active'}
+                  count={filteredOrders.active.orders.length}
+                  onClick={setSelectedTabFactory('active')}
+                />
+                <ShowOrdersButton
+                  type="liquidity"
+                  isActive={selectedTab === 'liquidity'}
+                  count={filteredOrders.liquidity.orders.length}
+                  onClick={setSelectedTabFactory('liquidity')}
+                />
+                <ShowOrdersButton
+                  type="expired"
+                  isActive={selectedTab === 'expired'}
+                  count={filteredOrders.expired.orders.length}
+                  onClick={setSelectedTabFactory('expired')}
+                />
               </div>
-            )} */}
-            <div className="deleteContainer">
-              <ButtonWithIcon disabled={markedForDeletion.size == 0 || deleting}>
-                <FontAwesomeIcon icon={faTrashAlt} /> {showActive ? 'Cancel' : 'Delete'} orders
-              </ButtonWithIcon>
-              {/* <span className={markedForDeletion.size == 0 ? '' : 'hidden'}>
-                  Select first the order(s) you want to {showActive ? 'cancel' : 'delete'}
-                </span> */}
-            </div>
-          </div>
-          {/* PENDING ORDERS */}
-          {pendingShownOrdersCount ? (
-            <div>
-              <h3>Pending Orders</h3>
-              <div className="ordersContainer">
-                <CardTable
-                  $columns="minmax(13.625rem, 1.3fr) repeat(2, minmax(6.2rem, 0.6fr)) minmax(5.5rem, 0.6fr)"
-                  $cellSeparation="0.2rem"
-                  $rowSeparation="0.6rem"
-                >
-                  <thead>
-                    <tr>
-                      <th>Order details</th>
-                      <th>Unfilled amount</th>
-                      <th>Account balance</th>
-                      <th>Expires</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {pendingOrders.map((order: PendingTxObj) => (
-                      <OrderRow
-                        key={Math.random()}
-                        order={order}
-                        networkId={networkId}
-                        isOverBalance={false}
-                        pending
-                        disabled={deleting}
-                        isPendingOrder
-                      />
-                    ))}
-                  </tbody>
-                </CardTable>
+              {/* {overBalanceOrders.size > 0 && showActive && (
+                <div className="warning">
+                  <FontAwesomeIcon icon={faExclamationTriangle} />
+                  <strong> Low balance</strong>
+                </div>
+              )} */}
+              <div className="deleteContainer">
+                <ButtonWithIcon disabled={markedForDeletion.size === 0 || deleting}>
+                  <FontAwesomeIcon icon={faTrashAlt} />{' '}
+                  {['active', 'liquidity'].includes(selectedTab) ? 'Cancel' : 'Delete'} {markedForDeletion.size} orders
+                </ButtonWithIcon>
+                {/* <span className={markedForDeletion.size == 0 ? '' : 'hidden'}>
+                    Select first the order(s) you want to {showActive ? 'cancel' : 'delete'}
+                  </span> */}
               </div>
             </div>
-          ) : null}
+            {/* PENDING ORDERS */}
+            {pendingShownOrdersCount ? (
+              <div>
+                <h3>Pending Orders</h3>
+                <div className="ordersContainer">
+                  <CardTable
+                    $columns="minmax(13.625rem, 1.3fr) repeat(2, minmax(6.2rem, 0.6fr)) minmax(5.5rem, 0.6fr)"
+                    $cellSeparation="0.2rem"
+                    $rowSeparation="0.6rem"
+                  >
+                    <thead>
+                      <tr>
+                        <th>Order details</th>
+                        <th>Unfilled amount</th>
+                        <th>Account balance</th>
+                        <th>Expires</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {pendingOrders.map((order: PendingTxObj) => (
+                        <OrderRow
+                          key={Math.random()}
+                          order={order}
+                          networkId={networkId}
+                          isOverBalance={false}
+                          pending
+                          disabled={deleting}
+                          isPendingOrder
+                        />
+                      ))}
+                    </tbody>
+                  </CardTable>
+                </div>
+              </div>
+            ) : null}
 
-          {shownOrdersCount ? (
-            <form action="submit" onSubmit={onSubmit}>
-              {pendingShownOrdersCount ? <h3>Current Orders</h3> : null}
-              <div className="ordersContainer">
-                <CardTable
-                  // $columns="minmax(2rem, min-content) minmax(13.625rem, 1fr) repeat(2, minmax(6.2rem, 0.6fr)) minmax(5.5rem, 1fr)"
-                  $columns="minmax(2rem,.4fr)  minmax(11rem,1fr)  minmax(11rem,1.3fr)  minmax(5rem,.9fr)  minmax(auto,1.4fr)"
-                  // $cellSeparation="0 .5rem;"
-                  $rowSeparation="0"
-                >
-                  <thead>
-                    <tr>
-                      <th className="checked">
-                        <input
-                          type="checkbox"
-                          onChange={toggleSelectAll}
-                          checked={orders.length === markedForDeletion.size}
+            {displayedOrders.length > 0 ? (
+              <>
+                {pendingShownOrdersCount ? <h3>Current Orders</h3> : null}
+                <div className="ordersContainer">
+                  <CardTable
+                    // $columns="minmax(2rem, min-content) minmax(13.625rem, 1fr) repeat(2, minmax(6.2rem, 0.6fr)) minmax(5.5rem, 1fr)"
+                    $columns="minmax(2rem,.4fr)  minmax(11rem,1fr)  minmax(11rem,1.3fr)  minmax(5rem,.9fr)  minmax(auto,1.4fr)"
+                    // $cellSeparation="0 .5rem;"
+                    $rowSeparation="0"
+                  >
+                    <thead>
+                      <tr>
+                        <th className="checked">
+                          <input
+                            type="checkbox"
+                            onChange={toggleSelectAll}
+                            checked={markedForDeletion.size === displayedOrders.length}
+                            disabled={deleting}
+                          />
+                        </th>
+                        <th>Limit price</th>
+                        <th className="filled">Filled / Total</th>
+                        <th>Expires</th>
+                        <th className="status">Status</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {displayedOrders.map(order => (
+                        <OrderRow
+                          key={order.id}
+                          order={order}
+                          networkId={networkId}
+                          isOverBalance={overBalanceOrders.has(order.id)}
+                          isMarkedForDeletion={markedForDeletion.has(order.id)}
+                          toggleMarkedForDeletion={toggleMarkForDeletionFactory(order.id, selectedTab)}
+                          pending={deleting && markedForDeletion.has(order.id)}
                           disabled={deleting}
                         />
-                      </th>
-                      <th>Limit price</th>
-                      <th className="filled">Filled / Total</th>
-                      <th>Expires</th>
-                      <th className="status">Status</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {orders.map(order => (
-                      <OrderRow
-                        key={order.id}
-                        order={order}
-                        networkId={networkId}
-                        isOverBalance={overBalanceOrders.has(order.id)}
-                        isMarkedForDeletion={markedForDeletion.has(order.id)}
-                        toggleMarkedForDeletion={toggleMarkForDeletionFactory(order.id)}
-                        pending={deleting && markedForDeletion.has(order.id)}
-                        disabled={deleting}
-                      />
-                    ))}
-                  </tbody>
-                </CardTable>
+                      ))}
+                    </tbody>
+                  </CardTable>
+                </div>
+              </>
+            ) : (
+              <div className="noOrders">
+                <span>You have no {selectedTab} orders</span>
               </div>
-            </form>
-          ) : (
-            <div className="noOrders">
-              <span>You have no {showActive ? 'active' : 'expired'} orders</span>
-            </div>
-          )}
+            )}
+          </form>
         </OrdersForm>
       )}
     </OrdersWrapper>


### PR DESCRIPTION
Closes #483 

 - Using a state for tracking all orders per tab, splitting orders/markedForDeletion
 - Showing amount of orders selected to be deleted
 - Every tab tracks independently which orders were selected
 - Order deletion now works again

![Screenshot from 2020-02-19 15-09-58](https://user-images.githubusercontent.com/43217/74861940-f062e900-5329-11ea-9ff5-9386ebab84af.png)


### Notes: 
- Did not do any styling at all. Would very much like to have the tabs like Michel's design (https://projects.invisionapp.com/share/5XVR9OE6FPJ#/screens/403151253_GnosisProtocol_-_V2-2_-_1_Order)
- ~~Oh my, it's soooo slow. What am I doing wrong?~~ It seems only local is painfully slow. Deployed version is much better, although a bit slow with over 100 orders.
- Still don't know why you need to first switch to a different tab upon refresh to load orders. Related to the `networkId == 0` issue maybe?