### PR TITLE
Close form on Escape

### DIFF
--- a/src/components/DepositWidget/Form.tsx
+++ b/src/components/DepositWidget/Form.tsx
@@ -12,6 +12,7 @@ import useScrollIntoView from 'hooks/useScrollIntoView'
 
 import { TokenBalanceDetails } from 'types'
 import { formatAmountFull, parseAmount } from 'utils'
+import useKeyPress from 'hooks/useKeyDown'
 
 export interface FormProps {
   tokenBalances: TokenBalanceDetails
@@ -62,6 +63,8 @@ export const Form: React.FC<FormProps> = (props: FormProps) => {
     setAmountInput('')
     props.onClose()
   }
+
+  useKeyPress('Escape', cancelForm)
 
   useEffect(() => {
     if (validatorActive) {

--- a/src/hooks/useKeyDown.ts
+++ b/src/hooks/useKeyDown.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+
+const useKeyPress = (key: string, callback: (event: KeyboardEvent) => void): void => {
+  useEffect(() => {
+    const filteredCallback = (event: KeyboardEvent): void => {
+      if (key === event.key) callback(event)
+    }
+    // why not keypress?, because it doesn't catch Escape
+    document.addEventListener('keydown', filteredCallback)
+
+    return (): void => document.removeEventListener('keydown', filteredCallback)
+    // don't care about stable callback reference
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key])
+}
+
+export default useKeyPress


### PR DESCRIPTION
Adds a hook to call callback on keydown
Uses it to close Deposit/Withdraw from on /wallet page

Modali already has that functionality, so no need there

Closes #629 