### PR TITLE
Wrap ether: Open modal, basic UI and logic

### DIFF
--- a/src/components/DepositWidget/Styled.tsx
+++ b/src/components/DepositWidget/Styled.tsx
@@ -1,13 +1,5 @@
 import styled from 'styled-components'
 
-export const ModalBodyWrapper = styled.div`
-  div > p {
-    font-size: inherit;
-    color: inherit;
-    padding: 0;
-  }
-`
-
 export const TokenRow = styled.tr`
   .enableToken {
     height: auto;

--- a/src/components/DepositWidget/useDepositModals.tsx
+++ b/src/components/DepositWidget/useDepositModals.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react'
 import BN from 'bn.js'
 
 import { ModalBodyWrapper } from './Styled'
+import { DEFAULT_MODAL_OPTIONS } from '../Modal'
 import Modali, { useModali, ModalHook, toggleModaliComponent } from 'modali'
 
 const OverwriteModalBody: React.FC = () => {
@@ -25,11 +26,6 @@ const WithdrawAndClaimModalBody: React.FC = () => {
       <p>By sending this withdraw request, you will automatically receive all claimable amounts back to your wallet.</p>
     </ModalBodyWrapper>
   )
-}
-
-const defaultOptions = {
-  centered: true,
-  animated: true,
 }
 
 interface Params {
@@ -68,7 +64,7 @@ export function useDepositModals(params: Params): Result {
   )
 
   const [withdrawOverwriteModal, toggleWithdrawOverwriteModal] = useModali({
-    ...defaultOptions,
+    ...DEFAULT_MODAL_OPTIONS,
     title: 'Confirm withdraw overwrite',
     message: <OverwriteModalBody />,
     buttons: getButtons((): void => {
@@ -77,7 +73,7 @@ export function useDepositModals(params: Params): Result {
   })
 
   const [withdrawAndClaimModal, toggleWithdrawAndClaimModal] = useModali({
-    ...defaultOptions,
+    ...DEFAULT_MODAL_OPTIONS,
     title: 'Please note',
     message: <WithdrawAndClaimModalBody />,
     buttons: getButtons((): void => toggleWithdrawAndClaimModal()),

--- a/src/components/DepositWidget/useDepositModals.tsx
+++ b/src/components/DepositWidget/useDepositModals.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback } from 'react'
 import BN from 'bn.js'
 
-import { ModalBodyWrapper } from './Styled'
-import { DEFAULT_MODAL_OPTIONS } from '../Modal'
+import { DEFAULT_MODAL_OPTIONS, ModalBodyWrapper } from '../Modal'
 import Modali, { useModali, ModalHook, toggleModaliComponent } from 'modali'
 
 const OverwriteModalBody: React.FC = () => {

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,4 +1,14 @@
+import styled from 'styled-components'
+
 export const DEFAULT_MODAL_OPTIONS = {
   centered: true,
   animated: true,
 }
+
+export const ModalBodyWrapper = styled.div`
+  div > p {
+    font-size: inherit;
+    color: inherit;
+    padding: 0;
+  }
+`

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,4 @@
+export const DEFAULT_MODAL_OPTIONS = {
+  centered: true,
+  animated: true,
+}

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -176,6 +176,10 @@ const WrapEtherModalWrapper = styled(ModalBodyWrapper)`
     padding-left: -0.5;
     display: block;
   }
+
+  a {
+    color: rgb(33, 141, 255);
+  }
 `
 
 const TokenBoxWrapper = styled.div`
@@ -267,6 +271,9 @@ const TokenRow: React.FC<Props> = ({
     precision: DEFAULT_PRECISION,
   })
 
+  // TODO: Get balance in another PR
+  const availableBalanceInEther = new BN('1234567800000000000')
+
   const [wrapEtherModal, toggleWrapEtherModal] = useModali({
     ...DEFAULT_MODAL_OPTIONS,
     title: 'Wrap Ether',
@@ -275,7 +282,11 @@ const TokenRow: React.FC<Props> = ({
         <div>
           <b>Available Ether</b>
           <div>
-            <a href="">{formatAmountFull({ amount: new BN(0), precision: DEFAULT_PRECISION }) || ''} ETH</a>
+            <a
+              onClick={(): void => setValue(INPUT_ID_WRAP_ETH_AMOUNT, formatAmountFull(availableBalanceInEther), true)}
+            >
+              {formatAmountFull({ amount: availableBalanceInEther, precision: DEFAULT_PRECISION }) || ''} ETH
+            </a>
           </div>
         </div>
         <div>
@@ -293,8 +304,8 @@ const TokenRow: React.FC<Props> = ({
                 autoFocus
                 required
                 ref={register({
-                  pattern: { value: validInputPattern, message: 'Invalid price' },
-                  validate: { positive: validatePositiveConstructor('Invalid price') },
+                  pattern: { value: validInputPattern, message: 'Invalid amount' },
+                  validate: { positive: validatePositiveConstructor('Invalid amount') },
                   required: 'The amount is required',
                   min: 0,
                 })}
@@ -314,9 +325,13 @@ const TokenRow: React.FC<Props> = ({
         label="Continue"
         key="yes"
         isStyleDefault
-        disabled={wrapEtherError}
         onClick={async (): Promise<void> => {
-          alert('Continue!')
+          if (!wrapEtherError) {
+            // TODO: Wrap ether in another PR
+            setTimeout(() => {
+              toggleWrapEtherModal()
+            }, 2000)
+          }
         }}
       />,
     ],

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -6,6 +6,7 @@ import TokenSelector from 'components/TokenSelector'
 import { TokenDetails, TokenBalanceDetails } from 'types'
 import { formatAmount, formatAmountFull, parseAmount, validInputPattern, validatePositiveConstructor } from 'utils'
 import { ZERO } from 'const'
+import Modali, { useModali } from 'modali'
 
 import { TradeFormTokenId, TradeFormData } from './'
 
@@ -209,6 +210,35 @@ const TokenRow: React.FC<Props> = ({
     precision: selectedToken.decimals,
   })
 
+  const [wrapEtherModal, toggleWrapEtherModal] = useModali({
+    centered: true,
+    animated: true,
+    title: 'Wrap Ether',
+    message: (
+      <div>
+        <div>
+          <p>
+            You currently have a pending withdraw request. By sending this new withdraw request, you will overwrite the
+            pending request amount. No funds will be lost.
+          </p>
+          <p>No funds will be lost.</p>
+        </div>
+        <strong>Do you wish to replace the previous withdraw request?</strong>
+      </div>
+    ),
+    buttons: [
+      <Modali.Button label="Cancel" key="no" isStyleCancel onClick={(): void => toggleWrapEtherModal()} />,
+      <Modali.Button
+        label="Continue"
+        key="yes"
+        isStyleDefault
+        onClick={async (): Promise<void> => {
+          alert('Continue!')
+        }}
+      />,
+    ],
+  })
+
   let overMax = ZERO
   if (balance && validateMaxAmount) {
     const max = balance.totalExchangeBalance
@@ -279,6 +309,16 @@ const TokenRow: React.FC<Props> = ({
               + Deposit
             </TooltipWrapper>
           )}
+          {selectedToken.symbol && selectedToken.symbol === 'WETH' && (
+            <TooltipWrapper
+              as="button"
+              type="button"
+              tooltip="Ether needs to be Wrapped and then deposited into the Exchange balance in order to be traded"
+              onClick={toggleWrapEtherModal}
+            >
+              + Wrap Ether
+            </TooltipWrapper>
+          )}
           <span>
             Balance:
             {readOnly ? (
@@ -340,6 +380,7 @@ const TokenRow: React.FC<Props> = ({
         </TokenBoxWrapper>
       </InputBox>
       {errorOrWarning}
+      <Modali.Modal {...wrapEtherModal} />
     </Wrapper>
   )
 }

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -6,7 +6,7 @@ import TokenSelector from 'components/TokenSelector'
 import { TokenDetails, TokenBalanceDetails } from 'types'
 import { formatAmount, formatAmountFull, parseAmount, validInputPattern, validatePositiveConstructor } from 'utils'
 import { ZERO } from 'const'
-import { DEFAULT_MODAL_OPTIONS } from '../Modal'
+import { DEFAULT_MODAL_OPTIONS, ModalBodyWrapper } from '../Modal'
 import Modali, { useModali } from 'modali'
 
 import { TradeFormTokenId, TradeFormData } from './'
@@ -215,7 +215,7 @@ const TokenRow: React.FC<Props> = ({
     ...DEFAULT_MODAL_OPTIONS,
     title: 'Wrap Ether',
     message: (
-      <div>
+      <ModalBodyWrapper>
         <div>
           <p>
             You currently have a pending withdraw request. By sending this new withdraw request, you will overwrite the
@@ -224,7 +224,7 @@ const TokenRow: React.FC<Props> = ({
           <p>No funds will be lost.</p>
         </div>
         <strong>Do you wish to replace the previous withdraw request?</strong>
-      </div>
+      </ModalBodyWrapper>
     ),
     buttons: [
       <Modali.Button label="Cancel" key="no" isStyleCancel onClick={(): void => toggleWrapEtherModal()} />,

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -6,6 +6,7 @@ import TokenSelector from 'components/TokenSelector'
 import { TokenDetails, TokenBalanceDetails } from 'types'
 import { formatAmount, formatAmountFull, parseAmount, validInputPattern, validatePositiveConstructor } from 'utils'
 import { ZERO } from 'const'
+import { DEFAULT_MODAL_OPTIONS } from '../Modal'
 import Modali, { useModali } from 'modali'
 
 import { TradeFormTokenId, TradeFormData } from './'
@@ -211,8 +212,7 @@ const TokenRow: React.FC<Props> = ({
   })
 
   const [wrapEtherModal, toggleWrapEtherModal] = useModali({
-    centered: true,
-    animated: true,
+    ...DEFAULT_MODAL_OPTIONS,
     title: 'Wrap Ether',
     message: (
       <div>


### PR DESCRIPTION
Part of #789

First PR for the Wrap Ether functionality.
Includes:
* The new button to wrap ether
* The modal
* Some basic validation
* Fill the input of the amount when you click your balance

Doesn't include:
* Getting the actual balance
* Wrapping the ether

## Details

If the selected token is Ether, it'll show a new button:
![image](https://user-images.githubusercontent.com/2352112/78139753-48146a00-7429-11ea-8b92-012469f72399.png)

![image](https://user-images.githubusercontent.com/2352112/78139779-519dd200-7429-11ea-908f-89660570eb7e.png)


The button will open the folling modal:

![image](https://user-images.githubusercontent.com/2352112/78139854-69755600-7429-11ea-9688-bd06b61f201f.png)


If clicked the link in the available balance, it'll fill the input with all your balance.