### PR TITLE
Add dune link, fix a broken link, and include smart contract addresses

### DIFF
--- a/src/components/EtherscanLink.tsx
+++ b/src/components/EtherscanLink.tsx
@@ -9,6 +9,7 @@ export interface EtherscanLinkProps {
   type: EtherscanLinkType
   identifier: string
   networkId?: number
+  networkIdDefault?: number
   label?: string | ReactElement | void
   className?: string // to allow subclassing styles with styled-components
 }
@@ -35,9 +36,12 @@ export const EtherscanLink: React.FC<EtherscanLinkProps> = ({
   identifier,
   label,
   className,
-  networkId: netId,
+  networkId: networkIdFixed,
+  networkIdDefault,
 }) => {
-  const { networkId = netId } = useWalletConnection()
+  const { networkId: networkIdWallet = networkIdDefault } = useWalletConnection()
+
+  const networkId = networkIdFixed || networkIdWallet
 
   if (!networkId || !identifier) {
     return null

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -110,6 +110,16 @@ const About: React.FC = () => (
           https://thegraph.com/explorer/subgraph/gnosis/dfusion
         </a>
       </li>
+      <li>
+        Protocol info:{' '}
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://explore.duneanalytics.com/public/dashboards/I43OkDWnojXZYm8vmdBDcLz5UsS3Tn0cx1xU8Hcg"
+        >
+          Dune analytics: Gnosis Protocol
+        </a>
+      </li>
 
       <li>
         Open Solver:{' '}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import styled from 'styled-components'
 import { ContentPage } from 'components/Layout/PageWrapper'
+import addressesByNetwork from 'api/deposit/batchExchangeAddresses'
+import { getNetworkFromId } from '@gnosis.pm/dex-js'
+import { EtherscanLink } from 'components/EtherscanLink'
 
 export const AboutWrapper = styled(ContentPage)`
   line-height: 2.2rem;
@@ -15,141 +18,168 @@ export const AboutWrapper = styled(ContentPage)`
     margin-left: 2rem;
     font-size: 1.2rem;
   }
+
+  .contract-addresses {
+    font-size: 0.85em;
+    a {
+      margin-left: 0;
+    }
+  }
 `
 
-const About: React.FC = () => (
-  <AboutWrapper>
-    <h1>About Mesa</h1>
-    <p>
-      Mesa it&apos;s an Open Source interface for{' '}
-      <a target="_blank" rel="noopener noreferrer" href="https://docs.gnosis.io/dfusion">
-        Gnosis Protocol
-      </a>
-      .<br />
-      <div id="code-link">
-        Check out the <a href="https://github.com/gnosis/dex-react">Source Code</a> and{' '}
-        <a href="https://github.com/gnosis/dex-react/releases">Releases</a>.
-      </div>
-    </p>
-    <p>
-      <strong>Gnosis Protocol</strong> introduces a new, fully decentralized exchange mechanism for ERC20 tokens with
-      the following properties:
-      <ul>
-        <li>Batch auctions</li>
-        <li>Multidimensional order books with ring trades</li>
-        <li>Uniform clearing prices in every batch</li>
-      </ul>
-      <a target="_blank" rel="noopener noreferrer" href="https://docs.gnosis.io/dfusion">
-        Read more here
-      </a>
-    </p>
-
-    <h2>Versions:</h2>
-    <ul>
-      <li>
-        Mesa:&nbsp;
-        <a target="_blank" rel="noopener noreferrer" href={'https://github.com/gnosis/dex-react/tree/v' + VERSION}>
-          v{VERSION}
-        </a>{' '}
-      </li>
-      <li>
-        Smart Contract:&nbsp;
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href={'https://github.com/gnosis/dex-contracts/tree/v' + CONTRACT_VERSION}
-        >
-          v{CONTRACT_VERSION}
-        </a>
-      </li>
-      <li>
-        dex-js library:&nbsp;
-        <a target="_blank" rel="noopener noreferrer" href={'https://github.com/gnosis/dex-js/tree/v' + DEX_JS_VERSION}>
-          v{DEX_JS_VERSION}
-        </a>
-      </li>
-    </ul>
-
-    <h2>Learn more about Gnosis Protocol</h2>
-    <ul>
-      <li>
-        dFusion Paper:{' '}
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://github.com/gnosis/dex-research/blob/master/dFusion/dfusion.v1.pdf"
-        >
-          dfusion.v1.pdf
-        </a>
-      </li>
-      <li>
-        Developer portal:{' '}
+const About: React.FC = () => {
+  const ContractAddresses = Object.entries(addressesByNetwork).map(([networkId, address], index) => (
+    <React.Fragment key={address}>
+      {index > 0 && <span>, </span>}
+      <EtherscanLink type="contract" identifier={address} networkId={+networkId} label={getNetworkFromId(+networkId)} />
+    </React.Fragment>
+  ))
+  return (
+    <AboutWrapper>
+      <h1>About Mesa</h1>
+      <p>
+        Mesa it&apos;s an Open Source interface for{' '}
         <a target="_blank" rel="noopener noreferrer" href="https://docs.gnosis.io/dfusion">
-          https://docs.gnosis.io/dfusion
+          Gnosis Protocol
         </a>
-      </li>
-      <li>
-        Smart Contracts:{' '}
-        <a target="_blank" rel="noopener noreferrer" href="https://github.com/gnosis/dex-contracts">
-          @gnosis/dex-contracts
+        .<br />
+        <div id="code-link">
+          Check out the{' '}
+          <a target="_blank" rel="noopener noreferrer" href="https://github.com/gnosis/dex-react">
+            Source Code
+          </a>{' '}
+          and{' '}
+          <a target="_blank" rel="noopener noreferrer" href="https://github.com/gnosis/dex-react/releases">
+            Releases
+          </a>
+          .
+        </div>
+      </p>
+      <p>
+        <strong>Gnosis Protocol</strong> introduces a new, fully decentralized exchange mechanism for ERC20 tokens with
+        the following properties:
+        <ul>
+          <li>Batch auctions</li>
+          <li>Multidimensional order books with ring trades</li>
+          <li>Uniform clearing prices in every batch</li>
+        </ul>
+        <a target="_blank" rel="noopener noreferrer" href="https://docs.gnosis.io/dfusion">
+          Read more here
         </a>
-      </li>
-    </ul>
+      </p>
 
-    <h2>Tools</h2>
-    <ul>
-      <li>
-        CLI <small>(Command Line Interface)</small>:{' '}
-        <a target="_blank" rel="noopener noreferrer" href="https://github.com/gnosis/dex-cli">
-          @gnosis/dex-cli
-        </a>
-      </li>
-      <li>
-        Subgraph API:{' '}
-        <a target="_blank" rel="noopener noreferrer" href="https://thegraph.com/explorer/subgraph/gnosis/dfusion">
-          https://thegraph.com/explorer/subgraph/gnosis/dfusion
-        </a>
-      </li>
-      <li>
-        Protocol info:{' '}
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://explore.duneanalytics.com/public/dashboards/I43OkDWnojXZYm8vmdBDcLz5UsS3Tn0cx1xU8Hcg"
-        >
-          Dune analytics: Gnosis Protocol
-        </a>
-      </li>
+      <h2>Versions:</h2>
+      <ul>
+        <li>
+          Mesa:&nbsp;
+          <a target="_blank" rel="noopener noreferrer" href={'https://github.com/gnosis/dex-react/tree/v' + VERSION}>
+            v{VERSION}
+          </a>{' '}
+        </li>
+        <li>
+          Smart Contract:&nbsp;
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href={'https://github.com/gnosis/dex-contracts/tree/v' + CONTRACT_VERSION}
+          >
+            v{CONTRACT_VERSION}
+          </a>{' '}
+          <span className="contract-addresses">({ContractAddresses})</span>
+        </li>
+        <li>
+          dex-js library:&nbsp;
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href={'https://github.com/gnosis/dex-js/tree/v' + DEX_JS_VERSION}
+          >
+            v{DEX_JS_VERSION}
+          </a>
+        </li>
+      </ul>
 
-      <li>
-        Open Solver:{' '}
-        <a target="_blank" rel="noopener noreferrer" href="https://github.com/gnosis/dex-open-solver">
-          @gnosis/dex-open-solver
-        </a>
-      </li>
+      <h2>Learn more about Gnosis Protocol</h2>
+      <ul>
+        <li>
+          dFusion Paper:{' '}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/gnosis/dex-research/blob/master/dFusion/dfusion.v1.pdf"
+          >
+            dfusion.v1.pdf
+          </a>
+        </li>
+        <li>
+          Developer portal:{' '}
+          <a target="_blank" rel="noopener noreferrer" href="https://docs.gnosis.io/dfusion">
+            https://docs.gnosis.io/dfusion
+          </a>
+        </li>
+        <li>
+          Smart Contracts:{' '}
+          <a target="_blank" rel="noopener noreferrer" href="https://github.com/gnosis/dex-contracts">
+            @gnosis/dex-contracts
+          </a>
+        </li>
+      </ul>
 
-      <li>
-        Telegram bot:{' '}
-        <a target="_blank" rel="noopener noreferrer" href="https://github.com/gnosis/dex-telegram">
-          @gnosis/dex-telegram
-        </a>
-      </li>
+      <h2>Tools</h2>
+      <ul>
+        <li>
+          CLI <small>(Command Line Interface)</small>:{' '}
+          <a target="_blank" rel="noopener noreferrer" href="https://github.com/gnosis/dex-cli">
+            @gnosis/dex-cli
+          </a>
+        </li>
+        <li>
+          Subgraph API:{' '}
+          <a target="_blank" rel="noopener noreferrer" href="https://thegraph.com/explorer/subgraph/gnosis/dfusion">
+            https://thegraph.com/explorer/subgraph/gnosis/dfusion
+          </a>
+        </li>
+        <li>
+          Protocol info:{' '}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://explore.duneanalytics.com/public/dashboards/I43OkDWnojXZYm8vmdBDcLz5UsS3Tn0cx1xU8Hcg"
+          >
+            Dune analytics: Gnosis Protocol
+          </a>
+        </li>
 
-      <li>
-        Visualization tools:{' '}
-        <a target="_blank" rel="noopener noreferrer" href="https://github.com/gnosis/dex-visualization-tools">
-          @gnosis/dex-visualization-tools
-        </a>
-      </li>
+        <li>
+          Open Solver:{' '}
+          <a target="_blank" rel="noopener noreferrer" href="https://github.com/gnosis/dex-open-solver">
+            @gnosis/dex-open-solver
+          </a>
+        </li>
 
-      <li>
-        Price Estimator:{' '}
-        <a target="_blank" rel="noopener noreferrer" href="dex-price-estimator">
-          dex-price-estimator
-        </a>
-      </li>
-    </ul>
-  </AboutWrapper>
-)
+        <li>
+          Telegram bot:{' '}
+          <a target="_blank" rel="noopener noreferrer" href="https://github.com/gnosis/dex-telegram">
+            @gnosis/dex-telegram
+          </a>
+        </li>
+
+        <li>
+          Visualization tools:{' '}
+          <a target="_blank" rel="noopener noreferrer" href="https://github.com/gnosis/dex-visualization-tools">
+            @gnosis/dex-visualization-tools
+          </a>
+        </li>
+
+        <li>
+          Price Estimator:{' '}
+          <a target="_blank" rel="noopener noreferrer" href="https://github.com/gnosis/dex-price-estimator">
+            @gnosis/dex-price-estimator
+          </a>
+        </li>
+      </ul>
+    </AboutWrapper>
+  )
+}
 
 export default About

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -28,12 +28,16 @@ export const AboutWrapper = styled(ContentPage)`
 `
 
 const About: React.FC = () => {
-  const ContractAddresses = Object.entries(addressesByNetwork).map(([networkId, address], index) => (
-    <React.Fragment key={address}>
-      {index > 0 && <span>, </span>}
-      <EtherscanLink type="contract" identifier={address} networkId={+networkId} label={getNetworkFromId(+networkId)} />
-    </React.Fragment>
-  ))
+  const ContractAddresses = Object.entries(addressesByNetwork).map(([networkIdString, address], index) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const networkId = +networkIdString!
+    return (
+      <React.Fragment key={address}>
+        {index > 0 && <span>, </span>}
+        <EtherscanLink type="contract" identifier={address} networkId={networkId} label={getNetworkFromId(networkId)} />
+      </React.Fragment>
+    )
+  })
   return (
     <AboutWrapper>
       <h1>About Mesa</h1>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/2352112/78012986-1676a280-7346-11ea-9f32-e639bd569d45.png)



Adds a link to dune analytics
Also, link to the smart contracts

As a bonus I had to fix the Ethescan link component, cause the `networkId` was being used as a default, instead of being set as the network you want. So you could not use a different network than the one you are connected with your wallet. 
I reviewed and we were not using the `networkId` param anywere, so I think it's safe to change the behaviour. I added an aditional optional parameter for `networkIdDefault` in case we need the old behaviour