### PR TITLE
Fix form submission

### DIFF
--- a/src/Console.tsx
+++ b/src/Console.tsx
@@ -117,13 +117,21 @@ const ConsoleFrame: React.FC = () => {
           <Console logs={logs} variant="dark" />
           <InputGroup>
             <input type="text" onKeyPress={handleCommand} ref={input} />
-            <button onClick={handleClick}>{'>>'}</button>
+            <button type="button" onClick={handleClick}>
+              {'>>'}
+            </button>
           </InputGroup>
         </>
       )}
       <ButtonGroup>
-        {showConsole && logs.length > 0 && <button onClick={(): void => setLogs([])}>clear</button>}
-        <button onClick={(): void => setShowConsole(on => !on)}>{showConsole ? 'x' : 'console'}</button>
+        {showConsole && logs.length > 0 && (
+          <button type="button" onClick={(): void => setLogs([])}>
+            clear
+          </button>
+        )}
+        <button type="button" onClick={(): void => setShowConsole(on => !on)}>
+          {showConsole ? 'x' : 'console'}
+        </button>
       </ButtonGroup>
     </ConsoleWrapper>
   )

--- a/src/components/DepositWidget/Row.tsx
+++ b/src/components/DepositWidget/Row.tsx
@@ -118,12 +118,17 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
         </td>
         <td data-label="Actions">
           {enabled ? (
-            <button className="withdrawToken" onClick={(): void => showForm('deposit')} disabled={isDepositFormVisible}>
+            <button
+              type="button"
+              className="withdrawToken"
+              onClick={(): void => showForm('deposit')}
+              disabled={isDepositFormVisible}
+            >
               <img src={plus} />
             </button>
           ) : (
             <>
-              <button className="enableToken" onClick={onEnableToken} disabled={enabling.has(address)}>
+              <button type="button" className="enableToken" onClick={onEnableToken} disabled={enabling.has(address)}>
                 {enabling.has(address) ? (
                   <>
                     <FontAwesomeIcon icon={faSpinner} spin />
@@ -137,6 +142,7 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
           )}
           {!totalExchangeBalance.isZero() && (
             <button
+              type="button"
               onClick={(): void => showForm('withdraw')}
               disabled={isWithdrawFormVisible}
               className="depositToken"

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -353,7 +353,9 @@ const DepositWidget: React.FC = () => {
             <input type="checkbox" />
             <b>Hide zero balances</b>
           </label>
-          <button className="balances-manageTokens">Manage Tokens</button>
+          <button type="button" className="balances-manageTokens">
+            Manage Tokens
+          </button>
         </BalanceTools>
         {error ? (
           <ErrorMsg title="oops..." message="Something happened while loading the balances" />

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -49,7 +49,7 @@ const DeleteOrder: React.FC<Pick<
       checked={isMarkedForDeletion && !pending}
       disabled={disabled}
     />
-    {/* <button className="danger" onClick={toggleMarkedForDeletion}>
+    {/* <button className="danger" type="button" onClick={toggleMarkedForDeletion}>
       Cancel Order <FontAwesomeIcon icon={faTrashAlt} />
     </button> */}
   </td>

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -30,7 +30,7 @@ interface ShowOrdersButtonProps {
 }
 
 const ShowOrdersButton: React.FC<ShowOrdersButtonProps> = ({ type, isActive, count, onClick }) => (
-  <button className={isActive ? 'selected' : ''} onClick={onClick}>
+  <button type="button" className={isActive ? 'selected' : ''} onClick={onClick}>
     {type} <i>{count}</i>
     {/* {!isActive ? <Highlight>{count}</Highlight> : <>{count}</>} {type} */}
   </button>
@@ -233,7 +233,7 @@ const OrdersWidget: React.FC = () => {
             </div>
             <div className="deleteContainer" data-disabled={markedForDeletion.size === 0 || deleting}>
               <b>↴</b>
-              <ButtonWithIcon disabled={markedForDeletion.size === 0 || deleting}>
+              <ButtonWithIcon disabled={markedForDeletion.size === 0 || deleting} type="button">
                 <FontAwesomeIcon icon={faTrashAlt} />{' '}
                 {['active', 'liquidity'].includes(selectedTab) ? 'Cancel' : 'Delete'} {markedForDeletion.size} orders
               </ButtonWithIcon>

--- a/src/components/PoolingWidget/index.tsx
+++ b/src/components/PoolingWidget/index.tsx
@@ -306,13 +306,17 @@ const PoolingInterface: React.FC = () => {
         <StepButtonsWrapper>
           {/* REMOVE BACK BUTTON ON TXRECEIPT */}
           {!txReceipt && (
-            <button disabled={step < 2 || selectedTokensMap.size < 2 || isSubmitting} onClick={(): void => prevStep()}>
+            <button
+              type="button"
+              disabled={step < 2 || selectedTokensMap.size < 2 || isSubmitting}
+              onClick={(): void => prevStep()}
+            >
               Back
             </button>
           )}
           {/* // REGULAR CONTINUE BUTTONS (STEPS 1 & 2) */}
           {step !== 3 ? (
-            <button disabled={selectedTokensMap.size < 2} onClick={(): void => nextStep()}>
+            <button type="button" disabled={selectedTokensMap.size < 2} onClick={(): void => nextStep()}>
               Continue
             </button>
           ) : // STEP 3 - TXRECEIPT OR NOT?
@@ -323,7 +327,7 @@ const PoolingInterface: React.FC = () => {
             </Link>
           ) : (
             // NOT YET SUBMITTED TX
-            <button className="finish" onClick={sendTransaction} disabled={!!txReceipt || isSubmitting}>
+            <button type="button" className="finish" onClick={sendTransaction} disabled={!!txReceipt || isSubmitting}>
               {isSubmitting && <FontAwesomeIcon icon={faSpinner} spin={isSubmitting} />}Submit transaction
             </button>
           )}

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -90,11 +90,11 @@ type WrapperPropsAll<T extends keyof JSX.IntrinsicElements | React.ComponentType
   React.ComponentProps<T>
 
 // can be used as
-// <Wrapper tooltip={}><button onClick={handler}/></Wrapper>
-// <Wrapper as="button" onClick={handler} tooltip={}><button/></Wrapper>
+// <Wrapper tooltip={}><button type="button" onClick={handler}/></Wrapper>
+// <Wrapper as="button" type="button" onClick={handler} tooltip={}><span/></Wrapper>
 // <Wrapper tooltip={} focus={false}><input onFocus={special_handler}/></Wrapper> --> don't touch onFocus
 // single child component gets cloned and ref assigned
-// <Wrapper onClick={handler} tooltip={}><button/><span/></Wrapper>
+// <Wrapper onClick={handler} tooltip={}><button type="button"/><span/></Wrapper>
 // multiple children get wrapped in div
 const Wrapper = <C extends keyof JSX.IntrinsicElements | React.ComponentType = 'div'>({
   children,

--- a/src/components/TradeWidget/OrderValidity.tsx
+++ b/src/components/TradeWidget/OrderValidity.tsx
@@ -162,7 +162,7 @@ const OrderValidity: React.FC<Props> = ({ inputId }) => {
   //TODO: re-enable input logic
   return (
     <Wrapper>
-      <button>
+      <button type="button">
         Order starts: <b>ASAP</b> - expires in: <b>30 minutes</b>
       </button>
       {/* <InputBox>

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -231,10 +231,10 @@ const TokenRow: React.FC<Props> = ({
         <strong>{selectLabel}</strong>
         <span>
           {/* can pass props to as={Component} */}
-          <TooltipWrapper as="button" tooltip="Deposit" onClick={console.log}>
+          <TooltipWrapper as="button" tooltip="Deposit" type="button" onClick={console.log}>
             + Deposit
           </TooltipWrapper>
-          {/* <button>+ Deposit</button> */}
+          {/* <button type="button">+ Deposit</button> */}
           <span>
             Balance:
             <TooltipWrapper as={FormMessage} tooltip="Fill maximum">

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -525,7 +525,7 @@ const TradeWidget: React.FC = () => {
       </FormContext>
       <OrdersPanel>
         {/* Toggle panel visibility (arrow) */}
-        <button onClick={(): void => setOrdersVisible(!ordersVisible)} />
+        <button type="button" onClick={(): void => setOrdersVisible(!ordersVisible)} />
         {/* Actual orders content */}
         <div>
           <h5>Your orders</h5>

--- a/src/components/UserWallet/WalletComponent.tsx
+++ b/src/components/UserWallet/WalletComponent.tsx
@@ -148,7 +148,7 @@ const UserWallet: React.FC<RouteComponentProps> = (props: UserWalletProps) => {
       {/* Main elements of Wallet: QR, Address copy, Etherscan URL, Log Out */}
       {userAddress && showWallet && (
         <UserWalletSlideWrapper>
-          <button onClick={(): void => setShowWallet(!showWallet)}>
+          <button type="button" onClick={(): void => setShowWallet(!showWallet)}>
             <b>Wallet</b>
             <i>×</i>
           </button>

--- a/test/hooks/useSafeState.hooks.test.tsx
+++ b/test/hooks/useSafeState.hooks.test.tsx
@@ -29,7 +29,7 @@ export const TestComponent: React.FC<TestComponentI> = ({ safeUpdate }) => {
 
   return (
     <div>
-      <button id="buttonTest" onClick={_handleClick}></button>
+      <button type="button" id="buttonTest" onClick={_handleClick}></button>
       <h1>{withoutSafe || withSafe}</h1>
     </div>
   )


### PR DESCRIPTION
`<button>` without explicit type is `type="submit"` by default
So any such `<button>` inside a form submits that form

Added explicit type to every button I found, let's do it explicitly from now on