### PR TITLE
Update URL dev portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Develop:
 
 <img align="right" width="350" src="./docs/screenshot.png">
 
-Mesa it's an interface for [Gnosis Protocol](https://docs.gnosis.io/dfusion) (see the [dFusion paper](https://github.com/gnosis/dex-research/blob/master/dFusion/dfusion.v1.pdf)).
+Mesa it's an interface for [Gnosis Protocol](https://docs.gnosis.io/protocol) (see the [dFusion paper](https://github.com/gnosis/dex-research/blob/master/dFusion/dfusion.v1.pdf)).
 
 Gnosis Protocol introduces a new, fully decentralized exchange mechanism for ERC20 tokens with the following
 properties:
@@ -25,7 +25,7 @@ properties:
 
 This UI will allow to:
 
-- Create orders in [Gnosis Protocol](https://docs.gnosis.io/dfusion)
+- Create orders in [Gnosis Protocol](https://docs.gnosis.io/protocol)
 - See the balances for any token: Both in your wallet and the exchange
 - Deposit/Withdraw tokens from the exchange
 

--- a/src/assets/md/FAQ.md
+++ b/src/assets/md/FAQ.md
@@ -1,10 +1,10 @@
 **What is Mesa?**
 
-Mesa is a decentralized application built on the **Gnosis Protocol**, a decentralized trading protocol for ERC-20s. Instead of using one order book per token pair, the Gnosis Protocol relies on batched auctions and a multidimensional orderbook. These mechanisms enable ring trades, in which liquidity amongst all assets tradable on the protocol is shared. Read more about the protocol’s mechanism on the Gnosis [DevPortal](https://docs.gnosis.io/dfusion/docs/introduction1/).
+Mesa is a decentralized application built on the **Gnosis Protocol**, a decentralized trading protocol for ERC-20s. Instead of using one order book per token pair, the Gnosis Protocol relies on batched auctions and a multidimensional orderbook. These mechanisms enable ring trades, in which liquidity amongst all assets tradable on the protocol is shared. Read more about the protocol’s mechanism on the Gnosis [DevPortal](https://docs.gnosis.io/protocol/docs/introduction1/).
 
 **How are trades matched?**
 
-Orders are collected in batches every 5 minutes, and external participants called solvers (everyone can participate as a solver) propose a settlement solution to the smart contract. The smart contract selects the solution that maximizes [trader welfare](https://docs.gnosis.io/dfusion/docs/devguide01/). The utility in this optimization function is the difference between what a trader is willing to pay and what they pay once a batch is cleared. After a solution is selected, orders are matched and settled accordingly and on-chain.
+Orders are collected in batches every 5 minutes, and external participants called solvers (everyone can participate as a solver) propose a settlement solution to the smart contract. The smart contract selects the solution that maximizes [trader welfare](https://docs.gnosis.io/protocol/docs/devguide01/). The utility in this optimization function is the difference between what a trader is willing to pay and what they pay once a batch is cleared. After a solution is selected, orders are matched and settled accordingly and on-chain.
 
 **What advantages does this bring?**
 
@@ -12,7 +12,7 @@ Through this method of order matching, liquidity is shared amongst all assets tr
 
 **Is Gnosis Protocol secure?**
 
-The Gnosis Protocol smart contracts have been audited externally. Check this section on their [DevPortal](https://docs.gnosis.io/dfusion/docs/devguide04/) for further information, including the audit report and the code repository.
+The Gnosis Protocol smart contracts have been audited externally. Check this section on their [DevPortal](https://docs.gnosis.io/protocol/docs/devguide04/) for further information, including the audit report and the code repository.
 
 **How do I trade on Mesa?**
 
@@ -30,7 +30,7 @@ Indeed, orders can be placed without a corresponding balance in the Exchange Wal
 
 Liquidity provision is a way in which Mesa users can easily provide liquidity and get rewarded with little effort and low risk. It works by letting users place standing orders to market-make between selected tokens.
 
-Users select their prefered stablecoin tokens, then define a price difference between \$1.00 and the price at which they would like to sell their tokens, which is called the spread (displayed as a percentage). This will place a set of orders that don’t expire unless they are cancelled These orders are for an unlimited amount, and the protocol will continuously trade between the selected tokens when the orders are matched. In the long run, it is expected, but not guaranteed, that these trades will slowly increment the user’s balances and generate a return. It is important to note that this possibility is[ based on the user’s expectation of the stablecoin to be worth 1USD](https://docs.gnosis.io/dfusion/docs/liquidity1/).
+Users select their prefered stablecoin tokens, then define a price difference between \$1.00 and the price at which they would like to sell their tokens, which is called the spread (displayed as a percentage). This will place a set of orders that don’t expire unless they are cancelled These orders are for an unlimited amount, and the protocol will continuously trade between the selected tokens when the orders are matched. In the long run, it is expected, but not guaranteed, that these trades will slowly increment the user’s balances and generate a return. It is important to note that this possibility is[ based on the user’s expectation of the stablecoin to be worth 1USD](https://docs.gnosis.io/protocol/docs/liquidity1/).
 
 To provide liquidity, click on the `Liquidity` page, and follow three simple steps: select your stablecoin tokens, define your spread, and finally, submit your orders.
 

--- a/src/components/PoolingWidget/StepDescriptors.tsx
+++ b/src/components/PoolingWidget/StepDescriptors.tsx
@@ -38,7 +38,7 @@ export const StepTitle: React.FC<Pick<ProgressBarProps, 'step'>> = ({ step }) =>
                 </li>
               </ul>
               <p>
-                <a href="https://docs.gnosis.io/dfusion/docs/liquidity1" target="_blank" rel="noopener noreferrer">
+                <a href="https://docs.gnosis.io/protocol/docs/liquidity1" target="_blank" rel="noopener noreferrer">
                   Learn more about liquidity provision
                 </a>
               </p>
@@ -63,7 +63,7 @@ export const StepTitle: React.FC<Pick<ProgressBarProps, 'step'>> = ({ step }) =>
                 <b>Only orders that have a deposited balance in the Exchange Wallet will be matched.</b>
               </p>
               <p>
-                <a href="https://docs.gnosis.io/dfusion/docs/liquidity1" target="_blank" rel="noopener noreferrer">
+                <a href="https://docs.gnosis.io/protocol/docs/liquidity1" target="_blank" rel="noopener noreferrer">
                   Learn more about the spread
                 </a>
               </p>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -43,7 +43,7 @@ const About: React.FC = () => {
       <h1>About Mesa</h1>
       <p>
         Mesa it&apos;s an Open Source interface for{' '}
-        <a target="_blank" rel="noopener noreferrer" href="https://docs.gnosis.io/dfusion">
+        <a target="_blank" rel="noopener noreferrer" href="https://docs.gnosis.io/protocol">
           Gnosis Protocol
         </a>
         .<br />
@@ -67,7 +67,7 @@ const About: React.FC = () => {
           <li>Multidimensional order books with ring trades</li>
           <li>Uniform clearing prices in every batch</li>
         </ul>
-        <a target="_blank" rel="noopener noreferrer" href="https://docs.gnosis.io/dfusion">
+        <a target="_blank" rel="noopener noreferrer" href="https://docs.gnosis.io/protocol">
           Read more here
         </a>
       </p>
@@ -117,8 +117,8 @@ const About: React.FC = () => {
         </li>
         <li>
           Developer portal:{' '}
-          <a target="_blank" rel="noopener noreferrer" href="https://docs.gnosis.io/dfusion">
-            https://docs.gnosis.io/dfusion
+          <a target="_blank" rel="noopener noreferrer" href="https://docs.gnosis.io/protocol">
+            https://docs.gnosis.io/protocol
           </a>
         </li>
         <li>


### PR DESCRIPTION
Updates the URL of the dev portal as asked by @c3rnst . 
It changed to https://docs.gnosis.io/protocol