### PR TITLE
Added custom react-select component for new styling

### DIFF
--- a/src/components/TokenSelector.tsx
+++ b/src/components/TokenSelector.tsx
@@ -240,6 +240,10 @@ const customSelectStyles = {
   }),
 }
 
+const components = { MenuList }
+
+const noOptionsMessage = (): string => 'No results'
+
 interface Props {
   label?: string
   isDisabled?: boolean
@@ -287,13 +291,13 @@ const TokenSelector: React.FC<Props> = ({ isDisabled, tokens, selected, onChange
         styles={customSelectStyles}
         className="tokenSelectBox"
         classNamePrefix="react-select"
-        noOptionsMessage={(): string => 'No results'}
+        noOptionsMessage={noOptionsMessage}
         formatOptionLabel={formatOptionLabel}
         options={options}
         value={{ token: selected }}
         onChange={onSelectChange}
         tabIndex={tabIndex.toString()}
-        components={{ MenuList }}
+        components={components}
         isFocused={isFocused || undefined}
         menuIsOpen={isFocused || undefined} // set to `true` to make it permanently open and work with styles
         onMenuInputFocus={onMenuInputFocus}

--- a/src/components/TokenSelector.tsx
+++ b/src/components/TokenSelector.tsx
@@ -281,6 +281,7 @@ const TokenSelector: React.FC<Props> = ({ isDisabled, tokens, selected, onChange
   return (
     <Wrapper>
       <StyledSelect
+        blurInputOnSelect
         isSearchable
         isDisabled={isDisabled}
         styles={customSelectStyles}

--- a/src/components/TokenSelector.tsx
+++ b/src/components/TokenSelector.tsx
@@ -274,12 +274,12 @@ const TokenSelector: React.FC<Props> = ({ isDisabled, tokens, selected, onChange
   // When the search input is focused, force menu to remain open
   const onMenuInputFocus = useCallback(() => setIsFocused(true), [])
 
-  const onKeyDown = useCallback((e): void => {
+  const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>): void => {
     if (e.key === 'Escape') {
       // Close menu on `Escape`
       e.stopPropagation()
       setIsFocused(false)
-    } else if (!e.target.value && e.key === ' ') {
+    } else if (!e.currentTarget.value && e.key === ' ') {
       // Prevent a space when input in empty.
       // That closes the menu. (/shrug)
       e.preventDefault()

--- a/src/components/TokenSelector.tsx
+++ b/src/components/TokenSelector.tsx
@@ -8,6 +8,7 @@ import { formatAmount } from '@gnosis.pm/dex-js'
 import { TokenDetails, TokenBalanceDetails } from 'types'
 import TokenImg from './TokenImg'
 import { FormatOptionLabelContext } from 'react-select/src/Select'
+import { menuListFactory } from './TokenSelectorComponents'
 
 const Wrapper = styled.div`
   display: flex;
@@ -261,6 +262,7 @@ const TokenSelector: React.FC<Props> = ({ isDisabled, tokens, selected, onChange
         classNamePrefix="react-select"
         noOptionsMessage={(): string => 'No results'}
         formatOptionLabel={formatOptionLabel}
+        // menuIsOpen={true}  // uncomment to be able to interact with menu styles
         options={options}
         value={{ token: selected }}
         onChange={(selected: { token: TokenDetails }, { action }: ActionMeta): void => {
@@ -269,6 +271,7 @@ const TokenSelector: React.FC<Props> = ({ isDisabled, tokens, selected, onChange
           }
         }}
         tabIndex={tabIndex.toString()}
+        components={{ MenuList: menuListFactory() }}
       />
     </Wrapper>
   )

--- a/src/components/TokenSelector.tsx
+++ b/src/components/TokenSelector.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useMemo, useState, useCallback } from 'react'
+import React, { CSSProperties, useMemo, useState, useCallback, useRef, useEffect } from 'react'
 import styled from 'styled-components'
 import Select, { ActionMeta } from 'react-select'
 import { MEDIA } from 'const'
@@ -296,11 +296,29 @@ const TokenSelector: React.FC<Props> = ({ isDisabled, tokens, selected, onChange
     }
   }, [])
 
+  const wrapperRef = useRef<HTMLDivElement>(null)
+
+  const onDocumentClick = useCallback(e => {
+    const menu = wrapperRef.current?.querySelector('.react-select__menu')
+    // whenever there's a click on the page, check whether the menu is visible and click was on the wrapper
+    // If neither, hand focus back to react-select but turning isFocused off
+    if (!wrapperRef.current?.contains(e.target) || !menu) {
+      setIsFocused(false)
+    }
+  }, [])
+
+  // mount and umount hooks for watching click events
+  useEffect(() => {
+    window.addEventListener('mousedown', onDocumentClick)
+
+    return (): void => window.removeEventListener('mousedown', onDocumentClick)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
-    <Wrapper>
+    <Wrapper ref={wrapperRef}>
       <StyledSelect
         blurInputOnSelect
-        // menuShouldBlockScroll
         isSearchable
         isDisabled={isDisabled}
         styles={customSelectStyles}

--- a/src/components/TokenSelector.tsx
+++ b/src/components/TokenSelector.tsx
@@ -70,6 +70,16 @@ const Wrapper = styled.div`
   .tokenSelectBox {
     position: relative;
     .react-select__menu {
+      // TODO: style custom menu header and search input
+      .header {
+        display: flex;
+        justify-content: space-between;
+      }
+
+      .searchContainer {
+        display: flex;
+      }
+
       &::before {
         @media ${MEDIA.mediumUp} {
           content: '';

--- a/src/components/TokenSelector.tsx
+++ b/src/components/TokenSelector.tsx
@@ -284,12 +284,12 @@ const TokenSelector: React.FC<Props> = ({ isDisabled, tokens, selected, onChange
   // When the search input is focused, force menu to remain open
   const onMenuInputFocus = useCallback(() => setIsFocused(true), [])
 
-  const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>): void => {
+  const onKeyDown = useCallback((e): void => {
     if (e.key === 'Escape') {
       // Close menu on `Escape`
       e.stopPropagation()
       setIsFocused(false)
-    } else if (!e.currentTarget.value && e.key === ' ') {
+    } else if (!e.target.value && e.key === ' ') {
       // Prevent a space when input in empty.
       // That closes the menu. (/shrug)
       e.preventDefault()
@@ -300,6 +300,7 @@ const TokenSelector: React.FC<Props> = ({ isDisabled, tokens, selected, onChange
     <Wrapper>
       <StyledSelect
         blurInputOnSelect
+        // menuShouldBlockScroll
         isSearchable
         isDisabled={isDisabled}
         styles={customSelectStyles}

--- a/src/components/TokenSelector.tsx
+++ b/src/components/TokenSelector.tsx
@@ -274,11 +274,15 @@ const TokenSelector: React.FC<Props> = ({ isDisabled, tokens, selected, onChange
   // When the search input is focused, force menu to remain open
   const onMenuInputFocus = useCallback(() => setIsFocused(true), [])
 
-  const onInputChange = useCallback((inputValue): void => {
-    // `inputValue` is an empty string on `Escape`.
-    // Setting isFocused to false hides the menu as desired
-    if (!inputValue) {
+  const onKeyDown = useCallback((e): void => {
+    if (e.key === 'Escape') {
+      // Close menu on `Escape`
+      e.stopPropagation()
       setIsFocused(false)
+    } else if (!e.target.value && e.key === ' ') {
+      // Prevent a space when input in empty.
+      // That closes the menu. (/shrug)
+      e.preventDefault()
     }
   }, [])
 
@@ -301,7 +305,7 @@ const TokenSelector: React.FC<Props> = ({ isDisabled, tokens, selected, onChange
         isFocused={isFocused || undefined}
         menuIsOpen={isFocused || undefined} // set to `true` to make it permanently open and work with styles
         onMenuInputFocus={onMenuInputFocus}
-        onInputChange={onInputChange}
+        onKeyDown={onKeyDown}
       />
     </Wrapper>
   )

--- a/src/components/TokenSelectorComponents.tsx
+++ b/src/components/TokenSelectorComponents.tsx
@@ -42,9 +42,8 @@ export const MenuList: ComponentType<MenuListComponentProps<any>> = props => {
   }, [])
 
   // for autofocus
-  const inputRef = useRef(null)
-  //TODO: how to properly type this?
-  useEffect(() => inputRef.current && inputRef.current.focus(), [])
+  const inputRef = useRef<HTMLInputElement>(null)
+  useEffect(() => inputRef.current?.focus(), [])
 
   return (
     // <components.MenuList {...props}>

--- a/src/components/TokenSelectorComponents.tsx
+++ b/src/components/TokenSelectorComponents.tsx
@@ -8,7 +8,7 @@ import { faSearch } from '@fortawesome/free-solid-svg-icons'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const MenuList: ComponentType<MenuListComponentProps<any>> = props => {
   const {
-    selectProps: { onInputChange, onMenuInputFocus, inputValue, value },
+    selectProps: { onKeyDown, onInputChange, onMenuInputFocus, inputValue, value },
     setValue,
   } = props
 
@@ -67,6 +67,7 @@ export const MenuList: ComponentType<MenuListComponentProps<any>> = props => {
           placeholder="Search by token Name, Symbol or Address"
           value={inputValue}
           onChange={onChange}
+          onKeyDown={onKeyDown}
           onMouseDown={onInputClick}
           onTouchEnd={onInputClick}
           onFocus={onMenuInputFocus}

--- a/src/components/TokenSelectorComponents.tsx
+++ b/src/components/TokenSelectorComponents.tsx
@@ -15,12 +15,19 @@ export const MenuList: ComponentType<MenuListComponentProps<any>> = props => {
   const childrenRef = useRef(props.children)
   childrenRef.current = props.children
 
+  // Wrap the event to capture `Enter` and avoid losing focus when there's no value set in the menu
   const wrappedOnKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (React.Children.count(childrenRef.current) === 1 && e.key === 'Enter') {
+      const childrenNames = React.Children.map(
+        childrenRef.current,
+        (c: { type: { name: string } }): string => c.type.name,
+      )
+
+      if (childrenNames?.length === 1 && e.key === 'Enter' && childrenNames[0] === 'NoOptionsMessage') {
         // the only child is noOptionsMessage
         e.preventDefault()
       }
+
       onKeyDown?.(e)
     },
     [onKeyDown],

--- a/src/components/TokenSelectorComponents.tsx
+++ b/src/components/TokenSelectorComponents.tsx
@@ -13,7 +13,6 @@ export const MenuList: ComponentType<MenuListComponentProps<any>> = props => {
   } = props
 
   const ariaAttributes = {
-    // 'aria-autocomplete': 'list',
     'aria-label': props.selectProps['aria-label'],
     'aria-labelledby': props.selectProps['aria-labelledby'],
   }
@@ -46,7 +45,6 @@ export const MenuList: ComponentType<MenuListComponentProps<any>> = props => {
   useEffect(() => inputRef.current?.focus(), [])
 
   return (
-    // <components.MenuList {...props}>
     <>
       <div className="header" style={{ display: 'flex', justifyContent: 'space-between' }}>
         <h2>Select token</h2>

--- a/src/components/TokenSelectorComponents.tsx
+++ b/src/components/TokenSelectorComponents.tsx
@@ -67,20 +67,16 @@ export const MenuList: ComponentType<MenuListComponentProps<any>> = props => {
 
   return (
     <>
-      <div className="header" style={{ display: 'flex', justifyContent: 'space-between' }}>
+      <div className="header">
         <h2>Select token</h2>
         <button type="button" onClick={onCloseButtonClick}>
           X
         </button>
       </div>
-      <div className="searchContainer" style={{ display: 'flex' }}>
+      <div className="searchContainer">
         <FontAwesomeIcon icon={faSearch} />
         <input
           ref={inputRef}
-          style={{
-            width: '100%',
-            boxSizing: 'border-box',
-          }}
           autoCorrect="off"
           autoComplete="off"
           spellCheck="false"

--- a/src/components/TokenSelectorComponents.tsx
+++ b/src/components/TokenSelectorComponents.tsx
@@ -1,0 +1,76 @@
+import React, { ComponentType } from 'react'
+import { components, MenuListComponentProps } from 'react-select'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faSearch } from '@fortawesome/free-solid-svg-icons'
+
+// Trying to use the same example from https://github.com/JedWatson/react-select/issues/3111#issuecomment-470911304
+// Without much luck so far.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function menuListFactory(toggleMenuIsOpen?: () => void): ComponentType<MenuListComponentProps<any>> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const MenuList: ComponentType<MenuListComponentProps<any>> = props => {
+    const ariaAttributes = {
+      // 'aria-autocomplete': 'list',
+      'aria-label': props.selectProps['aria-label'],
+      'aria-labelledby': props.selectProps['aria-labelledby'],
+    }
+
+    return (
+      <components.MenuList {...props}>
+        <div className="header" style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <h2>Select token</h2>
+          <button
+            type="button"
+            onClick={(): void => {
+              // TODO: no idea how to make this menu close
+              // I tried to use the state from the select, but besides breaking the menu on the parent
+              // it doesn't work here :/
+              toggleMenuIsOpen && toggleMenuIsOpen()
+              console.log('close pop up')
+            }}
+          >
+            X
+          </button>
+        </div>
+        <div className="searchContainer" style={{ display: 'flex' }}>
+          <FontAwesomeIcon icon={faSearch} />
+          <input
+            style={{
+              width: '100%',
+              boxSizing: 'border-box',
+            }}
+            autoCorrect="off"
+            autoComplete="off"
+            spellCheck="false"
+            type="text"
+            placeholder="Search by token Name, Symbol or Address"
+            value={props.selectProps.inputValue}
+            onChange={(e): void => {
+              const { selectProps } = props
+              const { onInputChange } = selectProps
+              onInputChange &&
+                onInputChange(e.currentTarget.value, {
+                  action: 'input-change',
+                })
+            }}
+            onMouseDown={(e): void => {
+              e.stopPropagation()
+              // TODO: don't know how to make focus
+              // e.target.focus()
+            }}
+            onTouchEnd={(e): void => {
+              e.stopPropagation()
+              //   e.target.focus()
+            }}
+            onFocus={props.selectProps.onMenuInputFocus}
+            {...ariaAttributes}
+          />
+        </div>
+        {props.children}
+      </components.MenuList>
+    )
+  }
+
+  return MenuList
+}

--- a/src/components/TokenSelectorComponents.tsx
+++ b/src/components/TokenSelectorComponents.tsx
@@ -12,6 +12,20 @@ export const MenuList: ComponentType<MenuListComponentProps<any>> = props => {
     setValue,
   } = props
 
+  const childrenRef = useRef(props.children)
+  childrenRef.current = props.children
+
+  const wrappedOnKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (React.Children.count(childrenRef.current) === 1 && e.key === 'Enter') {
+        // the only child is noOptionsMessage
+        e.preventDefault()
+      }
+      onKeyDown?.(e)
+    },
+    [onKeyDown],
+  )
+
   const ariaAttributes = {
     'aria-label': props.selectProps['aria-label'],
     'aria-labelledby': props.selectProps['aria-labelledby'],
@@ -67,7 +81,7 @@ export const MenuList: ComponentType<MenuListComponentProps<any>> = props => {
           placeholder="Search by token Name, Symbol or Address"
           value={inputValue}
           onChange={onChange}
-          onKeyDown={onKeyDown}
+          onKeyDown={wrappedOnKeyDown}
           onMouseDown={onInputClick}
           onTouchEnd={onInputClick}
           onFocus={onMenuInputFocus}


### PR DESCRIPTION
Addressing points missing on https://github.com/gnosis/dex-react/pull/597

Tried to use the example provided in this issue https://github.com/JedWatson/react-select/issues/3111

What I couldn't make work yet:

- ~Focus on search input~
- Placeholder text display fully
- ~Close button on title~
- List of tokens displayed over modal
- ~Build failing due to TS issues with `useRef` typings~
- ~(After merge with `0.9.0`) Enter on invalid selection loses focus to price input if any is unfilled~

Everything else (besides the horrible styling) work fine

Current looks:

![Screenshot from 2020-03-03 15-58-33](https://user-images.githubusercontent.com/43217/75809652-e4364d00-5d67-11ea-89df-535a68a397db.png)

