### PR TITLE
696/trade page formatting

### DIFF
--- a/src/components/Layout/Card/Card.tsx
+++ b/src/components/Layout/Card/Card.tsx
@@ -128,8 +128,6 @@ export const CardTable = styled.table<{
     position: sticky;
     background: #ecf2f7;
     top: 0;
-    // TODO: why is this 5? see no problems in testing
-    // z-index: 5;
     font-size: 1.1rem;
     color: #2F3E4E;
     letter-spacing: 0;

--- a/src/components/Layout/Card/Card.tsx
+++ b/src/components/Layout/Card/Card.tsx
@@ -128,7 +128,8 @@ export const CardTable = styled.table<{
     position: sticky;
     background: #ecf2f7;
     top: 0;
-    z-index: 5;
+    // TODO: why is this 5? see no problems in testing
+    // z-index: 5;
     font-size: 1.1rem;
     color: #2F3E4E;
     letter-spacing: 0;

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -124,8 +124,8 @@ const InputBox = styled.div`
     }
 
     &[datatype='readOnlyInput'] {
-      background: #334e69;
-      color: white;
+      background-color: var(--color-background-pageWrapper);
+      border: 1px solid #e7ecf3;
     }
   }
 `

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -122,6 +122,11 @@ const InputBox = styled.div`
     &:disabled {
       box-shadow: none;
     }
+
+    &[datatype='readOnlyInput'] {
+      background: #334e69;
+      color: white;
+    }
   }
 `
 
@@ -172,6 +177,7 @@ interface Props {
   readOnly: boolean
   tooltipText: string
   autoFocus?: boolean
+  inputDataType?: string
 }
 
 const TokenRow: React.FC<Props> = ({
@@ -187,6 +193,7 @@ const TokenRow: React.FC<Props> = ({
   readOnly = false,
   tooltipText,
   autoFocus,
+  inputDataType = '',
 }) => {
   const isEditable = isDisabled || readOnly
   const { register, errors, setValue, watch } = useFormContext<TradeFormData>()
@@ -287,6 +294,7 @@ const TokenRow: React.FC<Props> = ({
       </div>
       <InputBox>
         <InputWithTooltip
+          datatype={inputDataType}
           autoFocus={!readOnly && autoFocus}
           className={inputClassName}
           tooltip={tooltipText}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -662,6 +662,7 @@ const TradeWidget: React.FC = () => {
             tabIndex={2}
             readOnly
             tooltipText={receiveTokenTooltipText}
+            inputDataType="readOnlyInput"
           />
           <Price
             priceInputId={priceInputId}

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -123,7 +123,6 @@ const GlobalStyles = createGlobalStyle`
     &::placeholder {
       color: inherit;
       font-size: inherit;
-      line-height: inherit;
     }
     
     &:focus::placeholder {


### PR DESCRIPTION
Closes #696 

1. Read only inputs now have a darker bg via datatype prop
2. fixes zindex overlap issue with table header in orders and tooltip (not sure why the theader was set to zindex 5 in the first place?? may have been an artifact from earlier card css before michel)
3. fixes placeholder issue

