### PR TITLE
Triggering wallet connection from trade page on submission

### DIFF
--- a/src/components/PoolingWidget/index.tsx
+++ b/src/components/PoolingWidget/index.tsx
@@ -224,6 +224,8 @@ const PoolingInterface: React.FC = () => {
       setTxReceipt(undefined)
 
       const { receipt } = await placeMultipleOrders({
+        networkId,
+        userAddress,
         orders,
         txOptionalParams: {
           onSentTransaction: (txHash: string): void => {

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -488,6 +488,8 @@ const TradeWidget: React.FC = () => {
       if (validFrom === 0) {
         // ; for destructure reassign format
         ;({ success } = await placeOrder({
+          networkId,
+          userAddress,
           buyAmount,
           buyToken,
           sellAmount,
@@ -510,6 +512,8 @@ const TradeWidget: React.FC = () => {
       } else {
         // ; for destructure reassign format
         ;({ success } = await placeMultipleOrders({
+          networkId,
+          userAddress,
           orders: [
             {
               buyAmount,

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -28,7 +28,7 @@ import useGlobalState from 'hooks/useGlobalState'
 import { savePendingOrdersAction, removePendingOrdersAction } from 'reducers-actions/pendingOrders'
 import { MEDIA } from 'const'
 
-import { tokenListApi, walletApi } from 'api'
+import { tokenListApi } from 'api'
 
 import { Network, TokenDetails } from 'types'
 
@@ -574,22 +574,20 @@ const TradeWidget: React.FC = () => {
       })
     } else {
       // Not connected. Prompt user to connect his wallet
-      const success = await connectWallet()
-      if (success) {
-        const { userAddress: address, networkId: netId } = await walletApi.getWalletInfo()
+      const walletInfo = await connectWallet()
 
-        address &&
-          netId &&
-          (await _placeOrder({
-            validFrom,
-            validUntil,
-            sellAmount,
-            buyAmount,
-            sellToken: cachedSellToken,
-            buyToken: cachedBuyToken,
-            networkId: netId,
-            userAddress: address,
-          }))
+      // Then place the order if connection was successful
+      if (walletInfo && walletInfo.networkId && walletInfo.userAddress) {
+        await _placeOrder({
+          validFrom,
+          validUntil,
+          sellAmount,
+          buyAmount,
+          sellToken: cachedSellToken,
+          buyToken: cachedBuyToken,
+          networkId: walletInfo.networkId,
+          userAddress: walletInfo.userAddress,
+        })
       }
     }
   }

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -28,7 +28,7 @@ import useGlobalState from 'hooks/useGlobalState'
 import { savePendingOrdersAction, removePendingOrdersAction } from 'reducers-actions/pendingOrders'
 import { MEDIA } from 'const'
 
-import { tokenListApi } from 'api'
+import { tokenListApi, walletApi } from 'api'
 
 import { Network, TokenDetails } from 'types'
 
@@ -574,7 +574,23 @@ const TradeWidget: React.FC = () => {
       })
     } else {
       // Not connected. Prompt user to connect his wallet
-      await connectWallet()
+      const success = await connectWallet()
+      if (success) {
+        const { userAddress: address, networkId: netId } = await walletApi.getWalletInfo()
+
+        address &&
+          netId &&
+          (await _placeOrder({
+            validFrom,
+            validUntil,
+            sellAmount,
+            buyAmount,
+            sellToken: cachedSellToken,
+            buyToken: cachedBuyToken,
+            networkId: netId,
+            userAddress: address,
+          }))
+      }
     }
   }
 

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -5,7 +5,6 @@ import switchTokenPair from 'assets/img/switch.svg'
 import arrow from 'assets/img/arrow.svg'
 import { FieldValues } from 'react-hook-form/dist/types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { useHistory } from 'react-router'
 import { toast } from 'toastify'
 
 import TokenRow from './TokenRow'
@@ -35,6 +34,7 @@ import { Network, TokenDetails } from 'types'
 import { getToken, parseAmount, parseBigNumber } from 'utils'
 import { ZERO } from 'const'
 import Price, { invertPrice } from './Price'
+import { useConnectWallet } from 'hooks/useConnectWallet'
 
 const WrappedWidget = styled(Widget)`
   overflow-x: visible;
@@ -307,6 +307,7 @@ function _getReceiveTokenTooltipText(sellValue: string, receiveValue: string): s
 
 const TradeWidget: React.FC = () => {
   const { networkId, isConnected, userAddress } = useWalletConnection()
+  const { connectWallet } = useConnectWallet()
   const [, dispatch] = useGlobalState()
 
   // Avoid displaying an empty list of tokens when the wallet is not connected
@@ -410,7 +411,6 @@ const TradeWidget: React.FC = () => {
   )
 
   const { placeOrder, placeMultipleOrders, isSubmitting, setIsSubmitting } = usePlaceOrder()
-  const history = useHistory()
 
   const swapTokens = useCallback((): void => {
     setSellToken(receiveToken)
@@ -541,8 +541,8 @@ const TradeWidget: React.FC = () => {
         dispatch(removePendingOrdersAction({ networkId, pendingTxHash, userAddress }))
       }
     } else {
-      const from = history.location.pathname + history.location.search
-      history.push('/connect-wallet', { from })
+      // Not connected. Prompt user to connect his wallet
+      await connectWallet()
     }
   }
 

--- a/src/components/UserWallet/UserWallet.styled.ts
+++ b/src/components/UserWallet/UserWallet.styled.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import arrow from 'assets/img/arrow.svg'
 import { MEDIA } from 'const'
 
-export const UserWalletWrapper = styled.div<{ $walletOpen: boolean }>`
+export const UserWalletWrapper = styled.div`
   position: relative;
   display: flex;
   flex-flow: column nowrap;

--- a/src/components/UserWallet/WalletComponent.tsx
+++ b/src/components/UserWallet/WalletComponent.tsx
@@ -110,7 +110,7 @@ const UserWallet: React.FC<RouteComponentProps> = (props: UserWalletProps) => {
   }, [connectWallet, disconnectWallet, isConnected, loadingLabel, props.className])
 
   return (
-    <UserWalletWrapper $walletOpen={!!(showWallet && userAddress)}>
+    <UserWalletWrapper>
       {userAddress ? (
         <>
           {/* Wallet logo + address + chevron */}

--- a/src/components/UserWallet/WalletComponent.tsx
+++ b/src/components/UserWallet/WalletComponent.tsx
@@ -51,7 +51,8 @@ const UserWallet: React.FC<RouteComponentProps> = (props: UserWalletProps) => {
     await _connectWallet()
 
     setLoadingLabel(null)
-  }, [_connectWallet, setLoadingLabel])
+    setShowWallet(false)
+  }, [_connectWallet, setLoadingLabel, setShowWallet])
 
   const disconnectWallet = useCallback(async (): Promise<void> => {
     setLoadingLabel('Disconnecting...')
@@ -59,11 +60,12 @@ const UserWallet: React.FC<RouteComponentProps> = (props: UserWalletProps) => {
     await _disconnectWallet()
 
     setLoadingLabel(null)
+    setShowWallet(false)
 
     if (!orderPageMatch) {
       props.history.push('/')
     }
-  }, [_disconnectWallet, orderPageMatch, props.history, setLoadingLabel])
+  }, [_disconnectWallet, orderPageMatch, props.history, setLoadingLabel, setShowWallet])
 
   const handleCopyToClipBoard = useCallback((): NodeJS.Timeout => {
     setCopiedToClipboard(true)
@@ -136,7 +138,7 @@ const UserWallet: React.FC<RouteComponentProps> = (props: UserWalletProps) => {
       {/* Main elements of Wallet: QR, Address copy, Etherscan URL, Log Out */}
       {userAddress && showWallet && (
         <UserWalletSlideWrapper>
-          <button type="button" onClick={(): void => setShowWallet(!showWallet)}>
+          <button type="button" onClick={(): void => setShowWallet(false)}>
             <b>Wallet</b>
             <i>×</i>
           </button>

--- a/src/components/UserWallet/index.tsx
+++ b/src/components/UserWallet/index.tsx
@@ -24,7 +24,7 @@ const LazyUserWallet = React.lazy(async () => {
 })
 
 const SuspendedWallet: React.FC<RouteComponentProps> = props => (
-  <Suspense fallback={<UserWalletWrapper $walletOpen={false} style={{ visibility: 'hidden' }} />}>
+  <Suspense fallback={<UserWalletWrapper style={{ visibility: 'hidden' }} />}>
     <LazyUserWallet {...props} />
   </Suspense>
 )

--- a/src/hooks/useConnectWallet.ts
+++ b/src/hooks/useConnectWallet.ts
@@ -1,0 +1,35 @@
+import { walletApi } from 'api'
+import { toast } from 'toastify'
+
+interface Result {
+  connectWallet: () => Promise<void>
+  disconnectWallet: () => Promise<void>
+}
+
+export function useConnectWallet(): Result {
+  const connectWallet = async (): Promise<void> => {
+    try {
+      const success = await walletApi.connect()
+
+      // user closed Provider selection modal
+      if (!success) return
+
+      toast.success('Wallet connected')
+    } catch (error) {
+      console.error('[WalletComponent] Connect wallet error', error)
+      toast.error('Error connecting wallet')
+    }
+  }
+
+  const disconnectWallet = async (): Promise<void> => {
+    try {
+      await walletApi.disconnect()
+      toast.info('Wallet disconnected')
+    } catch (error) {
+      console.error('[WalletComponent] Disconnect wallet error', error)
+      toast.error('Error disconnecting wallet')
+    }
+  }
+
+  return { connectWallet, disconnectWallet }
+}

--- a/src/hooks/useConnectWallet.ts
+++ b/src/hooks/useConnectWallet.ts
@@ -2,32 +2,42 @@ import { walletApi } from 'api'
 import { toast } from 'toastify'
 
 interface Result {
-  connectWallet: () => Promise<void>
-  disconnectWallet: () => Promise<void>
+  connectWallet: () => Promise<boolean>
+  disconnectWallet: () => Promise<boolean>
 }
 
 export function useConnectWallet(): Result {
-  const connectWallet = async (): Promise<void> => {
+  const connectWallet = async (): Promise<boolean> => {
     try {
       const success = await walletApi.connect()
 
       // user closed Provider selection modal
-      if (!success) return
+      if (!success) {
+        return false
+      }
 
       toast.success('Wallet connected')
+
+      return true
     } catch (error) {
       console.error('[WalletComponent] Connect wallet error', error)
       toast.error('Error connecting wallet')
+
+      return false
     }
   }
 
-  const disconnectWallet = async (): Promise<void> => {
+  const disconnectWallet = async (): Promise<boolean> => {
     try {
       await walletApi.disconnect()
       toast.info('Wallet disconnected')
+
+      return true
     } catch (error) {
       console.error('[WalletComponent] Disconnect wallet error', error)
       toast.error('Error disconnecting wallet')
+
+      return false
     }
   }
 

--- a/src/hooks/useConnectWallet.ts
+++ b/src/hooks/useConnectWallet.ts
@@ -1,13 +1,14 @@
 import { walletApi } from 'api'
 import { toast } from 'toastify'
+import { WalletInfo } from 'api/wallet/WalletApi'
 
 interface Result {
-  connectWallet: () => Promise<boolean>
+  connectWallet: () => Promise<WalletInfo | false>
   disconnectWallet: () => Promise<boolean>
 }
 
 export function useConnectWallet(): Result {
-  const connectWallet = async (): Promise<boolean> => {
+  const connectWallet = async (): Promise<WalletInfo | false> => {
     try {
       const success = await walletApi.connect()
 
@@ -18,7 +19,7 @@ export function useConnectWallet(): Result {
 
       toast.success('Wallet connected')
 
-      return true
+      return walletApi.getWalletInfo()
     } catch (error) {
       console.error('[WalletComponent] Connect wallet error', error)
       toast.error('Error connecting wallet')

--- a/src/hooks/usePlaceOrder.ts
+++ b/src/hooks/usePlaceOrder.ts
@@ -9,11 +9,15 @@ import { exchangeApi } from 'api'
 import { PlaceOrderParams as ExchangeApiPlaceOrderParams } from 'api/exchange/ExchangeApi'
 import { logDebug, formatTimeInHours } from 'utils'
 import { txOptionalParams as defaultTxOptionalParams } from 'utils/transaction'
-import { useWalletConnection } from './useWalletConnection'
 import { BATCHES_TO_WAIT } from 'const'
 import useSafeState from './useSafeState'
 
-interface PlaceOrderParams<T> {
+interface ConnectionParams {
+  userAddress: string
+  networkId: number
+}
+
+interface PlaceOrderParams<T> extends ConnectionParams {
   buyAmount: BN
   buyToken: T
   sellAmount: BN
@@ -22,11 +26,12 @@ interface PlaceOrderParams<T> {
   txOptionalParams?: TxOptionalParams
 }
 
-export interface MultipleOrdersOrder extends Omit<PlaceOrderParams<number>, 'txOptionalParams'> {
+export interface MultipleOrdersOrder
+  extends Omit<PlaceOrderParams<number>, 'txOptionalParams' | 'userAddress' | 'networkId'> {
   validFrom?: number
 }
 
-interface PlaceMultipleOrdersParams {
+interface PlaceMultipleOrdersParams extends ConnectionParams {
   orders: MultipleOrdersOrder[]
   txOptionalParams?: TxOptionalParams
 }
@@ -45,7 +50,6 @@ export interface PlaceOrderResult {
 
 export const usePlaceOrder = (): Result => {
   const [isSubmitting, setIsSubmitting] = useSafeState(false)
-  const { userAddress, networkId } = useWalletConnection()
 
   const placeOrder = useCallback(
     async ({
@@ -55,8 +59,11 @@ export const usePlaceOrder = (): Result => {
       sellToken,
       validUntil,
       txOptionalParams,
+      userAddress,
+      networkId,
     }: PlaceOrderParams<TokenDetails>): Promise<PlaceOrderResult> => {
       if (!userAddress || !networkId) {
+        console.log('wallet not connected?', userAddress, networkId)
         toast.error('Wallet is not connected!')
         return { success: false }
       }
@@ -108,13 +115,13 @@ export const usePlaceOrder = (): Result => {
           //  the actual value of the constant
           const validityInMinutes = Math.ceil((validUntil * BATCH_TIME) / 60)
           toast.success(
-            `Transaction mined! Succesfully placed order valid ASAP and expiring ${formatTimeInHours(
+            `Transaction mined! Successfully placed order valid ASAP and expiring ${formatTimeInHours(
               validityInMinutes,
               'never',
             )}`,
           )
         } else {
-          toast.success(`Transaction mined! Succesfully placed order valid ASAP and never expiring`)
+          toast.success(`Transaction mined! Successfully placed order valid ASAP and never expiring`)
         }
 
         return { success: true, receipt }
@@ -134,12 +141,18 @@ export const usePlaceOrder = (): Result => {
         setIsSubmitting(false)
       }
     },
-    [networkId, setIsSubmitting, userAddress],
+    [setIsSubmitting],
   )
 
   const placeMultipleOrders = useCallback(
-    async ({ orders, txOptionalParams }: PlaceMultipleOrdersParams): Promise<PlaceOrderResult> => {
+    async ({
+      orders,
+      txOptionalParams,
+      userAddress,
+      networkId,
+    }: PlaceMultipleOrdersParams): Promise<PlaceOrderResult> => {
       if (!userAddress || !networkId) {
+        console.log('wallet not connected?', userAddress, networkId)
         toast.error('Wallet is not connected!')
         return { success: false }
       }
@@ -234,7 +247,7 @@ export const usePlaceOrder = (): Result => {
         setIsSubmitting(false)
       }
     },
-    [networkId, setIsSubmitting, userAddress],
+    [setIsSubmitting],
   )
 
   return { placeOrder, isSubmitting, setIsSubmitting, placeMultipleOrders }

--- a/src/hooks/usePlaceOrder.ts
+++ b/src/hooks/usePlaceOrder.ts
@@ -63,7 +63,6 @@ export const usePlaceOrder = (): Result => {
       networkId,
     }: PlaceOrderParams<TokenDetails>): Promise<PlaceOrderResult> => {
       if (!userAddress || !networkId) {
-        console.log('wallet not connected?', userAddress, networkId)
         toast.error('Wallet is not connected!')
         return { success: false }
       }
@@ -152,7 +151,6 @@ export const usePlaceOrder = (): Result => {
       networkId,
     }: PlaceMultipleOrdersParams): Promise<PlaceOrderResult> => {
       if (!userAddress || !networkId) {
-        console.log('wallet not connected?', userAddress, networkId)
         toast.error('Wallet is not connected!')
         return { success: false }
       }


### PR DESCRIPTION
Follow up to #588 

When user is logged and tries to submit an order, the wallet dropdown is shown over the trade page.

### Notes
- ~~There's a bug on `onSubmit` where the form data is not being passed down onto `data` object. To test I manually set the values. I guess this will be fixed by https://github.com/gnosis/dex-react/pull/551 so I didn't spend time trying to fix it. For this reason, you'll have to trust me it works or test locally.~~
- ~~It seems like the wallet widget is re-rendered every second, guess due to the batch time remaining thingy. Still have to check that.~~ Yep, that's the case.
- ~~For a reason that I yet haven't figured out, the wallet dropdown is expanded after logging in.~~