### PR TITLE
Select with arrows

### DIFF
--- a/src/components/TokenSelector.tsx
+++ b/src/components/TokenSelector.tsx
@@ -136,6 +136,10 @@ const Wrapper = styled.div`
       @media ${MEDIA.mobile} {
         height: 5.6rem;
       }
+
+      &--is-focused {
+        background: rgba(33, 141, 255, 0.1);
+      }
     }
   }
 `

--- a/src/components/TokenSelector.tsx
+++ b/src/components/TokenSelector.tsx
@@ -71,6 +71,14 @@ const Wrapper = styled.div`
   .tokenSelectBox {
     position: relative;
     .react-select__menu {
+      .menulist-head {
+        position: absolute;
+        bottom: 100%;
+        background-color: inherit;
+        width: 100%;
+        border-radius: 0.6rem;
+      }
+
       .header {
         display: flex;
         justify-content: space-between;
@@ -237,7 +245,7 @@ const customSelectStyles = {
   menuList: (): CSSProperties => ({
     height: '100%',
     overflow: 'auto',
-    borderRadius: '0.6rem',
+    borderRadius: '0 0 0.6rem 0.6rem',
     padding: '0 0 5rem 0',
     background: 'var(--color-background-pageWrapper)',
   }),

--- a/src/components/TokenSelectorComponents.tsx
+++ b/src/components/TokenSelectorComponents.tsx
@@ -67,9 +67,6 @@ export const MenuList: ComponentType<MenuListComponentProps<any>> = props => {
   const searchContainerRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     inputRef.current?.focus()
-
-    const menuList = searchContainerRef.current?.nextElementSibling
-    if (menuList) menuList.scrollTop = 0
   }, [])
 
   return (

--- a/src/components/TokenSelectorComponents.tsx
+++ b/src/components/TokenSelectorComponents.tsx
@@ -74,28 +74,30 @@ export const MenuList: ComponentType<MenuListComponentProps<any>> = props => {
 
   return (
     <>
-      <div className="header">
-        <h2>Select token</h2>
-        <button type="button" onClick={selectCurrent}>
-          ×
-        </button>
-      </div>
-      <div className="searchContainer" ref={searchContainerRef}>
-        <input
-          ref={inputRef}
-          autoCorrect="off"
-          autoComplete="off"
-          spellCheck="false"
-          type="text"
-          placeholder="Search by token Name, Symbol or Address"
-          value={inputValue}
-          onChange={onChange}
-          onKeyDown={wrappedOnKeyDown}
-          onMouseDown={onInputClick}
-          onTouchEnd={onInputClick}
-          onFocus={onMenuInputFocus}
-          {...ariaAttributes}
-        />
+      <div className="menulist-head">
+        <div className="header">
+          <h2>Select token</h2>
+          <button type="button" onClick={selectCurrent}>
+            ×
+          </button>
+        </div>
+        <div className="searchContainer" ref={searchContainerRef}>
+          <input
+            ref={inputRef}
+            autoCorrect="off"
+            autoComplete="off"
+            spellCheck="false"
+            type="text"
+            placeholder="Search by token Name, Symbol or Address"
+            value={inputValue}
+            onChange={onChange}
+            onKeyDown={wrappedOnKeyDown}
+            onMouseDown={onInputClick}
+            onTouchEnd={onInputClick}
+            onFocus={onMenuInputFocus}
+            {...ariaAttributes}
+          />
+        </div>
       </div>
       <components.MenuList {...props} />
     </>

--- a/src/components/TokenSelectorComponents.tsx
+++ b/src/components/TokenSelectorComponents.tsx
@@ -31,7 +31,7 @@ export const MenuList: ComponentType<MenuListComponentProps<any>> = props => {
       // When hitting the Esc key, the select will close.
       // If nothing is selected, the select will contain an empty value. Which we don't like.
       // To prevent that, we set again the currently selected value.
-      if (e.key === 'Escape') {
+      else if (e.key === 'Escape') {
         selectCurrent()
       }
 


### PR DESCRIPTION
`react-select` was already changing active option on `ArrowUp|Down`, it just wasn't visibly styled

This PR also takes care of the recurring issue of `scrollTop` which happens when `menuList` overflows and selected element changes from the last to first.
Can check the behavior if you press `ArrowDown` long enough in develop.

![overflow](https://user-images.githubusercontent.com/5121491/77401681-668dbc00-6dbe-11ea-8180-fa4d0acf86a7.gif)


As I understand when `menuList` determines how much to scroll it takes measurement  of the whole `MenuList` components and count from Top, but as we added our search component there top got moved.

By moving our custom elements above the `boundingRect` of `MenuList` , default `MenuList` is once again flush with custom `MenuList` dimensions..

Closes #741