### PR TITLE
Pooling interface input precision check

### DIFF
--- a/src/components/PoolingWidget/CreateStrategy.tsx
+++ b/src/components/PoolingWidget/CreateStrategy.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
-import { TokenDetails, DEFAULT_DECIMALS } from '@gnosis.pm/dex-js'
+import { TokenDetails } from '@gnosis.pm/dex-js'
 
 import { BlueBoldText, SpreadInformationWrapper } from './DefineSpread.styled'
 import DefineSpread from './DefineSpread'
 import { CreateStrategyWrapper } from './CreateStrategy.styled'
 import AddFunding from './AddFunding'
 import { Receipt } from 'types'
+import { formatPartialNumber } from 'utils'
+import { INPUT_PRECISION_SIZE } from 'const'
 
 export interface CreateStrategyProps {
   isSubmitting: boolean
@@ -32,12 +34,12 @@ const SpreadInformation: React.FC<SpreadInformationProps> = ({ selectedTokensMap
       <strong>Sell Spread</strong>
       <p>
         {tokenSymbolsString.join(', ')} for <b>at least</b> <br />
-        <i>${(1 + spread / 100).toFixed(DEFAULT_DECIMALS)}</i>
+        <i>${formatPartialNumber((1 + spread / 100).toFixed(INPUT_PRECISION_SIZE + 2))}</i>
       </p>
       <strong>Buy Spread</strong>
       <p>
         {tokenSymbolsString.join(', ')} for <b>at most</b> <br />
-        <i>${(1 - spread / 100).toFixed(DEFAULT_DECIMALS)}</i>
+        <i>${formatPartialNumber((1 - spread / 100).toFixed(INPUT_PRECISION_SIZE + 2))}</i>
       </p>
     </SpreadInformationWrapper>
   )

--- a/src/components/PoolingWidget/index.tsx
+++ b/src/components/PoolingWidget/index.tsx
@@ -25,7 +25,7 @@ import { tokenListApi } from 'api'
 import { Network, Receipt } from 'types'
 
 import { maxAmountsForSpread, stringOrNumberResolverFactory } from 'utils'
-import { DEFAULT_PRECISION, LIQUIDITY_TOKEN_LIST } from 'const'
+import { DEFAULT_PRECISION, LIQUIDITY_TOKEN_LIST, INPUT_PRECISION_SIZE } from 'const'
 
 export const FIRST_STEP = 1
 export const LAST_STEP = 2
@@ -91,7 +91,7 @@ const validationSchema = joi.object({
   spread: joi
     .number()
     .positive()
-    .precision(1)
+    .precision(INPUT_PRECISION_SIZE)
     .greater(0.0)
     .less(100.0)
     // dont autocast numbers

--- a/src/const.ts
+++ b/src/const.ts
@@ -102,3 +102,4 @@ export const GP_ORDER_TX_HASHES = {
 }
 
 export const LIQUIDITY_TOKEN_LIST = new Set(['USDT', 'TUSD', 'USDC', 'PAX', 'GUSD', 'DAI', 'sUSD'])
+export const INPUT_PRECISION_SIZE = 6


### PR DESCRIPTION
1. remove trailing zeros on SpreadInformation data
2. precision on liquidity spread input set to 6