### PR TITLE
tabIndex order in /trade

### DIFF
--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -242,7 +242,7 @@ const OrdersWidget: React.FC = () => {
             </div>
             <div className="deleteContainer" data-disabled={markedForDeletion.size === 0 || deleting}>
               <b>↴</b>
-              <ButtonWithIcon disabled={markedForDeletion.size === 0 || deleting}>
+              <ButtonWithIcon disabled={markedForDeletion.size === 0 || deleting} type="submit">
                 <FontAwesomeIcon icon={faTrashAlt} />{' '}
                 {['active', 'liquidity'].includes(selectedTab) ? 'Cancel' : 'Delete'} {markedForDeletion.size} orders
               </ButtonWithIcon>

--- a/src/components/TradeWidget/OrderValidity.tsx
+++ b/src/components/TradeWidget/OrderValidity.tsx
@@ -313,7 +313,7 @@ const OrderValidity: React.FC<Props> = ({
 
   return (
     <Wrapper>
-      <button type="button" onClick={handleShowConfig}>
+      <button type="button" onClick={handleShowConfig} tabIndex={tabIndex}>
         Order starts: <b>{formatTimeInHours(validFrom, 'ASAP')}</b> - expires:{' '}
         <b>{formatTimeInHours(validUntil, 'Never')}</b>
       </button>
@@ -341,10 +341,16 @@ const OrderValidity: React.FC<Props> = ({
               })}
               onChange={handleValidFromChange}
               onFocus={(e): void => e.target.select()}
-              tabIndex={tabIndex + 2}
+              tabIndex={tabIndex}
             />
             <div className="radio-container">
-              <input type="checkbox" checked={isAsap} disabled={isDisabled} onChange={handleASAPClick} />
+              <input
+                type="checkbox"
+                checked={isAsap}
+                disabled={isDisabled}
+                onChange={handleASAPClick}
+                tabIndex={tabIndex}
+              />
               <small>ASAP</small>
             </div>
           </label>
@@ -365,16 +371,22 @@ const OrderValidity: React.FC<Props> = ({
               })}
               onChange={handleValidUntilChange}
               onFocus={(e): void => e.target.select()}
-              tabIndex={tabIndex + 3}
+              tabIndex={tabIndex}
             />
             <div className="radio-container">
-              <input type="checkbox" disabled={isDisabled} checked={isUnlimited} onChange={handleUnlimitedClick} />
+              <input
+                type="checkbox"
+                disabled={isDisabled}
+                checked={isUnlimited}
+                onChange={handleUnlimitedClick}
+                tabIndex={tabIndex}
+              />
               <small>Never</small>
             </div>
           </label>
         </OrderValidityBox>
         <span>
-          <button type="button" onClick={handleShowConfig}>
+          <button type="button" onClick={handleShowConfig} tabIndex={tabIndex}>
             Set order parameters
           </button>
         </span>

--- a/src/components/TradeWidget/Price.tsx
+++ b/src/components/TradeWidget/Price.tsx
@@ -128,6 +128,7 @@ interface Props {
   receiveToken: TokenDetails
   priceInputId: string
   priceInverseInputId: string
+  tabIndex?: number
 }
 
 export function invertPriceFromString(priceValue: string): string {
@@ -135,7 +136,7 @@ export function invertPriceFromString(priceValue: string): string {
   return price ? invertPrice(price).toString(10) : ''
 }
 
-const Price: React.FC<Props> = ({ sellToken, receiveToken, priceInputId, priceInverseInputId }) => {
+const Price: React.FC<Props> = ({ sellToken, receiveToken, priceInputId, priceInverseInputId, tabIndex }) => {
   const { register, errors, setValue } = useFormContext<TradeFormData>()
 
   const errorPrice = errors[priceInputId]
@@ -203,7 +204,8 @@ const Price: React.FC<Props> = ({ sellToken, receiveToken, priceInputId, priceIn
             onKeyPress={onKeyPressPrice}
             onBlur={removeExcessZerosPrice}
             onFocus={(e): void => e.target.select()}
-          ></input>
+            tabIndex={tabIndex}
+          />
           <small>
             {sellToken.symbol}/{receiveToken.symbol}
           </small>
@@ -225,7 +227,8 @@ const Price: React.FC<Props> = ({ sellToken, receiveToken, priceInputId, priceIn
             onKeyPress={onKeyPressPriceInverse}
             onBlur={removeExcessZerosPriceInverse}
             onFocus={(e): void => e.target.select()}
-          ></input>
+            tabIndex={tabIndex}
+          />
           <small>
             {receiveToken.symbol}/{sellToken.symbol}
           </small>

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -314,7 +314,7 @@ const TokenRow: React.FC<Props> = ({
           onKeyPress={onKeyPress}
           onChange={enforcePrecision}
           onBlur={removeExcessZeros}
-          tabIndex={tabIndex + 2}
+          tabIndex={tabIndex}
           onFocus={(e): void => e.target.select()}
         />
 

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -77,6 +77,12 @@ const WrappedForm = styled.form`
   transition: width 0.2s ease-in-out, opacity 0.2s ease-in-out;
   opacity: 1;
 
+  .react-select__control:focus-within,
+  input[type='checkbox']:focus,
+  button:focus {
+    outline: 1px dotted gray;
+  }
+
   .expanded & {
     width: 0;
     overflow: hidden;

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -653,7 +653,7 @@ const TradeWidget: React.FC = () => {
             onSelectChange={onSelectChangeFactory(setReceiveToken, sellTokenBalance)}
             inputId={receiveInputId}
             isDisabled={isSubmitting}
-            tabIndex={2}
+            tabIndex={1}
             readOnly
             tooltipText={receiveTokenTooltipText}
           />
@@ -662,6 +662,7 @@ const TradeWidget: React.FC = () => {
             priceInverseInputId={priceInverseInputId}
             sellToken={sellToken}
             receiveToken={receiveToken}
+            tabIndex={1}
           />
           <OrderValidity
             validFromInputId={validFromId}
@@ -671,14 +672,14 @@ const TradeWidget: React.FC = () => {
             isUnlimited={unlimited}
             setAsap={setAsap}
             setUnlimited={setUnlimited}
-            tabIndex={3}
+            tabIndex={1}
           />
           <p>This order might be partially filled.</p>
           <SubmitButton
             data-text="This order might be partially filled."
             type="submit"
             disabled={isSubmitting}
-            tabIndex={5}
+            tabIndex={1}
           >
             {isSubmitting && <FontAwesomeIcon icon={faSpinner} size="lg" spin={isSubmitting} />}{' '}
             {sameToken ? 'Please select different tokens' : 'Submit limit order'}


### PR DESCRIPTION
Gives all inputs in TradeWidget natural same tabIndex (when tabIndex the same, tabs go in DOM order)
I't not very apparent when some buttons are active, maybe we should style `:focus|:focus-within` for them

![ezgif-7-7f777c842d6e](https://user-images.githubusercontent.com/5121491/76970785-6cf2e280-693d-11ea-9bbc-928e01c5af29.gif)

Orders validUntil modal was opened with Space in preview, so as not to break the index order

Closes #603