### PR TITLE
Reseting prices when switching tokens even if estimation is null

### DIFF
--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -26,7 +26,7 @@ import { usePlaceOrder } from 'hooks/usePlaceOrder'
 import { useQuery, buildSearchQuery } from 'hooks/useQuery'
 import useGlobalState from 'hooks/useGlobalState'
 import { savePendingOrdersAction, removePendingOrdersAction } from 'reducers-actions/pendingOrders'
-import { MEDIA } from 'const'
+import { MEDIA, PRICE_ESTIMATION_PRECISION } from 'const'
 
 import { tokenListApi } from 'api'
 
@@ -450,7 +450,7 @@ const TradeWidget: React.FC = () => {
 
       if (shouldUsePriceEstimation) {
         // Price estimation can be null. In that case, set the input to 0
-        const newPrice = priceEstimation ? priceEstimation.toFixed(5) : '0'
+        const newPrice = priceEstimation ? priceEstimation.toFixed(PRICE_ESTIMATION_PRECISION) : '0'
 
         setValue(priceInputId, newPrice)
         setValue(priceInverseInputId, invertPriceFromString(newPrice))

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -446,17 +446,17 @@ const TradeWidget: React.FC = () => {
       // Keep in mind that next time is when token selection is changed.
       // In that case, initial price doesn't matter anymore
       initialPrice.current = ''
+    }
 
-      logDebug('[TradeWidget] priceEstimation', priceEstimation.toString(10))
+    logDebug(`[TradeWidget] priceEstimation ${priceEstimation}`)
 
-      if (shouldUsePriceEstimation) {
-        const newPrice = priceEstimation.toFixed(5)
+    if (shouldUsePriceEstimation) {
+      const newPrice = priceEstimation ? priceEstimation.toFixed(5) : '0'
 
-        setValue(priceInputId, newPrice)
-        setValue(priceInverseInputId, invertPriceFromString(newPrice))
+      setValue(priceInputId, newPrice)
+      setValue(priceInverseInputId, invertPriceFromString(newPrice))
 
-        setValue(receiveInputId, calculateReceiveAmount(priceValue, sellValue))
-      }
+      setValue(receiveInputId, calculateReceiveAmount(priceValue, sellValue))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [priceEstimation])

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -391,7 +391,7 @@ const TradeWidget: React.FC = () => {
 
   const [ordersVisible, setOrdersVisible] = useState(true)
 
-  const priceEstimation = usePriceEstimation({
+  const { priceEstimation, isPriceLoading } = usePriceEstimation({
     baseTokenId: sellToken.id,
     quoteTokenId: receiveToken.id,
   })
@@ -438,28 +438,28 @@ const TradeWidget: React.FC = () => {
     // We DO want to use price estimation when there's no price coming from the URL
     const shouldUsePriceEstimation = !initialPrice.current || +initialPrice.current === 0
 
-    // Only bother when there's an actual priceEstimation
-    // This is important because on first page load, default price is `null`
-    // Only after the promise is resolved there will be anything
-    if (priceEstimation) {
-      // There's a valid price estimation, we can clear initial price.
-      // Keep in mind that next time is when token selection is changed.
-      // In that case, initial price doesn't matter anymore
-      initialPrice.current = ''
-    }
+    // Only try to update price estimation when not loading
+    if (!isPriceLoading) {
+      // If there was a price set coming from the URL, reset it
+      // It was supposed to be used only once. Initial price doesn't matter anymore
+      if (initialPrice.current) {
+        initialPrice.current = ''
+      }
 
-    logDebug(`[TradeWidget] priceEstimation ${priceEstimation}`)
+      logDebug(`[TradeWidget] priceEstimation ${priceEstimation}`)
 
-    if (shouldUsePriceEstimation) {
-      const newPrice = priceEstimation ? priceEstimation.toFixed(5) : '0'
+      if (shouldUsePriceEstimation) {
+        // Price estimation can be null. In that case, set the input to 0
+        const newPrice = priceEstimation ? priceEstimation.toFixed(5) : '0'
 
-      setValue(priceInputId, newPrice)
-      setValue(priceInverseInputId, invertPriceFromString(newPrice))
+        setValue(priceInputId, newPrice)
+        setValue(priceInverseInputId, invertPriceFromString(newPrice))
 
-      setValue(receiveInputId, calculateReceiveAmount(priceValue, sellValue))
+        setValue(receiveInputId, calculateReceiveAmount(priceValue, sellValue))
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [priceEstimation])
+  }, [priceEstimation, isPriceLoading])
 
   // Update receive amount
   useEffect(() => {

--- a/src/const.ts
+++ b/src/const.ts
@@ -43,6 +43,8 @@ export const HIGHLIGHT_TIME = 5000
 
 export const TOAST_NOTIFICATION_DURATION = 10000 // in milliseconds
 
+export const PRICE_ESTIMATION_PRECISION = 5
+
 export const LEGALDOCUMENT = {
   CONTACT_ADDRESS: '[INSERT ADDRESS]',
   POC_URL: '/',

--- a/src/hooks/usePriceEstimation.ts
+++ b/src/hooks/usePriceEstimation.ts
@@ -11,13 +11,24 @@ interface Params {
   quoteTokenId: number
 }
 
-export function usePriceEstimation(params: Params): BigNumber | null {
+interface Result {
+  priceEstimation: BigNumber | null
+  isPriceLoading: boolean
+}
+
+export function usePriceEstimation(params: Params): Result {
   const { baseTokenId, quoteTokenId } = params
-  const [price, setPrice] = useSafeState<BigNumber | null>(null)
+  const [isPriceLoading, setIsPriceLoading] = useSafeState(true)
+  const [priceEstimation, setPriceEstimation] = useSafeState<BigNumber | null>(null)
 
   useEffect(() => {
-    getPriceEstimation({ baseTokenId, quoteTokenId }).then(setPrice, logDebug)
-  }, [quoteTokenId, baseTokenId, setPrice])
+    setIsPriceLoading(true)
 
-  return price
+    getPriceEstimation({ baseTokenId, quoteTokenId }).then(price => {
+      setPriceEstimation(price)
+      setIsPriceLoading(false)
+    }, logDebug)
+  }, [quoteTokenId, baseTokenId, setPriceEstimation, setIsPriceLoading])
+
+  return { priceEstimation, isPriceLoading }
 }

--- a/src/hooks/usePriceEstimation.ts
+++ b/src/hooks/usePriceEstimation.ts
@@ -27,7 +27,7 @@ export function usePriceEstimation(params: Params): Result {
       try {
         setPriceEstimation(await getPriceEstimation({ baseTokenId, quoteTokenId }))
       } catch (e) {
-        logDebug(e)
+        console.error(`Error getting price estimation for tokens ${baseTokenId} and ${quoteTokenId}`, e)
       } finally {
         setIsPriceLoading(false)
       }

--- a/src/hooks/usePriceEstimation.ts
+++ b/src/hooks/usePriceEstimation.ts
@@ -22,12 +22,18 @@ export function usePriceEstimation(params: Params): Result {
   const [priceEstimation, setPriceEstimation] = useSafeState<BigNumber | null>(null)
 
   useEffect(() => {
-    setIsPriceLoading(true)
+    async function estimatePrice(): Promise<void> {
+      setIsPriceLoading(true)
+      try {
+        setPriceEstimation(await getPriceEstimation({ baseTokenId, quoteTokenId }))
+      } catch (e) {
+        logDebug(e)
+      } finally {
+        setIsPriceLoading(false)
+      }
+    }
 
-    getPriceEstimation({ baseTokenId, quoteTokenId }).then(price => {
-      setPriceEstimation(price)
-      setIsPriceLoading(false)
-    }, logDebug)
+    estimatePrice()
   }, [quoteTokenId, baseTokenId, setPriceEstimation, setIsPriceLoading])
 
   return { priceEstimation, isPriceLoading }


### PR DESCRIPTION
Part of #757 

Prices are reset even when a token pair has no price estimation.

### Note

This is no longer an issue. Leaving for future reference.

~One caveat is that one use case the price won't be updated, when it meets this conditions:~
- ~Price is set on the URL~
- ~One of the tokens in the URL doesn't have a price~
- ~The user picks different tokens, without changing the one without price.~

~Example:~
- ~Starting URL: `/trade/GUSD-SNX?price=10`~
- ~Token without a price: `GUSD`~

~1. Load the page~
~2. Switch `SNX` by any other token~

~Price will remain `10`~

~In that case, the price won't change UNTIL the _priceless_ token is swapped out. First time this happens price will work as expected.~

~3. Switch `GUSD` by any other token~

~Price will be updated~

~4. Switch back to `GUSD`~

~Price will be reset to `0`.~

---

~This happens because of the way the price is loaded and how we deal with prices coming from the URL.~

~We'll only start inserting the price estimation once we have a valid price, because on first load the price is always `null`.~

~And we want to avoid overwriting URL prices when they are present.~

~Any better ideas to get this working?~


