### PR TITLE
Create pending API and mocks

### DIFF
--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -94,12 +94,6 @@ export interface Order {
   remainingAmount: BN
 }
 
-export interface PendingTxObj extends AuctionElement {
-  txHash: string
-}
-
-export type PendingTxArray = PendingTxObj[]
-
 export interface GetOrdersPaginatedResult {
   orders: AuctionElement[]
   nextIndex?: number

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,6 +12,8 @@ import { DepositApiProxy } from './deposit/DepositApiProxy'
 import { ExchangeApi } from './exchange/ExchangeApi'
 import { ExchangeApiMock } from './exchange/ExchangeApiMock'
 import { ExchangeApiProxy } from './exchange/ExchangeApiProxy'
+import { PendingApi, PendingApiImpl } from './pending/PendingApi'
+import { PendingApiMock } from './pending/PendingApiMock'
 import {
   tokenList,
   exchangeBalanceStates,
@@ -19,6 +21,7 @@ import {
   erc20Allowances,
   FEE_TOKEN,
   exchangeOrders,
+  pendingOrders,
   unregisteredTokens,
   TOKEN_8,
 } from '../../test/data'
@@ -108,6 +111,19 @@ function createTokenListApi(): TokenList {
   return tokenListApi
 }
 
+function createPendingApi(): PendingApi {
+  let pendingApi
+  if (process.env.MOCK_WALLET === 'true') {
+    pendingApi = new PendingApiMock({
+      ordersByUser: pendingOrders,
+    })
+  } else {
+    pendingApi = new PendingApiImpl()
+  }
+  window['pendingApi'] = pendingApi // register for convenience
+  return pendingApi
+}
+
 // Build APIs
 export const web3: Web3 = createWeb3Api()
 export const walletApi: WalletApi = createWalletApi(web3)
@@ -121,3 +137,4 @@ export const erc20Api: Erc20Api = createErc20Api(injectedDependencies)
 export const depositApi: DepositApi = createDepositApi(erc20Api, injectedDependencies)
 export const exchangeApi: ExchangeApi = createExchangeApi(erc20Api, injectedDependencies)
 export const tokenListApi: TokenList = createTokenListApi()
+export const pendingApi: PendingApi = createPendingApi()

--- a/src/api/pending/PendingApi.ts
+++ b/src/api/pending/PendingApi.ts
@@ -1,0 +1,25 @@
+import { AuctionElement } from 'api/exchange/ExchangeApi'
+
+export interface PendingTxObj extends AuctionElement {
+  txHash: string
+}
+
+export type PendingTxArray = PendingTxObj[]
+
+interface BaseParams {
+  networkId: number
+}
+
+export interface GetOrdersParams extends BaseParams {
+  userAddress: string
+}
+
+export interface PendingApi {
+  getOrders(params: GetOrdersParams): Promise<PendingTxArray>
+}
+
+export class PendingApiImpl implements PendingApi {
+  async getOrders(): Promise<PendingTxArray> {
+    return []
+  }
+}

--- a/src/api/pending/PendingApiMock.ts
+++ b/src/api/pending/PendingApiMock.ts
@@ -1,0 +1,42 @@
+import { PendingTxArray, PendingTxObj } from './PendingApi'
+import { GetOrdersParams } from 'api/exchange/ExchangeApi'
+import BN from 'bn.js'
+import { ONE } from '@gnosis.pm/dex-js'
+import { OrderWithTx, OrdersWithTxByUser } from '../../../test/data'
+
+interface ConstructorParams {
+  ordersByUser: OrdersWithTxByUser
+}
+
+export class PendingApiMock implements PendingApiMock {
+  private orders: OrdersWithTxByUser
+
+  constructor(params: ConstructorParams) {
+    const { ordersByUser } = params
+    this.orders = ordersByUser
+  }
+
+  async getOrders({ userAddress }: GetOrdersParams): Promise<PendingTxArray> {
+    this._initOrders(userAddress)
+
+    const orders = this.orders[userAddress].map((order, index) => this.orderToAuctionElement(order, index, userAddress))
+    return orders
+  }
+
+  /********************************    private methods   ********************************/
+  private _initOrders(userAddress: string): void {
+    const userOrders = this.orders[userAddress]
+    if (!userOrders) {
+      this.orders[userAddress] = []
+    }
+  }
+
+  private orderToAuctionElement(order: OrderWithTx, index: number, userAddress: string): PendingTxObj {
+    return {
+      ...order,
+      user: userAddress,
+      sellTokenBalance: new BN('1500000000000000000000').add(ONE),
+      id: index.toString(),
+    }
+  }
+}

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -64,7 +64,8 @@ export function useOrders(): Result {
     const fetchOrders = async (offset: number): Promise<void> => {
       // isLoading is the important one
       // controls ongoing fetching chain
-      if (!userAddress || !networkId || !isLoading) {
+      if (!userAddress || !networkId /*|| !isLoading*/) {
+        // TODO: Do not merge with this, just for doing a quick test!!
         // next isLoading = true will be when userAddress and networkId are valid
         setIsLoading(false)
         return

--- a/src/hooks/usePendingOrders.ts
+++ b/src/hooks/usePendingOrders.ts
@@ -1,9 +1,10 @@
 import { useEffect } from 'react'
-import { PendingTxArray } from 'api/exchange/ExchangeApi'
+import { pendingApi } from 'api'
 
 import useGlobalState from './useGlobalState'
 import useSafeState from './useSafeState'
 import { useWalletConnection } from './useWalletConnection'
+import { PendingTxArray } from 'api/pending/PendingApi'
 
 function usePendingOrders(): PendingTxArray {
   const { userAddress, networkId } = useWalletConnection()
@@ -12,7 +13,17 @@ function usePendingOrders(): PendingTxArray {
   const [pendingOrders, setPendingOrders] = useSafeState<PendingTxArray>([])
 
   useEffect(() => {
-    userAddress && networkId && setPendingOrders(pendingOrdersGlobal[networkId][userAddress] || [])
+    if (userAddress && networkId) {
+      pendingApi
+        .getOrders({ userAddress, networkId })
+        .then(pendingOrders => {
+          setPendingOrders(pendingOrders)
+        })
+        .catch(error => {
+          // TODO: Handle error when
+          console.error('[usePendingOrders] Error getting pending orders', error)
+        })
+    }
   }, [networkId, pendingOrdersGlobal, setPendingOrders, userAddress])
 
   return pendingOrders

--- a/test/data/userOrders.ts
+++ b/test/data/userOrders.ts
@@ -5,7 +5,8 @@ import { UNLIMITED_ORDER_AMOUNT, MAX_BATCH_ID } from '@gnosis.pm/dex-js'
 
 import { dateToBatchId } from 'utils'
 
-import { USER_1, BATCH_ID } from './basic'
+import { USER_1, BATCH_ID, TX_HASH } from './basic'
+import { Order } from 'api/exchange/ExchangeApi'
 
 const NOW = Date.now()
 
@@ -59,7 +60,9 @@ export const exchangeOrders = {
   ],
 }
 
-export const pendingOrders = {
+export type OrderWithTx = Order & { txHash: string }
+export type OrdersWithTxByUser = { [user: string]: OrderWithTx[] }
+export const pendingOrders: OrdersWithTxByUser = {
   [USER_1]: [
     {
       buyTokenId: 7, // DAI
@@ -69,6 +72,7 @@ export const pendingOrders = {
       priceNumerator: new BN('1315273500000000000000'),
       priceDenominator: new BN('876849000'),
       remainingAmount: new BN('876849000'),
+      txHash: TX_HASH,
     },
   ],
 }


### PR DESCRIPTION
Adds a new `API` ---> `PendingAPI`

* This API has for now, ONLY getOrders. So it has the pending orders
* I created it for mocking the pending orders, this is why the REAL implementation returns an empty array
* In the future, we could use this API for persisting in the browser the pending orders, so it's refresh resistant