### PR TITLE
Fix focus stealing in production

### DIFF
--- a/src/components/TokenSelectorComponents.tsx
+++ b/src/components/TokenSelectorComponents.tsx
@@ -20,13 +20,13 @@ export const MenuList: ComponentType<MenuListComponentProps<any>> = props => {
   // Wrap the event to capture `Enter` and avoid losing focus when there's no value set in the menu
   const wrappedOnKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      const childrenNames = React.Children.map(
-        childrenRef.current,
-        (c: { type: { name: string } }): string => c.type.name,
-      )
-
-      if (childrenNames?.length === 1 && e.key === 'Enter' && childrenNames[0] === 'NoOptionsMessage') {
-        // the only child is noOptionsMessage
+      if (
+        e.key === 'Enter' &&
+        React.Children.count(childrenRef.current) === 1 &&
+        React.isValidElement(childrenRef.current) &&
+        childrenRef.current.props.children === 'No results'
+      ) {
+        // the only child is noOptionsMessage, which returns string 'No results'
         e.preventDefault()
       }
 


### PR DESCRIPTION
Original check was for a specific `displayName` of a child component.
That name as all the others was mangled and minified in production

Check proposed here looks at children of that child component, which comes from
```ts
// TokenSelector.tsx::L255
const noOptionsMessage = (): string => 'No results'
```

Still ugly but more robust