### PR TITLE
Merging both lists of tokens to avoid duplicates

### DIFF
--- a/src/api/tokenList/TokenListApi.ts
+++ b/src/api/tokenList/TokenListApi.ts
@@ -40,7 +40,7 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
 
     networkIds.forEach(networkId => {
       // initial value
-      const tokenList = getTokensByNetwork(networkId).concat(this.loadUserTokenList(networkId))
+      const tokenList = this.mergeTokenLists(getTokensByNetwork(networkId), this.loadUserTokenList(networkId))
       this._tokensByNetwork[networkId] = tokenList
 
       tokenList.forEach(({ address }) => {
@@ -57,6 +57,20 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
 
   public getTokens(networkId: number): TokenDetails[] {
     return this._tokensByNetwork[networkId] || []
+  }
+
+
+  private mergeTokenLists(baseList: TokenDetails[], newList: TokenDetails[]): TokenDetails[] {
+    const seenAddresses = new Set<string>()
+    const result: TokenDetails[] = []
+
+    baseList.concat(newList).forEach(token => {
+      if (!seenAddresses.has(token.address.toLocaleLowerCase())) {
+        seenAddresses.add(token.address.toLocaleLowerCase())
+        result.push(token)
+      }
+    })
+    return result
   }
 
   private static constructAddressNetworkKey({ tokenAddress, networkId }: HasTokenParams): string {

--- a/src/api/tokenList/TokenListApi.ts
+++ b/src/api/tokenList/TokenListApi.ts
@@ -40,7 +40,10 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
 
     networkIds.forEach(networkId => {
       // initial value
-      const tokenList = this.mergeTokenLists(getTokensByNetwork(networkId), this.loadUserTokenList(networkId))
+      const tokenList = TokenListApiImpl.mergeTokenLists(
+        getTokensByNetwork(networkId),
+        this.loadUserTokenList(networkId),
+      )
       this._tokensByNetwork[networkId] = tokenList
 
       tokenList.forEach(({ address }) => {
@@ -59,14 +62,13 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
     return this._tokensByNetwork[networkId] || []
   }
 
-
-  private mergeTokenLists(baseList: TokenDetails[], newList: TokenDetails[]): TokenDetails[] {
+  private static mergeTokenLists(baseList: TokenDetails[], newList: TokenDetails[]): TokenDetails[] {
     const seenAddresses = new Set<string>()
     const result: TokenDetails[] = []
 
     baseList.concat(newList).forEach(token => {
-      if (!seenAddresses.has(token.address.toLocaleLowerCase())) {
-        seenAddresses.add(token.address.toLocaleLowerCase())
+      if (!seenAddresses.has(token.address.toLowerCase())) {
+        seenAddresses.add(token.address.toLowerCase())
         result.push(token)
       }
     })


### PR DESCRIPTION
List of tokens were being concatenated with previously saved list of tokens from localStorage, making it quite large...

Here I do a simple 'merge' by only using unique addresses and ignoring repeated entries.