### PR TITLE
Tooltips for form input + extra

### DIFF
--- a/src/components/TradeWidget/FormMessage.tsx
+++ b/src/components/TradeWidget/FormMessage.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
 import styled from 'styled-components'
 
-const Wrapper = styled.div`
+const FormMessage = styled.div.attrs<{ className?: string }>(props => ({
+  className: props.className ? undefined : 'error',
+}))`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -42,18 +43,5 @@ const Wrapper = styled.div`
     margin: 0.3rem 0 1rem;
   }
 `
-interface Props {
-  children: React.ReactNode
-  className?: string
-}
 
-const FormMessage: React.FC<Props> = ({ className = 'error', children }, ref) => {
-  return (
-    <Wrapper ref={ref} className={className}>
-      {children}
-    </Wrapper>
-  )
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default React.forwardRef<any, Props>(FormMessage)
+export default FormMessage

--- a/src/components/TradeWidget/InputWithTooltip.tsx
+++ b/src/components/TradeWidget/InputWithTooltip.tsx
@@ -1,0 +1,74 @@
+import React, { ReactNode, useMemo } from 'react'
+import { usePopperDefault } from 'hooks/usePopper'
+import { Placement } from '@popperjs/core'
+import { Tooltip } from 'components/Tooltip'
+
+interface InputProps extends Partial<React.ComponentPropsWithRef<'input'>> {
+  tooltip: ReactNode
+  placement?: Placement
+}
+
+type TargetProps = Pick<
+  React.ComponentPropsWithRef<'input'>,
+  'onBlur' | 'onFocus' | 'onMouseEnter' | 'onMouseLeave' | 'ref'
+>
+
+const InputWithTooltip: React.RefForwardingComponent<HTMLInputElement, InputProps> = (
+  { tooltip, placement, onFocus, onBlur, onMouseEnter, onMouseLeave, ...props },
+  ref,
+) => {
+  const { targetProps, tooltipProps } = usePopperDefault<HTMLInputElement>(placement)
+
+  // compose input event handlers and ref with props form usePopper
+  // that way both tooltips and form logic can function together
+  const finalTargetProps = useMemo<TargetProps>(() => {
+    const composedProps: TargetProps = {}
+    composedProps.onBlur = onBlur
+      ? (event): void => {
+          console.log('event', event.currentTarget)
+          onBlur(event)
+          targetProps.onBlur()
+        }
+      : targetProps.onBlur
+    composedProps.onFocus = onFocus
+      ? (event): void => {
+          onFocus(event)
+          targetProps.onFocus()
+        }
+      : targetProps.onFocus
+    composedProps.onMouseEnter = onMouseEnter
+      ? (event): void => {
+          onMouseEnter(event)
+          targetProps.onMouseEnter()
+        }
+      : targetProps.onMouseEnter
+    composedProps.onMouseLeave = onMouseLeave
+      ? (event): void => {
+          onMouseLeave(event)
+          targetProps.onMouseLeave()
+        }
+      : targetProps.onMouseLeave
+
+    composedProps.ref = ref
+      ? (element: HTMLInputElement): void => {
+          if ('current' in ref) {
+            ;(ref as React.MutableRefObject<HTMLInputElement>).current = element
+          } else if (typeof ref === 'function') {
+            ref(element)
+          }
+          ;(targetProps.ref as React.MutableRefObject<HTMLInputElement>).current = element
+        }
+      : targetProps.ref
+
+    return composedProps
+  }, [onBlur, onFocus, onMouseEnter, onMouseLeave, ref, targetProps])
+
+  return (
+    <>
+      <input {...props} {...finalTargetProps} />
+      <Tooltip {...tooltipProps}>{tooltip}</Tooltip>
+    </>
+  )
+}
+
+export default React.forwardRef<HTMLInputElement, InputProps>(InputWithTooltip)

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -12,6 +12,7 @@ import { TradeFormTokenId, TradeFormData } from './'
 import { TooltipWrapper } from 'components/Tooltip'
 import FormMessage from './FormMessage'
 import { useNumberInput } from './useNumberInput'
+import InputWithTooltip from './InputWithTooltip'
 
 const Wrapper = styled.div`
   display: flex;
@@ -242,9 +243,9 @@ const TokenRow: React.FC<Props> = ({
       <InputBox>
         {/* focus = false as we already do stuff onFocus; to combine tooltips better use hook */}
         {/* <TooltipWrapper tooltip={tooltipText} focus={false}> */}
-        <input
+        <InputWithTooltip
           className={className}
-          title={tooltipText}
+          tooltip={tooltipText}
           placeholder="0"
           name={inputId}
           type="text"

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -241,8 +241,6 @@ const TokenRow: React.FC<Props> = ({
         </span>
       </div>
       <InputBox>
-        {/* focus = false as we already do stuff onFocus; to combine tooltips better use hook */}
-        {/* <TooltipWrapper tooltip={tooltipText} focus={false}> */}
         <InputWithTooltip
           className={className}
           tooltip={tooltipText}
@@ -259,7 +257,6 @@ const TokenRow: React.FC<Props> = ({
           tabIndex={tabIndex + 2}
           onFocus={(e): void => e.target.select()}
         />
-        {/* </TooltipWrapper> */}
 
         {/*
         <FormMessage>

--- a/src/hooks/usePopper.ts
+++ b/src/hooks/usePopper.ts
@@ -121,13 +121,16 @@ export const usePopperDefault = <T extends HTMLElement>(placement: Placement = '
     placement,
   })
 
-  const targetProps = {
-    onMouseEnter: show,
-    onMouseLeave: hide,
-    onFocus: show,
-    onBlur: hide,
-    ref: target,
-  }
+  const targetProps = useMemo(
+    () => ({
+      onMouseEnter: show,
+      onMouseLeave: hide,
+      onFocus: show,
+      onBlur: hide,
+      ref: target,
+    }),
+    [hide, show, target],
+  )
 
   return {
     targetProps,


### PR DESCRIPTION
Simplifies FormMessage component
Enables to use tooltips with <inputs> already hooked to form-hook