### PR TITLE
Fix overflow undulating at 886px window width

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -9,6 +9,7 @@ import { MEDIA } from 'const'
 
 const Wrapper = styled.div`
   width: 100%;
+  min-height: 100%;
   display: flex;
   flex-flow: column wrap;
 

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -12,7 +12,7 @@ const GlobalStyles = createGlobalStyle`
 
   html, body {  
     width: 100%;
-    height: auto;
+    height: 100%;
     margin: 0;
     font-size: 62.5%;
     line-height: 10px;
@@ -49,7 +49,7 @@ const GlobalStyles = createGlobalStyle`
   }
 
   #root {
-    min-height: 100vh;
+    height: 100%;
     font-size: 1.3rem;
   }
 


### PR DESCRIPTION
In general not a good idea to use `height: 100vh` as it doesn't account for scrollbar size.

![overflow](https://user-images.githubusercontent.com/5121491/76420152-b7f77d80-63b2-11ea-990b-951ff341fdef.gif)
