### PR TITLE
TheGraphApi and getPriceEstimation service

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -111,7 +111,7 @@ function createTokenListApi(): TokenList {
 
 function createTheGraphApi(): TheGraphApi {
   const urls = {
-    [Network.Mainnet]: 'https://api.thegraph.com/subgraphs/name/gnosis/dfusion',
+    [Network.Mainnet]: 'https://api.thegraph.com/subgraphs/name/gnosis/dfusion-staging',
     [Network.Rinkeby]: 'https://api.thegraph.com/subgraphs/name/gnosis/dfusion-rinkeby',
   }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -25,7 +25,8 @@ import {
 import Web3 from 'web3'
 import { INITIAL_INFURA_ENDPOINT } from 'const'
 import fetchGasPriceFactory from './gasStation'
-import { TheGraphApi, TheGraphApiImpl } from './thegraph/TheGraphApi'
+import { TheGraphApi } from './thegraph/TheGraphApi'
+import { TheGraphApiProxy } from './thegraph/TheGraphApiProxy'
 
 // TODO connect to mainnet if we need AUTOCONNECT at all
 export const getDefaultProvider = (): string | null =>
@@ -115,7 +116,7 @@ function createTheGraphApi(): TheGraphApi {
     [Network.Rinkeby]: 'https://api.thegraph.com/subgraphs/name/gnosis/dfusion-rinkeby',
   }
 
-  const theGraphApi = new TheGraphApiImpl({ urls })
+  const theGraphApi = new TheGraphApiProxy({ urls })
 
   window['theGraphApi'] = theGraphApi
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -25,6 +25,7 @@ import {
 import Web3 from 'web3'
 import { INITIAL_INFURA_ENDPOINT } from 'const'
 import fetchGasPriceFactory from './gasStation'
+import { TheGraphApi, TheGraphApiImpl } from './thegraph/TheGraphApi'
 
 // TODO connect to mainnet if we need AUTOCONNECT at all
 export const getDefaultProvider = (): string | null =>
@@ -108,6 +109,19 @@ function createTokenListApi(): TokenList {
   return tokenListApi
 }
 
+function createTheGraphApi(): TheGraphApi {
+  const urls = {
+    [Network.Mainnet]: 'https://thegraph.com/explorer/subgraph/gnosis/dfusion',
+    [Network.Rinkeby]: 'https://thegraph.com/explorer/subgraph/gnosis/dfusion-rinkeby',
+  }
+
+  const theGraphApi = new TheGraphApiImpl({ urls })
+
+  window['theGraphApi'] = theGraphApi
+
+  return theGraphApi
+}
+
 // Build APIs
 export const web3: Web3 = createWeb3Api()
 export const walletApi: WalletApi = createWalletApi(web3)
@@ -121,3 +135,4 @@ export const erc20Api: Erc20Api = createErc20Api(injectedDependencies)
 export const depositApi: DepositApi = createDepositApi(erc20Api, injectedDependencies)
 export const exchangeApi: ExchangeApi = createExchangeApi(erc20Api, injectedDependencies)
 export const tokenListApi: TokenList = createTokenListApi()
+export const theGraphApi: TheGraphApi = createTheGraphApi()

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -111,8 +111,8 @@ function createTokenListApi(): TokenList {
 
 function createTheGraphApi(): TheGraphApi {
   const urls = {
-    [Network.Mainnet]: 'https://thegraph.com/explorer/subgraph/gnosis/dfusion',
-    [Network.Rinkeby]: 'https://thegraph.com/explorer/subgraph/gnosis/dfusion-rinkeby',
+    [Network.Mainnet]: 'https://api.thegraph.com/subgraphs/name/gnosis/dfusion',
+    [Network.Rinkeby]: 'https://api.thegraph.com/subgraphs/name/gnosis/dfusion-rinkeby',
   }
 
   const theGraphApi = new TheGraphApiImpl({ urls })

--- a/src/api/thegraph/TheGraphApi.ts
+++ b/src/api/thegraph/TheGraphApi.ts
@@ -59,6 +59,8 @@ export class TheGraphApiImpl {
 
     const response = await fetch(url, {
       method: 'POST',
+      mode: 'cors',
+      credentials: 'omit',
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/api/thegraph/TheGraphApi.ts
+++ b/src/api/thegraph/TheGraphApi.ts
@@ -55,10 +55,14 @@ type GqlResult = PricesResponse | GqlError
 
 const isGqlError = (gqlResult: GqlResult): gqlResult is GqlError => 'errors' in gqlResult
 
+export interface Params {
+  urls: UrlByNetwork
+}
+
 export class TheGraphApiImpl {
   private urlByNetwork: UrlByNetwork
 
-  public constructor(params: { urls: UrlByNetwork }) {
+  public constructor(params: Params) {
     this.urlByNetwork = params.urls
   }
 

--- a/src/api/thegraph/TheGraphApi.ts
+++ b/src/api/thegraph/TheGraphApi.ts
@@ -21,6 +21,26 @@ interface UrlByNetwork {
   [network: number]: string
 }
 
+interface PricesData {
+  data: {
+    prices: {
+      batchId: string
+      priceInOwl: string
+    }[]
+  }
+}
+
+interface GqlError {
+  errors: {
+    locations: {
+      line: number
+      column: number
+    }[]
+    message: string
+  }[]
+}
+
+type GqlResult = PricesData | GqlError
 export class TheGraphApiImpl {
   private urlByNetwork: UrlByNetwork
 
@@ -39,7 +59,8 @@ export class TheGraphApiImpl {
             batchId
             priceInOwl
         }}`
-    const price = await this.query<string>({ networkId, queryString })
+
+    const gqlResult = await this.query<GqlResult>({ networkId, queryString })
     return new BigNumber(price)
   }
 

--- a/src/api/thegraph/TheGraphApi.ts
+++ b/src/api/thegraph/TheGraphApi.ts
@@ -1,0 +1,74 @@
+import BigNumber from 'bignumber.js'
+import BN from 'bn.js'
+import { assert, ZERO } from '@gnosis.pm/dex-js'
+
+export interface TheGraphApi {
+  getPrice(params: GetPriceParams): Promise<BigNumber>
+  getPriceInWei(params: GetPriceParams): Promise<BN>
+}
+
+export interface GetPriceParams {
+  networkId: number
+  tokenId: number
+}
+
+export interface QueryParams {
+  networkId: number
+  queryString: string
+}
+
+interface UrlByNetwork {
+  [network: number]: string
+}
+
+export class TheGraphApiImpl {
+  private urlByNetwork: UrlByNetwork
+
+  public constructor(params: { urls: UrlByNetwork }) {
+    this.urlByNetwork = params.urls
+  }
+
+  public async getPrice({ networkId, tokenId }: GetPriceParams): Promise<BigNumber> {
+    const queryString = `{ 
+        prices(
+          first: 1, 
+          orderBy: batchId
+          orderDirection: desc
+          where: { token: "${tokenId}" }
+        ) {
+            batchId
+            priceInOwl
+        }}`
+    const price = await this.query<string>({ networkId, queryString })
+    return new BigNumber(price)
+  }
+
+  public async getPriceInWei({}: GetPriceParams): Promise<BN> {
+    // TODO: implement this, maybe?
+    return ZERO
+  }
+
+  private async query<T>({ networkId, queryString }: QueryParams): Promise<T> {
+    const url = this.urlByNetwork[networkId]
+    assert(url, `No graph configured for network id ${networkId}`)
+
+    const data = {
+      query: queryString,
+      variables: null,
+    }
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Request failed: [${response.status}] ${response.body}`)
+    }
+
+    return response.json()
+  }
+}

--- a/src/api/thegraph/TheGraphApi.ts
+++ b/src/api/thegraph/TheGraphApi.ts
@@ -1,10 +1,10 @@
 import { assert, DEFAULT_PRECISION } from '@gnosis.pm/dex-js'
 import BigNumber from 'bignumber.js'
 
-import { ZERO_BIG_NUMBER, TEN_BIG_NUMBER } from 'const'
+import { TEN_BIG_NUMBER } from 'const'
 
 export interface TheGraphApi {
-  getPrice(params: GetPriceParams): Promise<BigNumber>
+  getPrice(params: GetPriceParams): Promise<BigNumber | null>
   getPrices(params: GetPricesParams): Promise<GetPricesResult>
 }
 
@@ -21,7 +21,7 @@ export interface GetPricesParams {
 }
 
 interface GetPricesResult {
-  [tokenId: number]: BigNumber
+  [tokenId: number]: BigNumber | null
 }
 
 interface UrlByNetwork {
@@ -66,7 +66,7 @@ export class TheGraphApiImpl {
     this.urlByNetwork = params.urls
   }
 
-  public async getPrice({ tokenId, ...params }: GetPriceParams): Promise<BigNumber> {
+  public async getPrice({ tokenId, ...params }: GetPriceParams): Promise<BigNumber | null> {
     // syntactic sugar
     const prices = this.getPrices({ ...params, tokenIds: [tokenId] })
     return prices[tokenId]
@@ -140,8 +140,8 @@ export class TheGraphApiImpl {
       // not possible to have a key with only integers, thus `Token` prefix was added
       const tokenId = +tokenKey.replace('Token', '')
 
-      // When there's no data for a token, return 0
-      acc[tokenId] = data[tokenKey].length > 0 ? this.calculatePrice(data[tokenKey][0], inWei) : ZERO_BIG_NUMBER
+      // When there's no data for a token, return is null
+      acc[tokenId] = data[tokenKey].length > 0 ? this.calculatePrice(data[tokenKey][0], inWei) : null
       return acc
     }, {})
   }

--- a/src/api/thegraph/TheGraphApi.ts
+++ b/src/api/thegraph/TheGraphApi.ts
@@ -41,6 +41,9 @@ interface GqlError {
 }
 
 type GqlResult = PricesData | GqlError
+
+const isGqlError = (gqlResult: GqlResult): gqlResult is GqlError => 'errors' in gqlResult
+
 export class TheGraphApiImpl {
   private urlByNetwork: UrlByNetwork
 
@@ -61,6 +64,12 @@ export class TheGraphApiImpl {
         }}`
 
     const gqlResult = await this.query<GqlResult>({ networkId, queryString })
+
+    if (isGqlError(gqlResult)) {
+      throw new Error(gqlResult.errors[0].message)
+    }
+
+    const price = gqlResult.data.prices[0].priceInOwl
     return new BigNumber(price)
   }
 

--- a/src/api/thegraph/TheGraphApi.ts
+++ b/src/api/thegraph/TheGraphApi.ts
@@ -138,7 +138,7 @@ export class TheGraphApiImpl {
   private parsePricesResponse({ data }: PricesResponse, inWei: boolean): GetPricesResult {
     return Object.keys(data).reduce((acc, tokenKey) => {
       // not possible to have a key with only integers, thus `Token` prefix was added
-      const tokenId = +tokenKey.replace(/Token/, '')
+      const tokenId = +tokenKey.replace('Token', '')
 
       // When there's no data for a token, return 0
       acc[tokenId] = data[tokenKey].length > 0 ? this.calculatePrice(data[tokenKey][0], inWei) : ZERO_BIG_NUMBER

--- a/src/api/thegraph/TheGraphApiProxy.ts
+++ b/src/api/thegraph/TheGraphApiProxy.ts
@@ -1,0 +1,20 @@
+import { TheGraphApiImpl, Params, TheGraphApi } from './TheGraphApi'
+import { CacheMixin } from 'api/proxy'
+
+// The prices on the contract will update at max once every batch, which is 5min long
+const PRICES_CACHE_TIME = 60 // in seconds
+
+export class TheGraphApiProxy extends TheGraphApiImpl {
+  private cache: CacheMixin
+
+  public constructor(params: Params) {
+    super(params)
+
+    this.cache = new CacheMixin()
+
+    this.cache.injectCache<TheGraphApi>(this, [
+      { method: 'getPrice', ttl: PRICES_CACHE_TIME },
+      { method: 'getPrices', ttl: PRICES_CACHE_TIME },
+    ])
+  }
+}

--- a/src/const.ts
+++ b/src/const.ts
@@ -12,6 +12,9 @@ export {
 } from '@gnosis.pm/dex-js'
 export { ZERO, ONE, TWO, TEN, ALLOWANCE_MAX_VALUE, ALLOWANCE_FOR_ENABLED_TOKEN } from '@gnosis.pm/dex-js'
 
+export const ZERO_BIG_NUMBER = new BigNumber(0)
+export const TEN_BIG_NUMBER = new BigNumber(10)
+
 // How much of the order needs to be matched to consider it filled
 // Will divide the total sell amount by this factor.
 // E.g.: Sell = 500; ORDER_FILLED_FACTOR = 100 (1%) => 500/100 => 5

--- a/src/services/factories/getPriceEstimation.ts
+++ b/src/services/factories/getPriceEstimation.ts
@@ -1,0 +1,59 @@
+import BigNumber from 'bignumber.js'
+import { assert } from '@gnosis.pm/dex-js'
+
+import { ZERO_BIG_NUMBER } from 'const'
+
+import { TheGraphApi } from 'api/thegraph/TheGraphApi'
+import { TokenList } from 'api/tokenList/TokenListApi'
+
+export interface GetPriceParams {
+  networkId: number
+  numeratorTokenId: number
+  denominatorTokenId: number
+}
+
+export function getPriceEstimationFactory(factoryParams: {
+  theGraphApi: TheGraphApi
+  tokenListApi: TokenList
+}): (params: GetPriceParams) => Promise<BigNumber> {
+  const { theGraphApi, tokenListApi } = factoryParams
+
+  return async (params: GetPriceParams): Promise<BigNumber> => {
+    const { networkId, numeratorTokenId, denominatorTokenId } = params
+
+    assert(numeratorTokenId !== denominatorTokenId, 'Token ids cannot be the equal')
+
+    // ---
+    // For an 'optimization' of sorts, we always query all known tokens plus the requested token ids.
+    // Assuming the caching is on for the TheGraphApi layer (it was last time I checked) and we don't
+    // expect to have tokens ids not often outside of our list.
+    // Thus, we can actually make a request once, and reuse the response for all token pairs falling into the same list
+
+    // all known token ids
+    const tokenIdsSet = new Set(tokenListApi.getTokens(networkId).map(token => token.id))
+    // just in case the tokens are not in our initial list:
+    tokenIdsSet.add(numeratorTokenId)
+    tokenIdsSet.add(denominatorTokenId)
+    // make it nice and sorted to help with caching
+    const tokenIds = [...tokenIdsSet].sort()
+
+    // end of the 'optimization' part
+    // ---
+
+    const prices = await theGraphApi.getPrices({ networkId, tokenIds })
+
+    if (denominatorTokenId === 0) {
+      // Optimization more for a matter of principle than performance:
+      // OWL token is always tokenId == 0 on the contract
+      // All prices are given in terms of OWL
+      // OWL price is always 1
+      // Anything divided by 1...
+      return prices[numeratorTokenId]
+    } else if (prices[numeratorTokenId].isZero() || prices[denominatorTokenId].isZero()) {
+      // there was never a trade for one of these tokens
+      return ZERO_BIG_NUMBER
+    }
+
+    return prices[numeratorTokenId].dividedBy(prices[denominatorTokenId])
+  }
+}

--- a/src/services/factories/getPriceEstimation.ts
+++ b/src/services/factories/getPriceEstimation.ts
@@ -1,8 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { assert, ONE_BIG_NUMBER } from '@gnosis.pm/dex-js'
 
-import { ZERO_BIG_NUMBER } from 'const'
-
 import { TheGraphApi } from 'api/thegraph/TheGraphApi'
 import { TokenList } from 'api/tokenList/TokenListApi'
 import { Network } from 'types'
@@ -15,7 +13,7 @@ export interface GetPriceParams {
 export function getPriceEstimationFactory(factoryParams: {
   theGraphApi: TheGraphApi
   tokenListApi: TokenList
-}): (params: GetPriceParams) => Promise<BigNumber> {
+}): (params: GetPriceParams) => Promise<BigNumber | null> {
   const { theGraphApi, tokenListApi } = factoryParams
 
   // Only make sense to fetch prices for mainnet, thus we won't accept networkId parameter on this service
@@ -40,7 +38,7 @@ export function getPriceEstimationFactory(factoryParams: {
     return false
   }
 
-  return async (params: GetPriceParams): Promise<BigNumber> => {
+  return async (params: GetPriceParams): Promise<BigNumber | null> => {
     const { baseTokenId, quoteTokenId } = params
 
     assert(baseTokenId !== quoteTokenId, 'Token ids cannot be the equal')
@@ -60,9 +58,9 @@ export function getPriceEstimationFactory(factoryParams: {
     const basePrice = baseTokenId === 0 ? ONE_BIG_NUMBER : prices[baseTokenId]
     const quotePrice = quoteTokenId === 0 ? ONE_BIG_NUMBER : prices[quoteTokenId]
 
-    if (basePrice.isZero() || quotePrice.isZero()) {
+    if (!basePrice || !quotePrice) {
       // there was never a trade for one of these tokens
-      return ZERO_BIG_NUMBER
+      return null
     }
 
     return basePrice.dividedBy(quotePrice)

--- a/src/services/factories/getPriceEstimation.ts
+++ b/src/services/factories/getPriceEstimation.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { assert } from '@gnosis.pm/dex-js'
+import { assert, ONE_BIG_NUMBER } from '@gnosis.pm/dex-js'
 
 import { ZERO_BIG_NUMBER } from 'const'
 
@@ -54,18 +54,17 @@ export function getPriceEstimationFactory(factoryParams: {
 
     const prices = await theGraphApi.getPrices({ networkId, tokenIds })
 
-    if (quoteTokenId === 0) {
-      // Optimization more for a matter of principle than performance:
-      // OWL token is always tokenId == 0 on the contract
-      // All prices are given in terms of OWL
-      // OWL price is always 1
-      // Anything divided by 1...
-      return prices[baseTokenId]
-    } else if (prices[baseTokenId].isZero() || prices[quoteTokenId].isZero()) {
+    // OWL token is always tokenId == 0 on the contract
+    // OWL price is always 1
+    // All prices are given in terms of OWL
+    const basePrice = baseTokenId === 0 ? ONE_BIG_NUMBER : prices[baseTokenId]
+    const quotePrice = quoteTokenId === 0 ? ONE_BIG_NUMBER : prices[quoteTokenId]
+
+    if (basePrice.isZero() || quotePrice.isZero()) {
       // there was never a trade for one of these tokens
       return ZERO_BIG_NUMBER
     }
 
-    return prices[baseTokenId].dividedBy(prices[quoteTokenId])
+    return basePrice.dividedBy(quotePrice)
   }
 }

--- a/src/services/factories/getPriceEstimation.ts
+++ b/src/services/factories/getPriceEstimation.ts
@@ -45,12 +45,10 @@ export function getPriceEstimationFactory(factoryParams: {
 
     assert(baseTokenId !== quoteTokenId, 'Token ids cannot be the equal')
 
-    // As much as it'd be visually pleasing, cannot simplify it to a single expression
-    // We need to execute both functions.
-    let needsToSort = addTokenId(baseTokenId)
-    needsToSort = addTokenId(quoteTokenId) || needsToSort
+    const baseTokenAdded = addTokenId(baseTokenId)
+    const quoteTokenAdded = addTokenId(quoteTokenId)
 
-    if (needsToSort) {
+    if (baseTokenAdded || quoteTokenAdded) {
       tokenIds.sort()
     }
 

--- a/src/services/factories/index.ts
+++ b/src/services/factories/index.ts
@@ -1,2 +1,3 @@
 export * from './addTokenToExchange'
 export * from './getTokenFromExchange'
+export * from './getPriceEstimation'

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,9 +1,10 @@
-import { tokenListApi, exchangeApi, erc20Api, web3 } from 'api'
+import { tokenListApi, exchangeApi, erc20Api, web3, theGraphApi } from 'api'
 
 import {
   getTokenFromExchangeByAddressFactory,
   getTokenFromExchangeByIdFactory,
   addTokenToExchangeFactory,
+  getPriceEstimationFactory,
 } from './factories'
 
 const apis = {
@@ -11,6 +12,7 @@ const apis = {
   exchangeApi,
   erc20Api,
   web3,
+  theGraphApi,
 }
 
 export const getTokenFromExchangeByAddress = getTokenFromExchangeByAddressFactory(apis)
@@ -18,3 +20,5 @@ export const getTokenFromExchangeByAddress = getTokenFromExchangeByAddressFactor
 export const getTokenFromExchangeById = getTokenFromExchangeByIdFactory(apis)
 
 export const addTokenToExchange = addTokenToExchangeFactory(apis)
+
+export const getPriceEstimation = getPriceEstimationFactory(apis)


### PR DESCRIPTION
Implementation of TheGraphApi for now only querying the prices.

Implementation of `getPriceEstimation` service.

Using Dima's suggestion, `getPrices` query for multiple prices at once, and `getPriceEstimation` service query for all known tokens at once as well for caching all prices locally.

Open for feedbacks and suggestions regarding this approach.

In another PR, will implement `usePriceEstimation` hook and add it to the interface somehow.