### PR TITLE
Fix Firefox Escape keydown

### DIFF
--- a/src/components/DepositWidget/Form.tsx
+++ b/src/components/DepositWidget/Form.tsx
@@ -126,6 +126,7 @@ export const Form: React.FC<FormProps> = (props: FormProps) => {
                 value={amountInput}
                 onChange={(e: ChangeEvent<HTMLInputElement>): void => setAmountInput(e.target.value)}
                 placeholder="0"
+                autoFocus
               />
             </div>
             {/* Error Message */}


### PR DESCRIPTION
So this is a quick fix and essentially a workaround

When Deposit/Withdraw modal opens in Chrome focus returns from the button just clicked to body
In Firefox it doesn't

That button swallows all onClick/KeyDown and doesn't let it bubble because react catches it, normally wouldn't prevent anything, or I think that's what happens

If we explicitly move focus bu clicking somewhere it works. Also it makes sense to just autofocus input