### PR TITLE
Expand your orders

### DIFF
--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -360,6 +360,7 @@ const TradeWidget: React.FC = () => {
   const { sell: sellTokenSymbol, buy: receiveTokenSymbol } = useParams()
   const { sellAmount, buyAmount: receiveAmount, validUntil } = useQuery()
 
+  const [ordersVisible, setOrdersVisible] = useState(true)
   const [sellToken, setSellToken] = useState(
     () => getToken('symbol', sellTokenSymbol, tokens) || (getToken('symbol', 'DAI', tokens) as Required<TokenDetails>),
   )
@@ -506,7 +507,7 @@ const TradeWidget: React.FC = () => {
   }
 
   return (
-    <WrappedWidget>
+    <WrappedWidget className={ordersVisible ? '' : 'expanded'}>
       {/* // Toggle Class 'expanded' on WrappedWidget on click of the <OrdersPanel> <button> */}
       <FormContext {...methods}>
         <WrappedForm onSubmit={handleSubmit(onSubmit)}>
@@ -580,7 +581,7 @@ const TradeWidget: React.FC = () => {
       </FormContext>
       <OrdersPanel>
         {/* Toggle panel visibility (arrow) */}
-        <button />
+        <button onClick={(): void => setOrdersVisible(!ordersVisible)} />
         {/* Actual orders content */}
         <div>
           <h5>Your orders</h5>


### PR DESCRIPTION
Expands "Your orders" by clicking here:


![image](https://user-images.githubusercontent.com/2352112/74962377-119e0500-5410-11ea-82e8-56e04a1cd6ce.png)

So it shows a expanded version of the orders:

![image](https://user-images.githubusercontent.com/2352112/74962396-1fec2100-5410-11ea-9c08-b859acfbf5cf.png)

Related to https://github.com/gnosis/dex-react/pull/582
