### PR TITLE
Tokens search+hide

### DIFF
--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -18,6 +18,7 @@ import useWindowSizes from 'hooks/useWindowSizes'
 import { logDebug, getToken } from 'utils'
 import { ZERO, MEDIA } from 'const'
 import { TokenBalanceDetails } from 'types'
+import { useDebounce } from 'hooks/useDebounce'
 
 interface WithdrawState {
   amount: BN
@@ -313,10 +314,12 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
 
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>): void => setSearch(e.target.value)
 
-  const filteredBalances = useMemo(() => {
-    if (!search || !balances || balances.length === 0) return balances
+  const debouncedSearch = useDebounce(search, 500)
 
-    const searchTxt = search.toLowerCase()
+  const filteredBalances = useMemo(() => {
+    if (!debouncedSearch || !balances || balances.length === 0) return balances
+
+    const searchTxt = debouncedSearch.toLowerCase()
 
     return balances.filter(({ symbol, name, address }) => {
       return (
@@ -325,7 +328,7 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
         address.toLowerCase().includes(searchTxt)
       )
     })
-  }, [search, balances])
+  }, [debouncedSearch, balances])
 
   return (
     <BalancesWidget>

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import Modali from 'modali'
 import BN from 'bn.js'
 
@@ -240,7 +240,7 @@ const BalanceTools = styled.div`
 
     > input {
       margin: 0;
-      width: 28rem;
+      width: 35rem;
       max-width: 100%;
       background: #e7ecf3 url(${searchIcon}) no-repeat left 1.6rem center/1.6rem;
       border-radius: 0.6rem 0.6rem 0 0;
@@ -309,11 +309,34 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
 }) => {
   const windowSpecs = useWindowSizes()
 
+  const [search, setSearch] = useState('')
+
+  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>): void => setSearch(e.target.value)
+
+  const filteredBalances = useMemo(() => {
+    if (!search || !balances || balances.length === 0) return balances
+
+    const searchTxt = search.toLowerCase()
+
+    return balances.filter(({ symbol, name, address }) => {
+      return (
+        symbol?.toLowerCase().includes(searchTxt) ||
+        name?.toLowerCase().includes(searchTxt) ||
+        address.toLowerCase().includes(searchTxt)
+      )
+    })
+  }, [search, balances])
+
   return (
     <BalancesWidget>
       <BalanceTools>
-        <label className="balances-searchTokens not-implemented">
-          <input placeholder="Search token by Name, Symbol" type="text" required />
+        <label className="balances-searchTokens">
+          <input
+            placeholder="Search token by Name, Symbol or Address"
+            type="text"
+            value={search}
+            onChange={handleSearch}
+          />
         </label>
         <label className="balances-hideZero not-implemented">
           <input type="checkbox" />
@@ -337,8 +360,8 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
             </tr>
           </thead>
           <tbody>
-            {balances &&
-              balances.map(tokenBalances => (
+            {filteredBalances &&
+              filteredBalances.map(tokenBalances => (
                 <Row
                   key={tokenBalances.addressMainnet}
                   tokenBalances={tokenBalances}

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -286,6 +286,29 @@ const BalanceTools = styled.div`
   }
 `
 
+const NoTokensMessage = styled.tr`
+  /* increase speicifcity */
+  &&&&&& {
+    margin: auto;
+    border: none;
+
+    :hover {
+      background: initial;
+    }
+
+    a {
+      color: #218dff;
+    }
+
+    > td {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-evenly;
+      min-height: 3.5em;
+    }
+  }
+`
+
 type BalanceDisplayProps = Omit<ReturnType<typeof useRowActions>, 'requestWithdrawToken'> &
   ReturnType<typeof useTokenBalances> & {
     requestWithdrawConfirmation(
@@ -316,6 +339,11 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>): void => setSearch(e.target.value)
 
   const handleHideZeroBalances = (e: React.ChangeEvent<HTMLInputElement>): void => setHideZeroBalances(e.target.checked)
+
+  const clearFilters = (): void => {
+    setSearch('')
+    setHideZeroBalances(false)
+  }
 
   const debouncedSearch = useDebounce(search, 500)
 
@@ -374,32 +402,39 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
             </tr>
           </thead>
           <tbody>
-            {displayedBalances &&
-              displayedBalances.map(tokenBalances => (
-                <Row
-                  key={tokenBalances.addressMainnet}
-                  tokenBalances={tokenBalances}
-                  onEnableToken={(): Promise<void> => enableToken(tokenBalances.address)}
-                  onSubmitDeposit={(balance, onTxHash): Promise<void> =>
-                    depositToken(balance, tokenBalances.address, onTxHash)
-                  }
-                  onSubmitWithdraw={(balance, onTxHash): Promise<void> => {
-                    return requestWithdrawConfirmation(
-                      balance,
-                      tokenBalances.address,
-                      tokenBalances.claimable,
-                      onTxHash,
-                    )
-                  }}
-                  onClaim={(): Promise<void> => claimToken(tokenBalances.address)}
-                  claiming={claiming.has(tokenBalances.address)}
-                  withdrawing={withdrawing.has(tokenBalances.address)}
-                  depositing={depositing.has(tokenBalances.address)}
-                  highlighted={highlighted.has(tokenBalances.address)}
-                  enabling={enabling.has(tokenBalances.address)}
-                  {...windowSpecs}
-                />
-              ))}
+            {displayedBalances && displayedBalances.length > 0
+              ? displayedBalances.map(tokenBalances => (
+                  <Row
+                    key={tokenBalances.addressMainnet}
+                    tokenBalances={tokenBalances}
+                    onEnableToken={(): Promise<void> => enableToken(tokenBalances.address)}
+                    onSubmitDeposit={(balance, onTxHash): Promise<void> =>
+                      depositToken(balance, tokenBalances.address, onTxHash)
+                    }
+                    onSubmitWithdraw={(balance, onTxHash): Promise<void> => {
+                      return requestWithdrawConfirmation(
+                        balance,
+                        tokenBalances.address,
+                        tokenBalances.claimable,
+                        onTxHash,
+                      )
+                    }}
+                    onClaim={(): Promise<void> => claimToken(tokenBalances.address)}
+                    claiming={claiming.has(tokenBalances.address)}
+                    withdrawing={withdrawing.has(tokenBalances.address)}
+                    depositing={depositing.has(tokenBalances.address)}
+                    highlighted={highlighted.has(tokenBalances.address)}
+                    enabling={enabling.has(tokenBalances.address)}
+                    {...windowSpecs}
+                  />
+                ))
+              : (search || hideZeroBalances) && (
+                  <NoTokensMessage>
+                    <td>
+                      No tokens match provided filters <a onClick={clearFilters}>clear filters</a>
+                    </td>
+                  </NoTokensMessage>
+                )}
           </tbody>
         </CardTable>
       )}

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -216,7 +216,7 @@ const BalanceTools = styled.div`
     cursor: pointer;
 
     @media ${MEDIA.mobile} {
-      margin: 0 1.6rem 0 0;
+      margin: 0 1.6rem 0 0.8rem;
     }
 
     > b {
@@ -311,8 +311,11 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
   const windowSpecs = useWindowSizes()
 
   const [search, setSearch] = useState('')
+  const [hideZeroBalances, setHideZeroBalances] = useState(false)
 
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>): void => setSearch(e.target.value)
+
+  const handleHideZeroBalances = (e: React.ChangeEvent<HTMLInputElement>): void => setHideZeroBalances(e.target.checked)
 
   const debouncedSearch = useDebounce(search, 500)
 
@@ -330,6 +333,14 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
     })
   }, [debouncedSearch, balances])
 
+  const displayedBalances = useMemo(() => {
+    if (!hideZeroBalances || !filteredBalances || filteredBalances.length === 0) return filteredBalances
+
+    return filteredBalances.filter(({ exchangeBalance, pendingWithdraw, walletBalance }) => {
+      return !exchangeBalance.isZero() || !pendingWithdraw.amount.isZero() || !walletBalance.isZero()
+    })
+  }, [hideZeroBalances, filteredBalances])
+
   return (
     <BalancesWidget>
       <BalanceTools>
@@ -341,8 +352,8 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
             onChange={handleSearch}
           />
         </label>
-        <label className="balances-hideZero not-implemented">
-          <input type="checkbox" />
+        <label className="balances-hideZero">
+          <input type="checkbox" checked={hideZeroBalances} onChange={handleHideZeroBalances} />
           <b>Hide zero balances</b>
         </label>
         <button type="button" className="balances-manageTokens not-implemented">
@@ -363,8 +374,8 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
             </tr>
           </thead>
           <tbody>
-            {filteredBalances &&
-              filteredBalances.map(tokenBalances => (
+            {displayedBalances &&
+              displayedBalances.map(tokenBalances => (
                 <Row
                   key={tokenBalances.addressMainnet}
                   tokenBalances={tokenBalances}

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -336,8 +336,8 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
   const displayedBalances = useMemo(() => {
     if (!hideZeroBalances || !filteredBalances || filteredBalances.length === 0) return filteredBalances
 
-    return filteredBalances.filter(({ exchangeBalance, pendingWithdraw, walletBalance }) => {
-      return !exchangeBalance.isZero() || !pendingWithdraw.amount.isZero() || !walletBalance.isZero()
+    return filteredBalances.filter(({ totalExchangeBalance, pendingWithdraw, walletBalance }) => {
+      return !totalExchangeBalance.isZero() || !pendingWithdraw.amount.isZero() || !walletBalance.isZero()
     })
   }, [hideZeroBalances, filteredBalances])
 

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -340,12 +340,13 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
 
   const handleHideZeroBalances = (e: React.ChangeEvent<HTMLInputElement>): void => setHideZeroBalances(e.target.checked)
 
+  const { value: debouncedSearch, setImmediate: setDebouncedSearch } = useDebounce(search, 500)
+
   const clearFilters = (): void => {
     setSearch('')
+    setDebouncedSearch('')
     setHideZeroBalances(false)
   }
-
-  const debouncedSearch = useDebounce(search, 500)
 
   const filteredBalances = useMemo(() => {
     if (!debouncedSearch || !balances || balances.length === 0) return balances

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -216,7 +216,7 @@ const BalanceTools = styled.div`
     cursor: pointer;
 
     @media ${MEDIA.mobile} {
-      margin: 0 1.6rem 0 0.8rem;
+      margin: 0 1.6rem 1.6rem;
     }
 
     > b {

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -305,6 +305,7 @@ const NoTokensMessage = styled.tr`
       flex-direction: column;
       justify-content: space-evenly;
       min-height: 3.5em;
+      line-height: 1.5;
     }
   }
 `

--- a/src/components/Layout/Card/Card.tsx
+++ b/src/components/Layout/Card/Card.tsx
@@ -116,6 +116,7 @@ export const CardTable = styled.table<{
   $webCSS?: string
 }>`
   display: grid;
+  flex: 1;
   // grid-gap: ${({ $headerGap = '0.3rem' }): string => $headerGap};
   width: 100%;
 
@@ -207,6 +208,9 @@ export const CardTable = styled.table<{
 
   // Table Body
   tbody {
+    flex: 1;
+    display: flex;
+    flex-flow: nowrap column;
     font-size: 1.1rem;
     font-family: var(--font-mono);
     font-weight: var(--font-weight-regular);

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,6 +1,12 @@
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
-export const useDebounce = <T>(value: T, delay: number): T => {
+export const useDebounce = <T>(
+  value: T,
+  delay: number,
+): {
+  value: T
+  setImmediate: React.Dispatch<React.SetStateAction<T>>
+} => {
   const [debouncedValue, setDebouncedValue] = useState(value)
 
   useEffect(() => {
@@ -15,5 +21,5 @@ export const useDebounce = <T>(value: T, delay: number): T => {
     }
   }, [value, delay])
 
-  return debouncedValue
+  return { value: debouncedValue, setImmediate: setDebouncedValue }
 }

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+export const useDebounce = <T>(value: T, delay: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(() => {
+    // Update debounced value after delay
+    const handler = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    // Cancel the timeout if value changes (also on delay change or unmount)
+    return (): void => {
+      clearTimeout(handler)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}


### PR DESCRIPTION
Adds logic for filtering tokens and hiding tokens that have 0 in all balance columns
in /wallet page

Closes #612, closes #613
<sup>have to write twice for github to auto-close both</sub>

This is a unique PR in that it closes two issues at once, first of its kind.