### PR TITLE
OrderValidity modal sanitization logic

### DIFF
--- a/src/components/TradeWidget/OrderValidity.tsx
+++ b/src/components/TradeWidget/OrderValidity.tsx
@@ -184,6 +184,8 @@ const OrderValidity: React.FC<Props> = ({
       const sanitizedUntilValue = makeMultipleOf(5, validUntilInputValue).toString()
 
       batchedUpdates(() => {
+        if (sanitizedFromValue === '0') setAsap(true)
+        if (sanitizedUntilValue === '0') setUnlimited(true)
         setValue(validFromInputId, sanitizedFromValue, true)
         setValue(validUntilInputId, sanitizedUntilValue, true)
       })
@@ -191,7 +193,9 @@ const OrderValidity: React.FC<Props> = ({
 
     setShowOrderConfig(showOrderConfig => !showOrderConfig)
   }, [
+    setAsap,
     setShowOrderConfig,
+    setUnlimited,
     setValue,
     showOrderConfig,
     validFromInputId,
@@ -261,7 +265,7 @@ const OrderValidity: React.FC<Props> = ({
               tabIndex={tabIndex + 2}
             />
             <div className="radio-container">
-              <input type="checkbox" disabled={isDisabled} defaultChecked={isAsap} onClick={handleASAPClick} />
+              <input type="checkbox" checked={isAsap} disabled={isDisabled} onChange={handleASAPClick} />
               <small>ASAP</small>
             </div>
           </label>
@@ -285,12 +289,7 @@ const OrderValidity: React.FC<Props> = ({
               tabIndex={tabIndex + 3}
             />
             <div className="radio-container">
-              <input
-                type="checkbox"
-                disabled={isDisabled}
-                defaultChecked={isUnlimited}
-                onClick={handleUnlimitedClick}
-              />
+              <input type="checkbox" disabled={isDisabled} checked={isUnlimited} onChange={handleUnlimitedClick} />
               <small>Never</small>
             </div>
           </label>


### PR DESCRIPTION
when manually setting `0` values for both `validFrom` and `validUntil` the app wasn't setting the toggle on the checkboxes - WELL now it does