### PR TITLE
First attempt at a rate limiter api

### DIFF
--- a/src/api/deposit/DepositApi.ts
+++ b/src/api/deposit/DepositApi.ts
@@ -9,6 +9,7 @@ import { getAddressForNetwork } from './batchExchangeAddresses'
 import { Receipt, TxOptionalParams } from 'types'
 
 import Web3 from 'web3'
+import { RateLimiterApi } from 'api/rateLimiter/RateLimiterApi'
 
 interface ReadOnlyParams {
   userAddress: string
@@ -55,11 +56,13 @@ export interface PendingFlux {
 export interface Params {
   web3: Web3
   fetchGasPrice(): Promise<string | undefined>
+  rateLimiterApi: RateLimiterApi<any>
 }
 
 export class DepositApiImpl implements DepositApi {
   protected _contractPrototype: BatchExchangeContract
   protected web3: Web3
+  protected rateLimiterApi: RateLimiterApi<any>
   protected static _contractsCache: { [network: number]: { [address: string]: BatchExchangeContract } } = {}
 
   protected fetchGasPrice: Params['fetchGasPrice']

--- a/src/api/erc20/Erc20Api.ts
+++ b/src/api/erc20/Erc20Api.ts
@@ -8,6 +8,7 @@ import { ZERO } from 'const'
 import { toBN } from 'utils'
 
 import Web3 from 'web3'
+import { RateLimiterApi } from 'api/rateLimiter/RateLimiterApi'
 
 interface BaseParams {
   tokenAddress: string
@@ -69,6 +70,7 @@ export interface Erc20Api {
 export interface Params {
   web3: Web3
   fetchGasPrice(): Promise<string | undefined>
+  rateLimiterApi: RateLimiterApi<any>
 }
 
 /**
@@ -77,6 +79,7 @@ export interface Params {
 export class Erc20ApiImpl implements Erc20Api {
   private _contractPrototype: Erc20Contract
   private web3: Web3
+  private rateLimiterApi: RateLimiterApi<any>
 
   private static _contractsCache: { [network: number]: { [address: string]: Erc20Contract } } = {}
 
@@ -97,7 +100,8 @@ export class Erc20ApiImpl implements Erc20Api {
 
     const erc20 = this._getERC20AtAddress(networkId, tokenAddress)
 
-    const result = await erc20.methods.balanceOf(userAddress).call()
+    const promise = erc20.methods.balanceOf(userAddress).call()
+    const result = await this.rateLimiterApi.call(promise)
 
     return toBN(result)
   }
@@ -105,19 +109,22 @@ export class Erc20ApiImpl implements Erc20Api {
   public async name({ tokenAddress, networkId }: NameParams): Promise<string> {
     const erc20 = this._getERC20AtAddress(networkId, tokenAddress)
 
-    return await erc20.methods.name().call()
+    const promise = erc20.methods.name().call()
+    return await this.rateLimiterApi.call(promise)
   }
 
   public async symbol({ tokenAddress, networkId }: SymbolParams): Promise<string> {
     const erc20 = this._getERC20AtAddress(networkId, tokenAddress)
 
-    return await erc20.methods.symbol().call()
+    const promise = erc20.methods.symbol().call()
+    return await this.rateLimiterApi.call(promise)
   }
 
   public async decimals({ tokenAddress, networkId }: DecimalsParams): Promise<number> {
     const erc20 = this._getERC20AtAddress(networkId, tokenAddress)
 
-    const decimals = await erc20.methods.decimals().call()
+    const promise = erc20.methods.decimals().call()
+    const decimals = await this.rateLimiterApi.call(promise)
 
     return Number(decimals)
   }
@@ -125,7 +132,8 @@ export class Erc20ApiImpl implements Erc20Api {
   public async totalSupply({ tokenAddress, networkId }: TotalSupplyParams): Promise<BN> {
     const erc20 = this._getERC20AtAddress(networkId, tokenAddress)
 
-    const totalSupply = await erc20.methods.totalSupply().call()
+    const promise = erc20.methods.totalSupply().call()
+    const totalSupply = await this.rateLimiterApi.call(promise)
 
     return toBN(totalSupply)
   }

--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -138,7 +138,8 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     )
 
     // query 1 more than required to check whether there's a next page
-    const encodedOrders = await contract.methods.getEncodedUserOrdersPaginated(userAddress, offset, pageSize + 1).call()
+    const promise = contract.methods.getEncodedUserOrdersPaginated(userAddress, offset, pageSize + 1).call()
+    const encodedOrders = await this.rateLimiterApi.call(promise)
 
     // is null if Contract returns empty bytes
     if (!encodedOrders) return { orders: [] }
@@ -176,12 +177,16 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
 
   public async getTokenAddressById({ tokenId, networkId }: GetTokenAddressByIdParams): Promise<string> {
     const contract = await this._getContract(networkId)
-    return contract.methods.tokenIdToAddressMap(tokenId).call()
+
+    const promise = contract.methods.tokenIdToAddressMap(tokenId).call()
+    return this.rateLimiterApi.call(promise)
   }
 
   public async getTokenIdByAddress({ tokenAddress, networkId }: GetTokenIdByAddressParams): Promise<number> {
     const contract = await this._getContract(networkId)
-    const tokenId = await contract.methods.tokenAddressToIdMap(tokenAddress).call()
+
+    const promise = contract.methods.tokenAddressToIdMap(tokenAddress).call()
+    const tokenId = await this.rateLimiterApi.call(promise)
     return +tokenId
   }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -27,6 +27,7 @@ import { INITIAL_INFURA_ENDPOINT } from 'const'
 import fetchGasPriceFactory from './gasStation'
 import { TheGraphApi } from './thegraph/TheGraphApi'
 import { TheGraphApiProxy } from './thegraph/TheGraphApiProxy'
+import { RateLimiterApiImpl, RateLimiterApi } from './rateLimiter/RateLimiterApi'
 
 // TODO connect to mainnet if we need AUTOCONNECT at all
 export const getDefaultProvider = (): string | null =>
@@ -127,9 +128,16 @@ function createTheGraphApi(): TheGraphApi {
 export const web3: Web3 = createWeb3Api()
 export const walletApi: WalletApi = createWalletApi(web3)
 
+export const rateLimiterApi: RateLimiterApi<any> = new RateLimiterApiImpl({
+  requestsPerSecond: 5,
+  waitTime: 1000,
+  maxTries: 5,
+})
+
 const injectedDependencies = {
   web3,
   fetchGasPrice: fetchGasPriceFactory(walletApi),
+  rateLimiterApi,
 }
 
 export const erc20Api: Erc20Api = createErc20Api(injectedDependencies)

--- a/src/api/rateLimiter/RateLimiterApi.ts
+++ b/src/api/rateLimiter/RateLimiterApi.ts
@@ -1,0 +1,67 @@
+import { wait } from 'utils'
+
+export interface RateLimiterApi<T> {
+  call: (promise: Promise<T>) => Promise<T>
+}
+
+interface Params {
+  requestsPerSecond: number
+  waitTime: number
+  maxTries: number
+}
+
+export class RateLimiterApiImpl<T> implements RateLimiterApi<T> {
+  private readonly bucketSize: number
+  private readonly waitTime: number
+  private readonly maxTries: number
+
+  private executedCount: number
+  private timerId: NodeJS.Timeout | null
+
+  public constructor({ requestsPerSecond, waitTime, maxTries }: Params) {
+    this.bucketSize = requestsPerSecond
+    this.waitTime = waitTime
+    this.maxTries = maxTries
+
+    // init counter/tracker
+    this.executedCount = 0
+    this.timerId = null
+  }
+
+  public async call(promise: Promise<T>): Promise<T> {
+    if (this.timerId === null) {
+      console.log(`Starting timer`)
+      this.startTimer()
+    }
+
+    for (let tries = 0; tries < this.maxTries; tries++) {
+      if (this.canExecute()) {
+        console.log(`Not waiting. Try ${tries}`)
+        this.executedCount += 1
+        return await promise
+      }
+      // This is always at max. Why?
+      console.log(`Waiting. Try ${tries}. Used: ${this.executedCount}`)
+      // naive wait period waiting as long as it takes to replenish the bucket
+      // next step, use an exponential back off algorithm
+      await wait(this.waitTime)
+    }
+    throw new Error(`Could not fulfill promise after ${this.maxTries} tries. Try again later.`)
+  }
+
+  private canExecute(): boolean {
+    console.log(`${this.executedCount} < ${this.bucketSize}`)
+    return this.executedCount < this.bucketSize
+  }
+
+  private resetCount(): void {
+    // This is always 0. Why?
+    console.log(`Resetting count. Current ${this.executedCount}`)
+    this.executedCount = 0
+  }
+
+  private startTimer(): void {
+    this.timerId = setInterval(this.resetCount, this.waitTime)
+    console.log(`Timer id ${this.timerId}`)
+  }
+}


### PR DESCRIPTION
First feeble attempt at a rate limiter implementation.

Failing miserably so far.

The interval and the actual method calls seem to be in a different context.

For example, when the interval clears (1s), the value is always `0`. (`Resetting count. Current 0` log entries)
When the method is called, the counter keeps incrementing, and is never reset (`x < 5` log entries):

![screenshot_2020-03-31_14-07-39](https://user-images.githubusercontent.com/43217/78075299-2186fe00-7359-11ea-9d54-614dba17b68b.png)

- I added the rate limiter to some contract read only methods. Not extensive and through yet.
- Still need some work on the interface typing and so on.
- Build probably failing due to the use of `any`.

Looking for:
1. Opinions on this interface
2. Suggestions on the apparently different context for instance variables
