### PR TITLE
528/show from date on orders

### DIFF
--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -150,32 +150,6 @@ const Amounts: React.FC<AmountsProps> = ({ sellToken, order, isUnlimited }) => {
   )
 }
 
-//TODO: no longer needed? remove
-// interface AccountBalanceProps extends Pick<Props, 'order' | 'isOverBalance'> {
-//   sellToken: TokenDetails
-//   isUnlimited: boolean
-// }
-
-// const AccountBalance: React.FC<AccountBalanceProps> = ({ sellToken, order, isOverBalance, isUnlimited }) => {
-//   const accountBalance = useMemo(() => formatAmount(order.sellTokenBalance, sellToken.decimals) || '0', [
-//     order.sellTokenBalance,
-//     sellToken.decimals,
-//   ])
-//   const isActive = isOrderActive(order, new Date())
-
-//   return (
-//     <td data-label="Account Balance" className="sub-columns three-columns">
-//       <div>{accountBalance}</div>
-//       <strong>{displayTokenSymbolOrLink(sellToken)}</strong>
-//       {isOverBalance && isActive && !isUnlimited && (
-//         <div className="warning">
-//           <FontAwesomeIcon icon={faExclamationTriangle} />
-//         </div>
-//       )}
-//     </td>
-//   )
-// }
-
 const Expires: React.FC<Pick<Props, 'order' | 'pending'>> = ({ order }) => {
   const { isNeverExpires, expiresOn } = useMemo(() => {
     const isNeverExpires = isNeverExpiresOrder(order.validUntil)
@@ -277,11 +251,6 @@ const OrderRow: React.FC<Props> = props => {
         <OrderImage sellToken={sellToken} buyToken={buyToken} />
         <OrderDetails order={order} sellToken={sellToken} buyToken={buyToken} />
         {!isPendingOrder ? <Amounts order={order} sellToken={sellToken} isUnlimited={isUnlimited} /> : <PendingLink />}
-        {/* {!isPendingOrder ? (
-          <AccountBalance order={order} isOverBalance={isOverBalance} sellToken={sellToken} isUnlimited={isUnlimited} />
-        ) : (
-          <PendingLink />
-        )} */}
         {!isPendingOrder ? <Expires order={order} pending={pending} /> : <PendingLink />}
         <td className="status">
           Partial Fill{' '}

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -15,7 +15,15 @@ import { getTokenFromExchangeById } from 'services'
 import useSafeState from 'hooks/useSafeState'
 import { TokenDetails } from 'types'
 
-import { safeTokenName, formatAmount, formatAmountFull, formatDateFromBatchId, formatPrice } from 'utils'
+import {
+  safeTokenName,
+  formatAmount,
+  formatAmountFull,
+  formatDateFromBatchId,
+  formatPrice,
+  batchIdToDate,
+  isOrderFilled,
+} from 'utils'
 import { onErrorFactory } from 'utils/onError'
 import { AuctionElement } from 'api/exchange/ExchangeApi'
 import TokenImg from 'components/TokenImg'
@@ -161,6 +169,72 @@ const Expires: React.FC<Pick<Props, 'order' | 'pending'>> = ({ order }) => {
   return <td data-label="Expires">{isNeverExpires ? <span>Never</span> : <span>{expiresOn}</span>}</td>
 }
 
+const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash' | 'isPendingOrder'>> = ({
+  order,
+  isOverBalance,
+  isPendingOrder,
+  transactionHash,
+}) => {
+  const now = new Date()
+
+  const isExpiredOrder = batchIdToDate(order.validUntil) <= now
+  const isScheduled = batchIdToDate(order.validFrom) > now
+  const isUnlimited = useMemo(() => isOrderUnlimited(order.priceNumerator, order.priceDenominator), [
+    order.priceDenominator,
+    order.priceNumerator,
+  ])
+  const isActive = useMemo(() => order.remainingAmount.eq(order.priceDenominator), [
+    order.priceDenominator,
+    order.remainingAmount,
+  ])
+  const isFilled = useMemo(() => isOrderFilled(order), [order])
+  // Display isLowBalance warning only for active and partial fill orders
+  const isLowBalance = isOverBalance && !isUnlimited && !isFilled && !isScheduled && !isPendingOrder && !isExpiredOrder
+
+  const pending = useMemo(
+    () =>
+      isPendingOrder && (
+        <>
+          Pending...
+          <br />
+          <PendingLink transactionHash={transactionHash} />
+        </>
+      ),
+    [isPendingOrder, transactionHash],
+  )
+
+  return (
+    <td className="status">
+      {pending ? (
+        pending
+      ) : isExpiredOrder ? (
+        'Expired'
+      ) : isScheduled ? (
+        <>
+          Scheduled
+          <br />
+          {formatDateFromBatchId(order.validFrom)}
+        </>
+      ) : isFilled ? (
+        'Filled'
+      ) : isActive ? (
+        'Active'
+      ) : (
+        'Partial Fill'
+      )}
+      {isLowBalance && (
+        <>
+          <br />
+          <span className="lowBalance">
+            low balance
+            <img src={lowBalanceIcon} />
+          </span>
+        </>
+      )}
+    </td>
+  )
+}
+
 async function fetchToken(
   tokenId: number,
   orderId: string,
@@ -219,6 +293,7 @@ const OrderRow: React.FC<Props> = props => {
     toggleMarkedForDeletion,
     disabled,
     isPendingOrder,
+    isOverBalance,
   } = props
 
   // Fetching buy and sell tokens
@@ -252,13 +327,12 @@ const OrderRow: React.FC<Props> = props => {
         <OrderDetails order={order} sellToken={sellToken} buyToken={buyToken} />
         {!isPendingOrder ? <Amounts order={order} sellToken={sellToken} isUnlimited={isUnlimited} /> : <PendingLink />}
         {!isPendingOrder ? <Expires order={order} pending={pending} /> : <PendingLink />}
-        <td className="status">
-          Partial Fill{' '}
-          <span className="lowBalance">
-            low balance
-            <img src={lowBalanceIcon} />
-          </span>
-        </td>
+        <Status
+          order={order}
+          isOverBalance={isOverBalance}
+          isPendingOrder={isPendingOrder}
+          transactionHash={transactionHash}
+        />
         <ResponsiveRowSizeToggler handleOpen={(): void => setOpenCard(!openCard)} openStatus={openCard} />
       </OrderRowWrapper>
     )

--- a/src/const.ts
+++ b/src/const.ts
@@ -12,7 +12,11 @@ export {
 } from '@gnosis.pm/dex-js'
 export { ZERO, ONE, TWO, TEN, ALLOWANCE_MAX_VALUE, ALLOWANCE_FOR_ENABLED_TOKEN } from '@gnosis.pm/dex-js'
 
-export const ONE_HUNDRED = new BN(100)
+// How much of the order needs to be matched to consider it filled
+// Will divide the total sell amount by this factor.
+// E.g.: Sell = 500; ORDER_FILLED_FACTOR = 100 (1%) => 500/100 => 5
+// ∴ when the amount is < 5 the order will be considered filled.
+export const ORDER_FILLED_FACTOR = new BN(10000) // 0.01%
 
 export const APP_NAME = 'fuse'
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -16,7 +16,7 @@ export { ZERO, ONE, TWO, TEN, ALLOWANCE_MAX_VALUE, ALLOWANCE_FOR_ENABLED_TOKEN }
 // Will divide the total sell amount by this factor.
 // E.g.: Sell = 500; ORDER_FILLED_FACTOR = 100 (1%) => 500/100 => 5
 // ∴ when the amount is < 5 the order will be considered filled.
-export const ORDER_FILLED_FACTOR = new BN(10000) // 0.01%
+export const ORDER_FILLED_FACTOR = new BN(1000000) // 0.0001%
 
 export const APP_NAME = 'fuse'
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import BN from 'bn.js'
 import { UNLIMITED_ORDER_AMOUNT } from '@gnosis.pm/dex-js'
 export {
   UNLIMITED_ORDER_AMOUNT,
@@ -10,6 +11,9 @@ export {
   DEFAULT_PRECISION,
 } from '@gnosis.pm/dex-js'
 export { ZERO, ONE, TWO, TEN, ALLOWANCE_MAX_VALUE, ALLOWANCE_FOR_ENABLED_TOKEN } from '@gnosis.pm/dex-js'
+
+export const ONE_HUNDRED = new BN(100)
+
 export const APP_NAME = 'fuse'
 
 export const ETHER_PNG =

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -2,6 +2,7 @@ import { TokenDetails } from 'types'
 import { AssertionError } from 'assert'
 import { AuctionElement } from 'api/exchange/ExchangeApi'
 import { batchIdToDate } from './time'
+import { ONE_HUNDRED } from 'const'
 
 export function assertNonNull<T>(val: T, message: string): asserts val is NonNullable<T> {
   if (val === undefined || val === null) {
@@ -51,3 +52,9 @@ export function getImageUrl(tokenAddress?: string): string | undefined {
 }
 
 export const isOrderActive = (order: AuctionElement, now: Date): boolean => batchIdToDate(order.validUntil) >= now
+
+export function isOrderFilled(order: AuctionElement): boolean {
+  // consider an oder filled when 99% or more is matched
+  const onePercent = order.priceDenominator.divRound(ONE_HUNDRED)
+  return !order.remainingAmount.gte(onePercent)
+}

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -2,7 +2,7 @@ import { TokenDetails } from 'types'
 import { AssertionError } from 'assert'
 import { AuctionElement } from 'api/exchange/ExchangeApi'
 import { batchIdToDate } from './time'
-import { ONE_HUNDRED } from 'const'
+import { ORDER_FILLED_FACTOR } from 'const'
 
 export function assertNonNull<T>(val: T, message: string): asserts val is NonNullable<T> {
   if (val === undefined || val === null) {
@@ -54,7 +54,7 @@ export function getImageUrl(tokenAddress?: string): string | undefined {
 export const isOrderActive = (order: AuctionElement, now: Date): boolean => batchIdToDate(order.validUntil) >= now
 
 export function isOrderFilled(order: AuctionElement): boolean {
-  // consider an oder filled when 99% or more is matched
-  const onePercent = order.priceDenominator.divRound(ONE_HUNDRED)
-  return !order.remainingAmount.gte(onePercent)
+  // consider an oder filled when less than `negligibleAmount` is left
+  const negligibleAmount = order.priceDenominator.divRound(ORDER_FILLED_FACTOR)
+  return !order.remainingAmount.gte(negligibleAmount)
 }

--- a/test/data/userOrders.ts
+++ b/test/data/userOrders.ts
@@ -1,9 +1,8 @@
 import BN from 'bn.js'
-import { addDays, addMinutes, addYears } from 'date-fns'
+import { addDays, addMinutes } from 'date-fns'
 
 import { UNLIMITED_ORDER_AMOUNT, MAX_BATCH_ID } from '@gnosis.pm/dex-js'
 
-import { ONE } from 'const'
 import { dateToBatchId } from 'utils'
 
 import { USER_1, BATCH_ID } from './basic'
@@ -15,11 +14,11 @@ export const exchangeOrders = {
     {
       buyTokenId: 3, // TUSD
       sellTokenId: 7, // DAI
-      validFrom: BATCH_ID,
-      validUntil: dateToBatchId(addMinutes(NOW, 5)),
+      validFrom: dateToBatchId(addDays(NOW, 1)), // scheduled order,
+      validUntil: dateToBatchId(addDays(NOW, 20)),
       priceNumerator: new BN('2100000000000000000000'),
       priceDenominator: new BN('2000000000000000000000'),
-      remainingAmount: new BN('1500000000000000000000'),
+      remainingAmount: new BN('2000000000000000000000'),
     },
     {
       buyTokenId: 7, // DAI
@@ -28,13 +27,13 @@ export const exchangeOrders = {
       validUntil: MAX_BATCH_ID, // as big as it gets
       priceNumerator: UNLIMITED_ORDER_AMOUNT, // unlimited order, spread 0.3%
       priceDenominator: UNLIMITED_ORDER_AMOUNT.mul(new BN(997)).divRound(new BN(1000)),
-      remainingAmount: ONE, // doesn't matter
+      remainingAmount: UNLIMITED_ORDER_AMOUNT.mul(new BN(997)).divRound(new BN(1000)), // not touched for liquidity orders
     },
     {
       buyTokenId: 7, // DAI
       sellTokenId: 5, // PAX
       validFrom: BATCH_ID,
-      validUntil: dateToBatchId(addDays(NOW, 2)),
+      validUntil: dateToBatchId(addMinutes(NOW, 2)),
       priceNumerator: new BN('10500000000000000000000'),
       priceDenominator: new BN('10000000000000000000000'),
       remainingAmount: new BN('5876842900000000000000'),
@@ -52,7 +51,7 @@ export const exchangeOrders = {
       buyTokenId: 1, // WETH
       sellTokenId: 8, // TOKEN_8; not in our list (forcing token fetch), registered in the exchange. Does not provide details (name, symbol, decimals)
       validFrom: BATCH_ID,
-      validUntil: dateToBatchId(addYears(NOW, 101)),
+      validUntil: MAX_BATCH_ID,
       priceNumerator: new BN('700000000000000000000000'),
       priceDenominator: new BN('10000000000000000000000'),
       remainingAmount: new BN('98000000000000000000'),


### PR DESCRIPTION
Closes #528

Went a bit over the task and also implemented all statuses seen in https://projects.invisionapp.com/share/5XVR9OE6FPJ#/screens/403151253_GnosisProtocol_-_V2-2_-_1_Order:

- Pending (well, pending...)
- Scheduled (`validFrom` in the future)
- Active (`validUntil` in the future AND (liquidity order OR matched amount == 0))
- Partial fill (NOT liquidity AND matched amount > 0)
- Filled (matched amount >= 99% order amount)
- Expired (`validUntil` in the past)
- Low balance warning displayed for *Active* and *Partial fill* orders

![Screenshot from 2020-02-20 17-45-16](https://user-images.githubusercontent.com/43217/75033307-616ce280-5489-11ea-997f-e0d5a1db974c.png)
![Screenshot from 2020-02-20 17-45-01](https://user-images.githubusercontent.com/43217/75033310-629e0f80-5489-11ea-883b-e889e34ae060.png)
![Screenshot from 2020-02-20 17-44-48](https://user-images.githubusercontent.com/43217/75033312-6336a600-5489-11ea-9d56-68f7be946025.png)


### Notes:
- Trade form currently not working. ~~Guess something from last merge. Will check and submit a new PR for that.~~ `data` value on `onSubmit` is not being filled. I'll leave this up to https://github.com/gnosis/dex-react/pull/551 to address.