### PR TITLE
Add order book page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,12 @@ const FAQ = React.lazy(() =>
     'pages/FAQ'
   ),
 )
+const OrderBook = React.lazy(() =>
+  import(
+    /* webpackChunkName: "OrderBook_chunk"*/
+    'pages/OrderBook'
+  ),
+)
 
 // Global State
 import { withGlobalContext } from 'hooks/useGlobalState'
@@ -87,6 +93,7 @@ const App: React.FC = () => (
             <PrivateRoute path="/wallet" exact component={Wallet} />
             <Route path="/about" exact component={About} />
             <Route path="/faq" exact component={FAQ} />
+            <Route path="/book" exact component={OrderBook} />
             <Route path="/connect-wallet" exact component={ConnectWallet} />
             <Redirect from="/" to="/trade/DAI-USDC?sell=0&price=0" />
             <Route component={NotFound} />

--- a/src/components/OrderBookWidget.tsx
+++ b/src/components/OrderBookWidget.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import styled from 'styled-components'
+import { TokenDetails } from 'types'
+
+interface OrderBookProps {
+  baseToken: TokenDetails
+  quoteToken: TokenDetails
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  background-color: #757597;
+  min-height: 25rem;
+  color: white;
+  text-align: center;
+  font-size: 1.6rem;
+  padding: 3rem;
+  width: 100%;
+`
+
+const OrderBookWidget: React.FC<OrderBookProps> = props => {
+  const { baseToken, quoteToken } = props
+
+  return (
+    <Wrapper>
+      Show order book for token {baseToken.symbol} ({baseToken.id}) and {quoteToken.symbol} ({quoteToken.id})
+    </Wrapper>
+  )
+}
+
+export default OrderBookWidget

--- a/src/pages/OrderBook.tsx
+++ b/src/pages/OrderBook.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect } from 'react'
+import { ContentPage } from 'components/Layout/PageWrapper'
+import OrderBookWidget from 'components/OrderBookWidget'
+import TokenSelector from 'components/TokenSelector'
+import { useTokenList } from 'hooks/useTokenList'
+import { useWalletConnection } from 'hooks/useWalletConnection'
+import { Network } from 'types'
+import useSafeState from 'hooks/useSafeState'
+import { TokenDetails } from 'types'
+
+const OrderBook: React.FC = () => {
+  const { networkId } = useWalletConnection()
+  const fallBackNetworkId = networkId ? networkId : Network.Mainnet // fallback to mainnet
+  const tokenList = useTokenList(fallBackNetworkId)
+  const [baseToken, setBaseToken] = useSafeState<TokenDetails | null>(null)
+  const [quoteToken, setQuoteToken] = useSafeState<TokenDetails | null>(null)
+
+  const tokensLoaded = tokenList.length !== 0
+  useEffect(() => {
+    if (tokensLoaded) {
+      if (baseToken === null) {
+        setBaseToken(tokenList[0])
+      }
+
+      if (quoteToken === null) {
+        setQuoteToken(tokenList[1])
+      }
+    }
+  }, [baseToken, quoteToken, setBaseToken, setQuoteToken, tokenList, tokensLoaded])
+
+  if (!tokensLoaded || baseToken === null || quoteToken === null) {
+    return null
+  }
+
+  return (
+    <ContentPage>
+      <h1>Order book</h1>
+      <TokenSelector tokens={tokenList} selected={baseToken} onChange={setBaseToken} />
+      <TokenSelector tokens={tokenList} selected={quoteToken} onChange={setQuoteToken} />
+      <OrderBookWidget baseToken={baseToken} quoteToken={quoteToken}></OrderBookWidget>
+    </ContentPage>
+  )
+}
+
+export default OrderBook


### PR DESCRIPTION
Part of #791

I would like to create as mentioned in #791  a placeholder so Felix can work on integrating his order book.

his PR includes:
- A new page with the selectors logic
- A new component for the Otherbook
- Add a wrapper with some example CSS --> just to show how to add CSS, but Felix pls remove the CSS in the next PR

![image](https://user-images.githubusercontent.com/2352112/78058058-0384c200-7388-11ea-989d-f3088ff45439.png)


Test it by navigating to `/book` address:
* http://localhost:8080/book
* https://pr800--dexreact.review.gnosisdev.com/book
