### PR TITLE
Non-blocking Deposit/Withdraw modals

### DIFF
--- a/src/components/DepositWidget/Form.tsx
+++ b/src/components/DepositWidget/Form.tsx
@@ -23,7 +23,7 @@ export interface FormProps {
   responsive?: boolean
   submitBtnLabel: string
   submitBtnIcon: IconDefinition
-  onSubmit: (amount: BN) => Promise<void>
+  onSubmit: (amount: BN, onTxHash: (hash: string) => void) => Promise<void>
   onClose: () => void
 }
 
@@ -84,12 +84,15 @@ export const Form: React.FC<FormProps> = (props: FormProps) => {
     if (!error) {
       setLoading(true)
       const parsedAmt = parseAmount(amountInput, decimals)
-      parsedAmt &&
-        props.onSubmit(parsedAmt).then(() => {
-          setLoading(false)
-          setValidatorActive(false)
-          cancelForm()
-        })
+      let called = false
+      const onFinish = (): void => {
+        if (called) return
+        called = true
+        setLoading(false)
+        setValidatorActive(false)
+        cancelForm()
+      }
+      parsedAmt && props.onSubmit(parsedAmt, onFinish).then(onFinish)
     }
   }
 

--- a/src/components/DepositWidget/Row.tsx
+++ b/src/components/DepositWidget/Row.tsx
@@ -7,7 +7,7 @@ import plus from 'assets/img/plus.svg'
 
 import Form from './Form'
 import TokenImg from 'components/TokenImg'
-import { TokenRow, RowClaimButton, RowClaimLink } from './Styled'
+import { TokenRow, RowClaimButton, RowClaimSpan } from './Styled'
 
 import useNoScroll from 'hooks/useNoScroll'
 
@@ -95,9 +95,7 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
               <RowClaimButton className="success" onClick={onClaim} disabled={claiming}>
                 {(claiming || withdrawing) && spinner}
                 {formatAmount(pendingWithdraw.amount, decimals)}
-                <div>
-                  <RowClaimLink className={claiming || withdrawing ? 'disabled' : 'success'}></RowClaimLink>
-                </div>
+                <RowClaimSpan className={claiming || withdrawing ? 'disabled' : 'success'}>Claim</RowClaimSpan>
               </RowClaimButton>
             </>
           ) : pendingWithdraw.amount.gt(ZERO) ? (

--- a/src/components/DepositWidget/Row.tsx
+++ b/src/components/DepositWidget/Row.tsx
@@ -16,7 +16,7 @@ import { formatAmount, formatAmountFull } from 'utils'
 import { TokenBalanceDetails, Command } from 'types'
 import { TokenLocalState } from 'reducers-actions'
 
-export interface RowProps extends TokenLocalState {
+export interface RowProps extends Record<keyof TokenLocalState, boolean> {
   tokenBalances: TokenBalanceDetails
   onSubmitDeposit: (amount: BN, onTxHash: (hash: string) => void) => Promise<void>
   onSubmitWithdraw: (amount: BN, onTxHash: (hash: string) => void) => Promise<void>
@@ -62,9 +62,9 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
   useNoScroll(!!visibleForm && showResponsive)
 
   let className
-  if (highlighted.has(address)) {
+  if (highlighted) {
     className = 'highlight'
-  } else if (enabling.has(address)) {
+  } else if (enabling) {
     className = 'enabling'
   } else if (visibleForm) {
     className = 'selected'
@@ -84,20 +84,18 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
           </div>
         </td>
         <td data-label="Exchange Wallet" title={formatAmountFull(totalExchangeBalance, decimals) || ''}>
-          {depositing.has(address) && <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />}
+          {depositing && <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />}
           {formatAmount(totalExchangeBalance, decimals)}
         </td>
         <td data-label="Pending Withdrawals" title={formatAmountFull(pendingWithdraw.amount, decimals) || ''}>
           {claimable ? (
             <>
-              <RowClaimButton className="success" onClick={onClaim} disabled={claiming.has(address)}>
-                {(claiming.has(address) || withdrawing.has(address)) && (
-                  <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />
-                )}
+              <RowClaimButton className="success" onClick={onClaim} disabled={claiming}>
+                {(claiming || withdrawing) && <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />}
                 {formatAmount(pendingWithdraw.amount, decimals)}
                 <div>
                   <RowClaimLink
-                    className={claiming.has(address) || withdrawing.has(address) ? 'disabled' : 'success'}
+                    className={claiming || withdrawing ? 'disabled' : 'success'}
                     // onClick={(): void => {
                     //   if (!claiming.has(address) && !withdrawing.has(address)) {
                     //     console.debug('Claiming')
@@ -110,18 +108,16 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
             </>
           ) : pendingWithdraw.amount.gt(ZERO) ? (
             <>
-              {withdrawing.has(address) && <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />}
+              {withdrawing && <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />}
               <FontAwesomeIcon icon={faClock} style={{ marginRight: 7 }} />
               {formatAmount(pendingWithdraw.amount, decimals)}
             </>
           ) : (
-            <>{withdrawing.has(address) && <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />}0</>
+            <>{withdrawing && <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />}0</>
           )}
         </td>
         <td data-label="Wallet" title={formatAmountFull(walletBalance, decimals) || ''}>
-          {(claiming.has(address) || depositing.has(address)) && (
-            <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />
-          )}
+          {(claiming || depositing) && <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />}
           {formatAmount(walletBalance, decimals)}
         </td>
         <td data-label="Actions">
@@ -136,8 +132,8 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
             </button>
           ) : (
             <>
-              <button type="button" className="enableToken" onClick={onEnableToken} disabled={enabling.has(address)}>
-                {enabling.has(address) ? (
+              <button type="button" className="enableToken" onClick={onEnableToken} disabled={enabling}>
+                {enabling ? (
                   <>
                     <FontAwesomeIcon icon={faSpinner} spin />
                     Enabling {symbol}

--- a/src/components/DepositWidget/Row.tsx
+++ b/src/components/DepositWidget/Row.tsx
@@ -26,6 +26,8 @@ export interface RowProps extends Record<keyof TokenLocalState, boolean> {
   innerHeight?: number
 }
 
+const spinner = <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />
+
 export const Row: React.FC<RowProps> = (props: RowProps) => {
   const {
     tokenBalances,
@@ -84,14 +86,14 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
           </div>
         </td>
         <td data-label="Exchange Wallet" title={formatAmountFull(totalExchangeBalance, decimals) || ''}>
-          {depositing && <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />}
+          {depositing && spinner}
           {formatAmount(totalExchangeBalance, decimals)}
         </td>
         <td data-label="Pending Withdrawals" title={formatAmountFull(pendingWithdraw.amount, decimals) || ''}>
           {claimable ? (
             <>
               <RowClaimButton className="success" onClick={onClaim} disabled={claiming}>
-                {(claiming || withdrawing) && <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />}
+                {(claiming || withdrawing) && spinner}
                 {formatAmount(pendingWithdraw.amount, decimals)}
                 <div>
                   <RowClaimLink
@@ -108,16 +110,16 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
             </>
           ) : pendingWithdraw.amount.gt(ZERO) ? (
             <>
-              {withdrawing && <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />}
+              {withdrawing && spinner}
               <FontAwesomeIcon icon={faClock} style={{ marginRight: 7 }} />
               {formatAmount(pendingWithdraw.amount, decimals)}
             </>
           ) : (
-            <>{withdrawing && <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />}0</>
+            <>{withdrawing && spinner}0</>
           )}
         </td>
         <td data-label="Wallet" title={formatAmountFull(walletBalance, decimals) || ''}>
-          {(claiming || depositing) && <FontAwesomeIcon icon={faSpinner} style={{ marginRight: 7 }} spin />}
+          {(claiming || depositing) && spinner}
           {formatAmount(walletBalance, decimals)}
         </td>
         <td data-label="Actions">

--- a/src/components/DepositWidget/Row.tsx
+++ b/src/components/DepositWidget/Row.tsx
@@ -98,6 +98,12 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
                 <div>
                   <RowClaimLink
                     className={claiming.has(address) || withdrawing.has(address) ? 'disabled' : 'success'}
+                    // onClick={(): void => {
+                    //   if (!claiming.has(address) && !withdrawing.has(address)) {
+                    //     console.debug('Claiming')
+                    //     onClaim()
+                    //   }
+                    // }}
                   ></RowClaimLink>
                 </div>
               </RowClaimButton>

--- a/src/components/DepositWidget/Row.tsx
+++ b/src/components/DepositWidget/Row.tsx
@@ -96,15 +96,7 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
                 {(claiming || withdrawing) && spinner}
                 {formatAmount(pendingWithdraw.amount, decimals)}
                 <div>
-                  <RowClaimLink
-                    className={claiming || withdrawing ? 'disabled' : 'success'}
-                    // onClick={(): void => {
-                    //   if (!claiming.has(address) && !withdrawing.has(address)) {
-                    //     console.debug('Claiming')
-                    //     onClaim()
-                    //   }
-                    // }}
-                  ></RowClaimLink>
+                  <RowClaimLink className={claiming || withdrawing ? 'disabled' : 'success'}></RowClaimLink>
                 </div>
               </RowClaimButton>
             </>

--- a/src/components/DepositWidget/Styled.tsx
+++ b/src/components/DepositWidget/Styled.tsx
@@ -95,27 +95,19 @@ export const RowClaimButton = styled.button`
   }
 `
 
-export const RowClaimLink = styled.a`
-  text-decoration: none;
-  cursor: pointer;
+export const RowClaimSpan = styled.span`
   font-size: 1.2rem;
   line-height: 1;
+  display: block;
+  border: 0.1rem solid #63ab52;
+  border-radius: 2rem;
+  background: transparent;
+  color: #63ab52;
+  padding: 0.4rem 1rem;
+  transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
+  margin: 0 0 0 0.5rem;
 
-  &::after {
-    content: 'Claim';
-    display: block;
-    line-height: inherit;
-    border: 0.1rem solid #63ab52;
-    border-radius: 2rem;
-    background: transparent;
-    color: #63ab52;
-    padding: 0.4rem 1rem;
-    transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
-    box-sizing: border-box;
-    margin: 0 0 0 0.5rem;
-  }
-
-  &:hover::after {
+  &:hover {
     background: var(--color-button-success);
     color: white;
   }

--- a/src/components/DepositWidget/Styled.tsx
+++ b/src/components/DepositWidget/Styled.tsx
@@ -98,7 +98,6 @@ export const RowClaimButton = styled.button`
 export const RowClaimSpan = styled.span`
   font-size: 1.2rem;
   line-height: 1;
-  display: block;
   border: 0.1rem solid #63ab52;
   border-radius: 2rem;
   background: transparent;

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -354,10 +354,7 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
                       onTxHash,
                     )
                   }}
-                  onClaim={(): Promise<void> => {
-                    console.debug('Claim token')
-                    return claimToken(tokenBalances.address)
-                  }}
+                  onClaim={(): Promise<void> => claimToken(tokenBalances.address)}
                   claiming={claiming.has(tokenBalances.address)}
                   withdrawing={withdrawing.has(tokenBalances.address)}
                   depositing={depositing.has(tokenBalances.address)}

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -358,11 +358,11 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
                     console.debug('Claim token')
                     return claimToken(tokenBalances.address)
                   }}
-                  claiming={claiming}
-                  withdrawing={withdrawing}
-                  depositing={depositing}
-                  highlighted={highlighted}
-                  enabling={enabling}
+                  claiming={claiming.has(tokenBalances.address)}
+                  withdrawing={withdrawing.has(tokenBalances.address)}
+                  depositing={depositing.has(tokenBalances.address)}
+                  highlighted={highlighted.has(tokenBalances.address)}
+                  enabling={enabling.has(tokenBalances.address)}
                   {...windowSpecs}
                 />
               ))}

--- a/src/components/DepositWidget/useRowActions.tsx
+++ b/src/components/DepositWidget/useRowActions.tsx
@@ -37,7 +37,6 @@ export const useRowActions = (params: Params): Result => {
   const { balances } = params
 
   const [{ tokens: state }, dispatch] = useGlobalState()
-  console.log('state', state)
 
   const { userAddress, networkId } = useWalletConnection()
 

--- a/src/components/DepositWidget/useRowActions.tsx
+++ b/src/components/DepositWidget/useRowActions.tsx
@@ -8,10 +8,16 @@ import { ALLOWANCE_MAX_VALUE } from 'const'
 import { useWalletConnection } from 'hooks/useWalletConnection'
 
 import { formatAmount, formatAmountFull, logDebug, getToken, safeFilledToken } from 'utils'
-import { txOptionalParams } from 'utils/transaction'
+import { composeOptionalParams } from 'utils/transaction'
 
 import useGlobalState from 'hooks/useGlobalState'
-import { TokenLocalState, setHighlightAction, setEnablingAction, setHighlightAndClaimingAction } from 'reducers-actions'
+import {
+  TokenLocalState,
+  setEnablingAction,
+  setHighlightAndClaimingAction,
+  setHighlightAndDepositing,
+  setHighlightAndWithdrawing,
+} from 'reducers-actions'
 import { useMemo } from 'react'
 
 const ON_ERROR_MESSAGE = 'No logged in user found. Please check wallet connectivity status and try again.'
@@ -21,23 +27,24 @@ interface Params {
 }
 
 interface Result extends TokenLocalState {
-  enableToken: (tokenAddress: string) => Promise<void>
-  depositToken: (amount: BN, tokenAddress: string) => Promise<void>
-  requestWithdrawToken: (amount: BN, tokenAddress: string) => Promise<void>
-  claimToken: (tokenAddress: string) => Promise<void>
+  enableToken: (tokenAddress: string, onTxHash?: (hash: string) => void) => Promise<void>
+  depositToken: (amount: BN, tokenAddress: string, onTxHash?: (hash: string) => void) => Promise<void>
+  requestWithdrawToken: (amount: BN, tokenAddress: string, onTxHash?: (hash: string) => void) => Promise<void>
+  claimToken: (tokenAddress: string, onTxHash?: (hash: string) => void) => Promise<void>
 }
 
 export const useRowActions = (params: Params): Result => {
   const { balances } = params
 
   const [{ tokens: state }, dispatch] = useGlobalState()
+  console.log('state', state)
 
   const { userAddress, networkId } = useWalletConnection()
 
   const methods = useMemo(() => {
     const contractAddress = networkId ? depositApi.getContractAddress(networkId) : null
 
-    async function enableToken(tokenAddress: string): Promise<void> {
+    async function enableToken(tokenAddress: string, onTxHash?: (hash: string) => void): Promise<void> {
       try {
         assert(userAddress, 'User address missing. Aborting.')
         assert(networkId, 'NetworkId missing. Aborting.')
@@ -56,7 +63,7 @@ export const useRowActions = (params: Params): Result => {
           spenderAddress: contractAddress,
           networkId,
           amount: ALLOWANCE_MAX_VALUE,
-          txOptionalParams,
+          txOptionalParams: composeOptionalParams(onTxHash),
         })
         logDebug(`[DepositWidget:useRowActions] The transaction has been mined: ${receipt.transactionHash}`)
 
@@ -69,7 +76,7 @@ export const useRowActions = (params: Params): Result => {
       }
     }
 
-    async function depositToken(amount: BN, tokenAddress: string): Promise<void> {
+    async function depositToken(amount: BN, tokenAddress: string, onTxHash?: (hash: string) => void): Promise<void> {
       try {
         assert(userAddress, ON_ERROR_MESSAGE)
         assert(networkId, ON_ERROR_MESSAGE)
@@ -77,12 +84,18 @@ export const useRowActions = (params: Params): Result => {
         const token = getToken('address', tokenAddress, balances)
         assert(token, 'No token')
 
-        dispatch(setHighlightAction(tokenAddress))
+        dispatch(setHighlightAndDepositing(tokenAddress))
 
         const { symbol, decimals } = safeFilledToken<TokenBalanceDetails>(token)
 
         logDebug(`[DepositWidget:useRowActions] Processing deposit of ${amount} ${symbol} from ${userAddress}`)
-        const receipt = await depositApi.deposit({ userAddress, tokenAddress, networkId, amount, txOptionalParams })
+        const receipt = await depositApi.deposit({
+          userAddress,
+          tokenAddress,
+          networkId,
+          amount,
+          txOptionalParams: composeOptionalParams(onTxHash),
+        })
         logDebug(`[DepositWidget:useRowActions] The transaction has been mined: ${receipt.transactionHash}`)
 
         toast.success(`Successfully deposited ${formatAmount(amount, decimals)} ${symbol}`)
@@ -90,11 +103,15 @@ export const useRowActions = (params: Params): Result => {
         console.error('DepositWidget:useRowActions] Error depositing', error)
         toast.error(`Error depositing: ${error.message}`)
       } finally {
-        dispatch(setHighlightAction(tokenAddress))
+        dispatch(setHighlightAndDepositing(tokenAddress))
       }
     }
 
-    async function requestWithdrawToken(amount: BN, tokenAddress: string): Promise<void> {
+    async function requestWithdrawToken(
+      amount: BN,
+      tokenAddress: string,
+      onTxHash?: (hash: string) => void,
+    ): Promise<void> {
       try {
         assert(userAddress, ON_ERROR_MESSAGE)
         assert(networkId, ON_ERROR_MESSAGE)
@@ -102,7 +119,7 @@ export const useRowActions = (params: Params): Result => {
         const token = getToken('address', tokenAddress, balances)
         assert(token, 'No token')
 
-        dispatch(setHighlightAction(tokenAddress))
+        dispatch(setHighlightAndWithdrawing(tokenAddress))
 
         const { symbol, decimals } = safeFilledToken<TokenBalanceDetails>(token)
 
@@ -114,7 +131,7 @@ export const useRowActions = (params: Params): Result => {
           tokenAddress,
           networkId,
           amount,
-          txOptionalParams,
+          txOptionalParams: composeOptionalParams(onTxHash),
         })
         logDebug(`[DepositWidget:useRowActions] The transaction has been mined: ${receipt.transactionHash}`)
 
@@ -123,11 +140,11 @@ export const useRowActions = (params: Params): Result => {
         console.error('DepositWidget:useRowActions] Error requesting withdraw', error)
         toast.error(`Error requesting withdraw: ${error.message}`)
       } finally {
-        dispatch(setHighlightAction(tokenAddress))
+        dispatch(setHighlightAndWithdrawing(tokenAddress))
       }
     }
 
-    async function claimToken(tokenAddress: string): Promise<void> {
+    async function claimToken(tokenAddress: string, onTxHash?: (hash: string) => void): Promise<void> {
       try {
         assert(userAddress, ON_ERROR_MESSAGE)
         assert(networkId, ON_ERROR_MESSAGE)
@@ -141,7 +158,12 @@ export const useRowActions = (params: Params): Result => {
 
         dispatch(setHighlightAndClaimingAction(tokenAddress))
 
-        const receipt = await depositApi.withdraw({ userAddress, tokenAddress, networkId, txOptionalParams })
+        const receipt = await depositApi.withdraw({
+          userAddress,
+          tokenAddress,
+          networkId,
+          txOptionalParams: composeOptionalParams(onTxHash),
+        })
 
         logDebug(`[DepositWidget:useRowActions] The transaction has been mined: ${receipt.transactionHash}`)
         toast.success(`Withdraw of ${formatAmount(pendingWithdraw.amount, decimals)} ${symbol} completed`)
@@ -164,10 +186,8 @@ export const useRowActions = (params: Params): Result => {
   return useMemo(
     () => ({
       ...methods,
-      enabling: state.enabling,
-      claiming: state.claiming,
-      highlighted: state.highlighted,
+      ...state,
     }),
-    [methods, state.claiming, state.enabling, state.highlighted],
+    [methods, state],
   )
 }

--- a/src/reducers-actions/tokenRow.ts
+++ b/src/reducers-actions/tokenRow.ts
@@ -68,40 +68,57 @@ export const TokenRowInitialState: TokenLocalState = {
   withdrawing: new Set(),
 }
 
+function getRemainingType(type: ActionTypes.SET_HIGHLIGHTED_AND_CLAIMING): ActionTypes.SET_CLAIMING
+function getRemainingType(type: ActionTypes.SET_HIGHLIGHTED_AND_WITHDRAWING): ActionTypes.SET_WITHDRAWING
+function getRemainingType(type: ActionTypes.SET_HIGHLIGHTED_AND_DEPOSITING): ActionTypes.SET_DEPOSITING
+function getRemainingType(
+  type:
+    | ActionTypes.SET_HIGHLIGHTED_AND_CLAIMING
+    | ActionTypes.SET_HIGHLIGHTED_AND_WITHDRAWING
+    | ActionTypes.SET_HIGHLIGHTED_AND_DEPOSITING,
+): ActionTypes.SET_CLAIMING | ActionTypes.SET_WITHDRAWING | ActionTypes.SET_DEPOSITING
+function getRemainingType(type: ActionTypes): ActionTypes {
+  switch (type) {
+    case ActionTypes.SET_HIGHLIGHTED_AND_CLAIMING:
+      return ActionTypes.SET_CLAIMING
+
+    case ActionTypes.SET_HIGHLIGHTED_AND_DEPOSITING:
+      return ActionTypes.SET_DEPOSITING
+
+    case ActionTypes.SET_HIGHLIGHTED_AND_WITHDRAWING:
+      return ActionTypes.SET_WITHDRAWING
+  }
+
+  // to appease TS
+  throw new Error(`Unexpected ActionTypes -- ${type}`)
+}
+
 export const reducer = (state: TokenLocalState, action: Actions): TokenLocalState => {
-  switch (action.type) {
+  const { type, payload } = action
+  switch (type) {
     case ActionTypes.SET_ENABLING:
     case ActionTypes.SET_CLAIMING:
+    case ActionTypes.SET_DEPOSITING:
+    case ActionTypes.SET_WITHDRAWING:
     case ActionTypes.SET_HIGHLIGHTED: {
-      const newSet = new Set(state[action.type])
+      const newSet = new Set(state[type])
       return {
         ...state,
-        [action.type]: newSet.has(action.payload)
-          ? newSet.delete(action.payload) && newSet
-          : newSet.add(action.payload),
+        [type]: newSet.has(payload) ? newSet.delete(payload) && newSet : newSet.add(payload),
       }
     }
+    case ActionTypes.SET_HIGHLIGHTED_AND_DEPOSITING:
+    case ActionTypes.SET_HIGHLIGHTED_AND_WITHDRAWING:
     case ActionTypes.SET_HIGHLIGHTED_AND_CLAIMING: {
-      const newClaimingSet = new Set(state.claiming)
-      const newHighlightedSet = new Set(state.highlighted)
+      const setWithHighlighted = reducer(state, {
+        type: ActionTypes.SET_HIGHLIGHTED,
+        payload,
+      })
 
-      if (newClaimingSet.has(action.payload)) {
-        newClaimingSet.delete(action.payload)
-      } else {
-        newClaimingSet.add(action.payload)
-      }
-
-      if (newHighlightedSet.has(action.payload)) {
-        newHighlightedSet.delete(action.payload)
-      } else {
-        newHighlightedSet.add(action.payload)
-      }
-
-      return {
-        ...state,
-        claiming: newClaimingSet,
-        highlighted: newHighlightedSet,
-      }
+      return reducer(setWithHighlighted, {
+        type: getRemainingType(type),
+        payload,
+      })
     }
     default:
       return state

--- a/src/reducers-actions/tokenRow.ts
+++ b/src/reducers-actions/tokenRow.ts
@@ -1,8 +1,12 @@
 export const enum ActionTypes {
   SET_ENABLING = 'enabling',
   SET_CLAIMING = 'claiming',
+  SET_DEPOSITING = 'depositing',
+  SET_WITHDRAWING = 'withdrawing',
   SET_HIGHLIGHTED = 'highlighted',
   SET_HIGHLIGHTED_AND_CLAIMING = 'highlighted_and_claiming',
+  SET_HIGHLIGHTED_AND_DEPOSITING = 'highlighted_and_depositing',
+  SET_HIGHLIGHTED_AND_WITHDRAWING = 'highlighted_and_withdrawing',
 }
 
 interface Actions {
@@ -12,6 +16,14 @@ interface Actions {
 
 export const setClaimingAction = (payload: string): Actions => ({
   type: ActionTypes.SET_CLAIMING,
+  payload,
+})
+export const setDepositingAction = (payload: string): Actions => ({
+  type: ActionTypes.SET_DEPOSITING,
+  payload,
+})
+export const setWithdrawingAction = (payload: string): Actions => ({
+  type: ActionTypes.SET_WITHDRAWING,
   payload,
 })
 
@@ -27,6 +39,16 @@ export const setHighlightAction = (payload: string): Actions => ({
 
 export const setHighlightAndClaimingAction = (payload: string): Actions => ({
   type: ActionTypes.SET_HIGHLIGHTED_AND_CLAIMING,
+  payload,
+})
+
+export const setHighlightAndDepositing = (payload: string): Actions => ({
+  type: ActionTypes.SET_HIGHLIGHTED_AND_DEPOSITING,
+  payload,
+})
+
+export const setHighlightAndWithdrawing = (payload: string): Actions => ({
+  type: ActionTypes.SET_HIGHLIGHTED_AND_WITHDRAWING,
   payload,
 })
 

--- a/src/reducers-actions/tokenRow.ts
+++ b/src/reducers-actions/tokenRow.ts
@@ -53,15 +53,19 @@ export const setHighlightAndWithdrawing = (payload: string): Actions => ({
 })
 
 export interface TokenLocalState {
-  enabling: Set<string>
-  highlighted: Set<string>
-  claiming: Set<string>
+  [ActionTypes.SET_ENABLING]: Set<string>
+  [ActionTypes.SET_HIGHLIGHTED]: Set<string>
+  [ActionTypes.SET_CLAIMING]: Set<string>
+  [ActionTypes.SET_DEPOSITING]: Set<string>
+  [ActionTypes.SET_WITHDRAWING]: Set<string>
 }
 
 export const TokenRowInitialState: TokenLocalState = {
   enabling: new Set(),
   highlighted: new Set(),
   claiming: new Set(),
+  depositing: new Set(),
+  withdrawing: new Set(),
 }
 
 export const reducer = (state: TokenLocalState, action: Actions): TokenLocalState => {

--- a/src/utils/transaction.tsx
+++ b/src/utils/transaction.tsx
@@ -12,3 +12,13 @@ export const txOptionalParams: TxOptionalParams = {
     }
   },
 }
+
+export const composeOptionalParams = (callback?: TxOptionalParams['onSentTransaction']): TxOptionalParams => {
+  if (!callback) return txOptionalParams
+  return {
+    onSentTransaction: (hash): void => {
+      txOptionalParams.onSentTransaction?.(hash)
+      callback(hash)
+    },
+  }
+}

--- a/test/components/DepositWidget.components.test.tsx
+++ b/test/components/DepositWidget.components.test.tsx
@@ -9,12 +9,12 @@ import { TokenBalanceDetails } from 'types'
 import { TokenLocalState } from 'reducers-actions'
 import { createFlux } from '../data'
 
-const fakeRowState: TokenLocalState = {
-  enabling: new Set(),
-  claiming: new Set(),
-  depositing: new Set(),
-  withdrawing: new Set(),
-  highlighted: new Set(),
+const fakeRowState: Record<keyof TokenLocalState, boolean> = {
+  enabling: false,
+  claiming: false,
+  depositing: false,
+  withdrawing: false,
+  highlighted: false,
 }
 
 const initialTokenBalanceDetails = {
@@ -39,10 +39,10 @@ function _createRow(params: Partial<TokenBalanceDetails> = {}, rowProps = fakeRo
     ...params,
   }
 
-  const onSubmitDeposit = jest.fn<Promise<void>, BN[]>()
-  const onClaim = jest.fn<Promise<void>, void[]>()
-  const onEnableToken = jest.fn<Promise<void>, void[]>()
-  const onSubmitWithdraw = jest.fn<Promise<void>, BN[]>()
+  const onSubmitDeposit = jest.fn<Promise<void>, [BN, Function]>()
+  const onClaim = jest.fn<Promise<void>, []>()
+  const onEnableToken = jest.fn<Promise<void>, []>()
+  const onSubmitWithdraw = jest.fn<Promise<void>, [BN, Function]>()
   return (
     <Row
       tokenBalances={tokenBalanceDetails}
@@ -127,7 +127,7 @@ describe('<Row /> style', () => {
     const wrapper = render(
       _createRow(undefined, {
         ...fakeRowState,
-        highlighted: fakeRowState.highlighted.add(initialTokenBalanceDetails.address),
+        highlighted: true,
       }),
     )
     expect(wrapper.attr('class')).toMatch(/highlight/)
@@ -137,8 +137,8 @@ describe('<Row /> style', () => {
     const wrapper = render(
       _createRow(undefined, {
         ...fakeRowState,
-        highlighted: new Set(),
-        enabling: fakeRowState.enabling.add(initialTokenBalanceDetails.address),
+        highlighted: false,
+        enabling: true,
       }),
     )
     expect(wrapper.attr('class')).toMatch(/enabling/)

--- a/test/components/DepositWidget.components.test.tsx
+++ b/test/components/DepositWidget.components.test.tsx
@@ -12,6 +12,8 @@ import { createFlux } from '../data'
 const fakeRowState: TokenLocalState = {
   enabling: new Set(),
   claiming: new Set(),
+  depositing: new Set(),
+  withdrawing: new Set(),
   highlighted: new Set(),
 }
 


### PR DESCRIPTION
Deposit/Withdraw modals now close `onSentTransaction`. That is when user confirms transaction in the wallet.
To show tx in progress as modals are closed now there are spinners near values that will be updated
That's why there are individual sets to track claiming/withdrawing/depositing txs in progress

Closes #621