### PR TITLE
Fix for modali screen flash

### DIFF
--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -947,6 +947,23 @@ const GlobalStyles = createGlobalStyle`
     color: #476481;
   }
   // End WalletConnect Modal
+
+  /* Hack to fix Modali screen flash */
+  .modali-overlay {
+    display: none
+  }
+
+  body.modali-open::after {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    content: "";
+    background-color: rgba(47,62,78,0.5);
+    z-index: 1040;
+  }
+  /* End hack */
   
   .modali-open .modali-overlay {
     background-color: rgba(47,62,78,0.5);


### PR DESCRIPTION
When opening Modali modal from Withdraw modal (when overriding withdraw request) screen briefly flashes
![ezgif-7-c2fda6feb21c](https://user-images.githubusercontent.com/5121491/75550312-b937ba80-5a42-11ea-91fb-b855aad2ec8f.gif)


Happens because Withdraw modal has it's own overlay (not really overlay, but box shadow), so what actually goes on is:

1. Withdraw overlay on -> overlay background darkish
2. Withdraw off -> no overlay -> white background
3. Modali on -> overlay background darkish

A proper fix would be to change not modals but content of one modal: Form -> Modali contents,; without changing overlay in-between

Candidate for refactor? Candidate for refactor!