### PR TITLE
Updating validation to not prevent default in case input is not valid

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -6,7 +6,8 @@ export function preventInvalidChars(event: React.KeyboardEvent<HTMLInputElement>
   if (
     event.key !== 'Backspace' &&
     event.key !== 'Delete' &&
-    !validInputPattern.test(event.currentTarget.value + event.key)
+    !validInputPattern.test(event.currentTarget.value + event.key) &&
+    validInputPattern.test(event.currentTarget.value)
   ) {
     event.preventDefault()
   }


### PR DESCRIPTION
Closes #752 

Validation prevented a new key to be pressed because the input was invalid, but input was already invalid in the first place.

This change allows invalid inputs to be cleared.