### PR TITLE
Fix duplicate orders

### DIFF
--- a/src/components/PoolingWidget/index.tsx
+++ b/src/components/PoolingWidget/index.tsx
@@ -103,9 +103,11 @@ const validationSchema = joi.object({
 const numberResolver = stringOrNumberResolverFactory<PoolingFormData>(validationSchema, 'number')
 
 const PoolingInterface: React.FC = () => {
+  const { networkId, userAddress } = useWalletConnection()
   const [
     {
       orders: { orders },
+      pendingOrders,
     },
     dispatch,
   ] = useGlobalState()
@@ -117,9 +119,11 @@ const PoolingInterface: React.FC = () => {
   const [txReceipt, setTxReceipt] = useSafeState<Receipt | undefined>(undefined)
   const [txError, setTxError] = useSafeState(undefined)
 
-  const lastOrderIdRef = useLastOrderIdRef(orders)
+  const lastOrderIdRef = useLastOrderIdRef(
+    orders,
+    networkId && userAddress ? pendingOrders[networkId][userAddress] : [],
+  )
 
-  const { networkId, userAddress } = useWalletConnection()
   // Avoid displaying an empty list of tokens when the wallet is not connected
   const fallBackNetworkId = networkId ? networkId : Network.Mainnet // fallback to mainnet
 

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -321,11 +321,15 @@ const TradeWidget: React.FC = () => {
   const [
     {
       orders: { orders },
+      pendingOrders,
     },
     dispatch,
   ] = useGlobalState()
 
-  const lastOrderIdRef = useLastOrderIdRef(orders)
+  const lastOrderIdRef = useLastOrderIdRef(
+    orders,
+    networkId && userAddress ? pendingOrders[networkId][userAddress] : [],
+  )
 
   // Avoid displaying an empty list of tokens when the wallet is not connected
   const fallBackNetworkId = networkId ? networkId : Network.Mainnet // fallback to mainnet

--- a/src/hooks/useGlobalState.tsx
+++ b/src/hooks/useGlobalState.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useReducer, useRef, useEffect } from 'react'
 import { GlobalState } from 'reducers-actions'
 import { AnyAction } from 'combine-reducers'
-import { AuctionElement } from 'api/exchange/ExchangeApi'
+import { AuctionElement, PendingTxObj } from 'api/exchange/ExchangeApi'
 
 const GlobalStateContext = React.createContext({})
 
@@ -25,16 +25,17 @@ const useGlobalState = (): [GlobalState, Function] => useContext(GlobalStateCont
 
 export default useGlobalState
 
-export const useLastOrderIdRef = (orders: AuctionElement[]): React.MutableRefObject<number> => {
+export const useLastOrderIdRef = (
+  orders: AuctionElement[],
+  pendingOrders: PendingTxObj[],
+): React.MutableRefObject<number> => {
   const lastOrderId = useRef(0)
 
   useEffect(() => {
-    if (orders.length) {
-      lastOrderId.current = +orders[orders.length - 1].id
-    } else {
-      lastOrderId.current = 0
-    }
-  }, [orders])
+    const ordersMaxId = orders.length && +orders[orders.length - 1].id
+    const pendingOrdersMaxId = pendingOrders.length && +pendingOrders[pendingOrders.length - 1].id
+    lastOrderId.current = Math.max(ordersMaxId, pendingOrdersMaxId)
+  }, [orders, pendingOrders])
 
   return lastOrderId
 }

--- a/src/hooks/useGlobalState.tsx
+++ b/src/hooks/useGlobalState.tsx
@@ -1,6 +1,7 @@
-import React, { useContext, useReducer } from 'react'
+import React, { useContext, useReducer, useRef, useEffect } from 'react'
 import { GlobalState } from 'reducers-actions'
 import { AnyAction } from 'combine-reducers'
+import { AuctionElement } from 'api/exchange/ExchangeApi'
 
 const GlobalStateContext = React.createContext({})
 
@@ -23,3 +24,17 @@ export function withGlobalContext<P>(
 const useGlobalState = (): [GlobalState, Function] => useContext(GlobalStateContext) as [GlobalState, Function]
 
 export default useGlobalState
+
+export const useLastOrderIdRef = (orders: AuctionElement[]): React.MutableRefObject<number> => {
+  const lastOrderId = useRef(0)
+
+  useEffect(() => {
+    if (orders.length) {
+      lastOrderId.current = +orders[orders.length - 1].id
+    } else {
+      lastOrderId.current = 0
+    }
+  }, [orders])
+
+  return lastOrderId
+}


### PR DESCRIPTION
So I thought about filtering `pendingOrders` against `orders`
But as @alfetopito  mentioned in #718 issue we can't really
Bu then again we can pretty much guess what id will be when assigning pendingOrders as ids are incremental.
And there you have it

Anticipating questions:
Q: Why not use `offset` for `lastId`?
A: While it almost always matches, there are cases when we reset offset to refetch every order (on order cancellation/deletion), so it's less reliable.

Q: But why not ...
A: No,no trust me on this.

Also, I can't really reproduce duplicate orders, for me it's always mined first, new block with orders later. So would be cool if someone who can reproduce tested this PR.

Closes #718