### PR TITLE
Use production endpoint for the graph

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -112,7 +112,7 @@ function createTokenListApi(): TokenList {
 
 function createTheGraphApi(): TheGraphApi {
   const urls = {
-    [Network.Mainnet]: 'https://api.thegraph.com/subgraphs/name/gnosis/dfusion-staging',
+    [Network.Mainnet]: 'https://api.thegraph.com/subgraphs/name/gnosis/dfusion',
     [Network.Rinkeby]: 'https://api.thegraph.com/subgraphs/name/gnosis/dfusion-rinkeby',
   }
 


### PR DESCRIPTION
Update TheGraph endpoint to use production.

Still indexing 👍 
It'll be updated soon:
https://thegraph.com/explorer/subgraph/gnosis/dfusion