### PR TITLE
Dynamically loading tokens ids, per network, first time getTokens is called

### DIFF
--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -29,6 +29,8 @@ export interface GetTokenIdByAddressParams extends BaseParams {
   tokenAddress: string
 }
 
+export type HasTokenParams = GetTokenIdByAddressParams
+
 interface WithTxOptionalParams {
   txOptionalParams?: TxOptionalParams
 }
@@ -75,6 +77,7 @@ export interface ExchangeApi extends DepositApi {
 
   getTokenAddressById(params: GetTokenAddressByIdParams): Promise<string> // tokenAddressToIdMap
   getTokenIdByAddress(params: GetTokenIdByAddressParams): Promise<number>
+  hasToken(params: HasTokenParams): Promise<boolean>
 
   addToken(params: AddTokenParams): Promise<Receipt>
   placeOrder(params: PlaceOrderParams): Promise<Receipt>
@@ -183,6 +186,11 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     const contract = await this._getContract(networkId)
     const tokenId = await contract.methods.tokenAddressToIdMap(tokenAddress).call()
     return +tokenId
+  }
+
+  public async hasToken({ tokenAddress, networkId }: HasTokenParams): Promise<boolean> {
+    const contract = await this._getContract(networkId)
+    return contract.methods.hasToken(tokenAddress).call()
   }
 
   public async addToken({ userAddress, tokenAddress, networkId, txOptionalParams }: AddTokenParams): Promise<Receipt> {

--- a/src/api/exchange/ExchangeApiMock.ts
+++ b/src/api/exchange/ExchangeApiMock.ts
@@ -20,6 +20,7 @@ import {
   PlaceValidFromOrdersParams,
   GetOrdersPaginatedParams,
   GetOrdersPaginatedResult,
+  HasTokenParams,
 } from './ExchangeApi'
 import { Erc20Api } from 'api/erc20/Erc20Api'
 import { wait } from 'utils'
@@ -106,6 +107,10 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
   public async getTokenIdByAddress({ tokenAddress }: GetTokenIdByAddressParams): Promise<number> {
     assert(typeof this.tokenAddressToId[tokenAddress] === 'number', 'Must have Address to get ID')
     return this.tokenAddressToId[tokenAddress]
+  }
+
+  public async hasToken({ tokenAddress }: HasTokenParams): Promise<boolean> {
+    return !!this.tokenAddressToId[tokenAddress]
   }
 
   public async addToken({ tokenAddress, txOptionalParams }: AddTokenParams): Promise<Receipt> {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -96,14 +96,14 @@ function createExchangeApi(erc20Api: Erc20Api, injectedDependencies: DepositApiD
   return exchangeApi
 }
 
-function createTokenListApi(exchangeApi: ExchangeApi): TokenList {
+function createTokenListApi(): TokenList {
   const networkIds = [Network.Mainnet, Network.Rinkeby]
 
   let tokenListApi: TokenList
   if (process.env.MOCK_TOKEN_LIST === 'true') {
     tokenListApi = new TokenListApiMock(tokenList)
   } else {
-    tokenListApi = new TokenListApiImpl({ networkIds, exchangeApi })
+    tokenListApi = new TokenListApiImpl({ networkIds })
   }
 
   window['tokenListApi'] = tokenListApi // register for convenience
@@ -135,5 +135,5 @@ const injectedDependencies = {
 export const erc20Api: Erc20Api = createErc20Api(injectedDependencies)
 export const depositApi: DepositApi = createDepositApi(erc20Api, injectedDependencies)
 export const exchangeApi: ExchangeApi = createExchangeApi(erc20Api, injectedDependencies)
-export const tokenListApi: TokenList = createTokenListApi(exchangeApi)
+export const tokenListApi: TokenList = createTokenListApi()
 export const theGraphApi: TheGraphApi = createTheGraphApi()

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -96,14 +96,14 @@ function createExchangeApi(erc20Api: Erc20Api, injectedDependencies: DepositApiD
   return exchangeApi
 }
 
-function createTokenListApi(): TokenList {
-  const networks = [Network.Mainnet, Network.Rinkeby]
+function createTokenListApi(exchangeApi: ExchangeApi): TokenList {
+  const networkIds = [Network.Mainnet, Network.Rinkeby]
 
   let tokenListApi: TokenList
   if (process.env.MOCK_TOKEN_LIST === 'true') {
     tokenListApi = new TokenListApiMock(tokenList)
   } else {
-    tokenListApi = new TokenListApiImpl(networks)
+    tokenListApi = new TokenListApiImpl({ networkIds, exchangeApi })
   }
 
   window['tokenListApi'] = tokenListApi // register for convenience
@@ -135,5 +135,5 @@ const injectedDependencies = {
 export const erc20Api: Erc20Api = createErc20Api(injectedDependencies)
 export const depositApi: DepositApi = createDepositApi(erc20Api, injectedDependencies)
 export const exchangeApi: ExchangeApi = createExchangeApi(erc20Api, injectedDependencies)
-export const tokenListApi: TokenList = createTokenListApi()
+export const tokenListApi: TokenList = createTokenListApi(exchangeApi)
 export const theGraphApi: TheGraphApi = createTheGraphApi()

--- a/src/api/tokenList/Subscriptions.ts
+++ b/src/api/tokenList/Subscriptions.ts
@@ -1,6 +1,6 @@
 import { Command } from 'types'
 
-type SubscriptionCallback<T> = (newState: T) => void
+export type SubscriptionCallback<T> = (newState: T) => void
 
 export interface SubscriptionsInterface<State> {
   subscribe(callback: SubscriptionCallback<State>): Command

--- a/src/api/tokenList/TokenListApi.ts
+++ b/src/api/tokenList/TokenListApi.ts
@@ -2,16 +2,16 @@ import { TokenDetails } from 'types'
 import { getTokensByNetwork } from './tokenList'
 import { logDebug } from 'utils'
 import GenericSubscriptions, { SubscriptionsInterface } from './Subscriptions'
-import { ExchangeApi } from 'api/exchange/ExchangeApi'
 
 export interface TokenList extends SubscriptionsInterface<TokenDetails[]> {
   getTokens: (networkId: number) => TokenDetails[]
   addToken: (params: AddTokenParams) => void
   hasToken: (params: HasTokenParams) => boolean
+
+  persistTokens: (params: PersistTokensParams) => void
 }
 
 export interface TokenListApiParams {
-  exchangeApi: ExchangeApi
   networkIds: number[]
 }
 
@@ -25,6 +25,11 @@ export interface HasTokenParams {
   tokenAddress: string
 }
 
+export interface PersistTokensParams {
+  networkId: number
+  tokenList: TokenDetails[]
+}
+
 /**
  * Basic implementation of Token API
  *
@@ -33,18 +38,13 @@ export interface HasTokenParams {
 export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> implements TokenList {
   private _tokensByNetwork: { [networkId: number]: TokenDetails[] }
   private _tokenAddressNetworkSet: Set<string>
-  private updatedIdsForNetwork: Set<number>
-  private exchangeApi: ExchangeApi
 
-  public constructor({ networkIds, exchangeApi }: TokenListApiParams) {
+  public constructor({ networkIds }: TokenListApiParams) {
     super()
-
-    this.exchangeApi = exchangeApi
 
     // Init the tokens by network
     this._tokensByNetwork = {}
     this._tokenAddressNetworkSet = new Set<string>()
-    this.updatedIdsForNetwork = new Set<number>()
 
     networkIds.forEach(networkId => {
       // initial value
@@ -67,11 +67,6 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
   }
 
   public getTokens(networkId: number): TokenDetails[] {
-    if (!this.updatedIdsForNetwork.has(networkId)) {
-      // update token ids from contract if this it has not updated successfully before, async
-      this.updateTokenIds(networkId)
-    }
-
     return this._tokensByNetwork[networkId] || []
   }
 
@@ -123,70 +118,14 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
     localStorage.setItem(storageKey, JSON.stringify(currentUserList))
   }
 
-  private persistTokensForNetwork(networkId: number): void {
+  public persistTokens({ networkId, tokenList }: PersistTokensParams): void {
+    // update copy in memory
+    this._tokensByNetwork[networkId] = tokenList
+    // update copy in local storage
     const storageKey = TokenListApiImpl.getLocalStorageKey(networkId)
-    localStorage.setItem(storageKey, JSON.stringify(this._tokensByNetwork[networkId]))
-  }
-
-  private async getTokenId(networkId: number, tokenAddress: string): Promise<{ value: number | null; remove?: true }> {
-    try {
-      return { value: await this.exchangeApi.getTokenIdByAddress({ networkId, tokenAddress }) }
-    } catch (e) {
-      const value = null
-      if (e.message.match(/Must have Address to get ID/)) {
-        logDebug(
-          `[network:${networkId}][address:${tokenAddress}] Address not registered on network, removing from the list`,
-        )
-        return { value, remove: true }
-      } else {
-        logDebug(`[network:${networkId}][address:${tokenAddress}] Failed to fetch id from contract`, e.message)
-        return { value }
-      }
-    }
-  }
-
-  private async updateTokenIds(networkId: number): Promise<void> {
-    // Set as updated on start to prevent concurrent queries
-    this.updatedIdsForNetwork.add(networkId)
-
-    const promises = this._tokensByNetwork[networkId].map(token => this.getTokenId(networkId, token.address))
-
-    const results = await Promise.all(promises)
-
-    let failedToUpdate = false
-
-    const updatedTokenList = results.reduce(
-      (tokens: TokenDetails[], result: { value: number | null; remove?: true }, index: number) => {
-        if (result.value !== null) {
-          // We got a result, yay
-          const token = this._tokensByNetwork[networkId][index]
-          token.id = result.value
-          tokens.push(token)
-        } else if (!result.remove) {
-          // Failed to query, but don't remove from the list
-          tokens.push(this._tokensByNetwork[networkId][index])
-          // Try again next time
-          // TODO: try again only for the ones that failed
-          failedToUpdate = true
-        }
-        return tokens
-      },
-      [],
-    )
-
-    this._tokensByNetwork[networkId] = updatedTokenList
-
-    // If any token failed, clear flag to try again next time
-    if (failedToUpdate) {
-      this.updatedIdsForNetwork.delete(networkId)
-      // TODO: update only the ones that failed
-    }
-
-    // persist
-    this.persistTokensForNetwork(networkId)
-
-    // update subscribers
-    this.triggerSubscriptions(this._tokensByNetwork[networkId])
+    localStorage.setItem(storageKey, JSON.stringify(tokenList))
+    // notify subscribers
+    this.triggerSubscriptions(tokenList)
   }
 }
 

--- a/src/api/tokenList/TokenListApiMock.ts
+++ b/src/api/tokenList/TokenListApiMock.ts
@@ -1,5 +1,5 @@
 import { TokenDetails } from 'types'
-import { TokenList, AddTokenParams, HasTokenParams } from './TokenListApi'
+import { TokenList, AddTokenParams, HasTokenParams, PersistTokensParams } from './TokenListApi'
 import GenericSubscriptions from './Subscriptions'
 
 export class TokenListApiMock extends GenericSubscriptions<TokenDetails[]> implements TokenList {
@@ -23,6 +23,11 @@ export class TokenListApiMock extends GenericSubscriptions<TokenDetails[]> imple
 
   public hasToken({ tokenAddress }: HasTokenParams): boolean {
     return !!this._tokenList.find(({ address }) => address === tokenAddress)
+  }
+
+  public persistTokens({ tokenList }: PersistTokensParams): void {
+    this._tokenList = tokenList
+    this.triggerSubscriptions(tokenList)
   }
 }
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -97,7 +97,7 @@ export const MEDIA = {
 export const ELLIPSIS = '...'
 // TODO change infuraID for production
 export const INFURA_ID = '8b4d9b4306294d2e92e0775ff1075066'
-export const INITIAL_INFURA_ENDPOINT = `wss://rinkeby.infura.io/ws/v3/${INFURA_ID}`
+export const INITIAL_INFURA_ENDPOINT = `wss://mainnet.infura.io/ws/v3/${INFURA_ID}`
 
 export const STORAGE_KEY_LAST_PROVIDER = 'lastProvider'
 

--- a/src/hooks/useTokenList.ts
+++ b/src/hooks/useTokenList.ts
@@ -1,18 +1,18 @@
 import { useEffect } from 'react'
-import { tokenListApi } from 'api'
 import { TokenDetails } from 'types'
 import useSafeState from './useSafeState'
+import { getTokens, subscribeToTokenList } from 'services'
 
 // for stable reference
 // to avoid updates on setState([])
 const emptyArray: TokenDetails[] = []
 
 export const useTokenList = (networkId?: number): TokenDetails[] => {
-  const [tokens, setTokens] = useSafeState(networkId === undefined ? emptyArray : tokenListApi.getTokens(networkId))
+  const [tokens, setTokens] = useSafeState(networkId === undefined ? emptyArray : getTokens(networkId))
 
   useEffect(() => {
     if (networkId === undefined) return setTokens(emptyArray)
-    return tokenListApi.subscribe(setTokens)
+    return subscribeToTokenList(setTokens)
   }, [networkId, setTokens])
 
   return tokens

--- a/src/services/factories/index.ts
+++ b/src/services/factories/index.ts
@@ -1,3 +1,4 @@
 export * from './addTokenToExchange'
 export * from './getTokenFromExchange'
 export * from './getPriceEstimation'
+export * from './tokenList'

--- a/src/services/factories/tokenList.ts
+++ b/src/services/factories/tokenList.ts
@@ -1,0 +1,88 @@
+import { TokenList } from 'api/tokenList/TokenListApi'
+import { SubscriptionCallback } from 'api/tokenList/Subscriptions'
+import { ExchangeApi } from 'api/exchange/ExchangeApi'
+import { TokenDetails, Command } from 'types'
+import { logDebug } from 'utils'
+
+export function getTokensFactory(factoryParams: {
+  tokenListApi: TokenList
+  exchangeApi: ExchangeApi
+}): (tokenId: number) => TokenDetails[] {
+  const { tokenListApi, exchangeApi } = factoryParams
+
+  const updatedIdsForNetwork = new Set<number>()
+
+  interface GetTokenIdResult {
+    value: number | null
+    remove?: true
+  }
+
+  async function getTokenId(networkId: number, tokenAddress: string): Promise<GetTokenIdResult> {
+    try {
+      return { value: await exchangeApi.getTokenIdByAddress({ networkId, tokenAddress }) }
+    } catch (e) {
+      const value = null
+      if (e.message.match(/Must have Address to get ID/)) {
+        logDebug(
+          `[network:${networkId}][address:${tokenAddress}] Address not registered on network, removing from the list`,
+        )
+        return { value, remove: true }
+      } else {
+        logDebug(`[network:${networkId}][address:${tokenAddress}] Failed to fetch id from contract`, e.message)
+        return { value }
+      }
+    }
+  }
+
+  async function updateTokenIds(networkId: number): Promise<void> {
+    // Set as updated on start to prevent concurrent queries
+    updatedIdsForNetwork.add(networkId)
+
+    const promises = tokenListApi.getTokens(networkId).map(token => getTokenId(networkId, token.address))
+
+    const results = await Promise.all(promises)
+
+    let failedToUpdate = false
+
+    const tokenList = results.reduce((tokens: TokenDetails[], result: GetTokenIdResult, index: number) => {
+      if (result.value !== null) {
+        // We got a result, yay
+        const token = tokenListApi.getTokens(networkId)[index]
+        token.id = result.value
+        tokens.push(token)
+      } else if (!result.remove) {
+        // Failed to query, but don't remove from the list
+        tokens.push(tokenListApi.getTokens(networkId)[index])
+        // Try again next time
+        // TODO: try again only for the ones that failed
+        failedToUpdate = true
+      }
+      return tokens
+    }, [])
+
+    // If any token failed, clear flag to try again next time
+    if (failedToUpdate) {
+      updatedIdsForNetwork.delete(networkId)
+      // TODO: update only the ones that failed
+    }
+
+    // persist
+    tokenListApi.persistTokens({ networkId, tokenList })
+  }
+
+  return function(networkId: number): TokenDetails[] {
+    if (!updatedIdsForNetwork.has(networkId)) {
+      updateTokenIds(networkId)
+    }
+    return tokenListApi.getTokens(networkId)
+  }
+}
+
+export function subscribeToTokenListFactory(factoryParams: {
+  tokenListApi: TokenList
+}): (callback: SubscriptionCallback<TokenDetails[]>) => Command {
+  const { tokenListApi } = factoryParams
+  return function(callback: SubscriptionCallback<TokenDetails[]>): Command {
+    return tokenListApi.subscribe(callback)
+  }
+}

--- a/src/services/factories/tokenList.ts
+++ b/src/services/factories/tokenList.ts
@@ -19,18 +19,14 @@ export function getTokensFactory(factoryParams: {
 
   async function getTokenId(networkId: number, tokenAddress: string): Promise<GetTokenIdResult> {
     try {
+      const hasToken = await exchangeApi.hasToken({ networkId, tokenAddress })
+      if (!hasToken) {
+        return { value: null, remove: true }
+      }
       return { value: await exchangeApi.getTokenIdByAddress({ networkId, tokenAddress }) }
     } catch (e) {
-      const value = null
-      if (e.message.match(/Must have Address to get ID/)) {
-        logDebug(
-          `[network:${networkId}][address:${tokenAddress}] Address not registered on network, removing from the list`,
-        )
-        return { value, remove: true }
-      } else {
-        logDebug(`[network:${networkId}][address:${tokenAddress}] Failed to fetch id from contract`, e.message)
-        return { value }
-      }
+      logDebug(`[network:${networkId}][address:${tokenAddress}] Failed to fetch id from contract`, e.message)
+      return { value: null }
     }
   }
 

--- a/src/services/helpers/getErc20Info.ts
+++ b/src/services/helpers/getErc20Info.ts
@@ -1,21 +1,9 @@
 import Web3 from 'web3'
 
 import { MinimalTokenDetails } from 'types'
-import { logDebug } from 'utils'
+import { logDebug, silentPromise } from 'utils'
 import { DEFAULT_PRECISION } from 'const'
 import { Erc20Api } from 'api/erc20/Erc20Api'
-
-/**
- * Wraps erc20 function and returns undefined in case of failure
- */
-async function wrapPromise<T>(promise: Promise<T>): Promise<T | undefined> {
-  try {
-    return await promise
-  } catch (e) {
-    console.error('[services:helpers:getErc20Info] Failed to get ERC20 detail', e)
-    return
-  }
-}
 
 interface Params {
   tokenAddress: string
@@ -50,11 +38,12 @@ export async function getErc20Info({
     return null
   }
 
+  const errorMsg = '[services:helpers:getErc20Info] Failed to get ERC20 detail'
   // Query for optional details. Do not fail in case any is missing.
   const [symbol, name, decimals] = await Promise.all([
-    wrapPromise(erc20Api.symbol({ tokenAddress, networkId })),
-    wrapPromise(erc20Api.name({ tokenAddress, networkId })),
-    wrapPromise(erc20Api.decimals({ tokenAddress, networkId })),
+    silentPromise(erc20Api.symbol({ tokenAddress, networkId }), errorMsg),
+    silentPromise(erc20Api.name({ tokenAddress, networkId }), errorMsg),
+    silentPromise(erc20Api.decimals({ tokenAddress, networkId }), errorMsg),
   ])
   return { address: tokenAddress, symbol, name, decimals: decimals || DEFAULT_PRECISION }
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -5,7 +5,10 @@ import {
   getTokenFromExchangeByIdFactory,
   addTokenToExchangeFactory,
   getPriceEstimationFactory,
+  subscribeToTokenListFactory,
+  getTokensFactory,
 } from './factories'
+
 import { logDebug } from 'utils'
 import { TokenDetails } from 'types'
 
@@ -24,6 +27,10 @@ export const getTokenFromExchangeById = getTokenFromExchangeByIdFactory(apis)
 export const addTokenToExchangeContract = addTokenToExchangeFactory(apis)
 
 export const getPriceEstimation = getPriceEstimationFactory(apis)
+
+export const subscribeToTokenList = subscribeToTokenListFactory(apis)
+
+export const getTokens = getTokensFactory(apis)
 
 export interface AddTokenToListParams {
   networkId: number

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -81,3 +81,12 @@ export function isOrderFilled(order: AuctionElement): boolean {
   const negligibleAmount = order.priceDenominator.divRound(ORDER_FILLED_FACTOR)
   return !order.remainingAmount.gte(negligibleAmount)
 }
+
+export async function silentPromise<T>(promise: Promise<T>, customMessage?: string): Promise<T | undefined> {
+  try {
+    return await promise
+  } catch (e) {
+    console.error(customMessage || 'Failed to fetch promise', e)
+    return
+  }
+}

--- a/test/api/ExchangeApi/TokenListApiMock.test.ts
+++ b/test/api/ExchangeApi/TokenListApiMock.test.ts
@@ -4,6 +4,8 @@ import TokenListApiMock from 'api/tokenList/TokenListApiMock'
 import { TokenListApiImpl, TokenList } from 'api/tokenList/TokenListApi'
 import { tokenList as testTokenList } from '../../data'
 import SubscriptionBase from 'api/tokenList/Subscriptions'
+import ExchangeApiImpl from 'api/exchange/ExchangeApi'
+import Web3 from 'web3'
 
 class GenericSubscriptions<T> extends SubscriptionBase<T> {
   // expose triggerSubscriptions for testing
@@ -12,12 +14,26 @@ class GenericSubscriptions<T> extends SubscriptionBase<T> {
   }
 }
 
+// Setup to mock exchangeApi
+// Mocking web3
+jest.mock('web3')
+const web3 = new Web3()
+
+// Mocking fetchGasPrice
+const fetchGasPrice = jest.fn(async (): Promise<string | undefined> => undefined)
+
+// Mocking ExchangeApi
+jest.mock('api/exchange/ExchangeApi')
+const exchangeApi = new ExchangeApiImpl({ web3, fetchGasPrice })
+// patching getTokenIdByAddress to always return the same id
+exchangeApi.getTokenIdByAddress = async (_: any): Promise<number> => 87
+
 let instanceMock: TokenList
 let instanceReal: TokenList
 
 beforeEach(() => {
   instanceMock = new TokenListApiMock(testTokenList)
-  instanceReal = new TokenListApiImpl([Network.Mainnet, Network.Rinkeby])
+  instanceReal = new TokenListApiImpl({ networkIds: [Network.Mainnet, Network.Rinkeby], exchangeApi })
 })
 
 const NEW_TOKEN = {
@@ -64,22 +80,29 @@ describe('REAL: Basic functions', () => {
     expect(instanceReal.hasToken({ tokenAddress: tokens[0].address, networkId: 1 })).toBe(true)
   })
   test('API Token list can add tokens', () => {
-    const tokens = instanceReal.getTokens(1)
+    // patching ids, updated async on first getTokens invocation
+    const tokens = instanceReal.getTokens(1).map(t => {
+      t.id = 87
+      return t
+    })
+
     instanceReal.addToken({
       token: NEW_TOKEN,
       networkId: 1,
     })
 
+    const newListOfTokens = tokens.concat(NEW_TOKEN)
+
     expect(instanceReal.hasToken({ tokenAddress: NEW_TOKEN.address, networkId: 1 })).toBe(true)
     expect(instanceReal.getTokens(1)).toHaveLength(tokens.length + 1)
-    expect(instanceReal.getTokens(1)).toEqual(tokens.concat(NEW_TOKEN))
+    expect(instanceReal.getTokens(1)).toEqual(newListOfTokens)
 
     const userListStringified = localStorage.getItem('USER_TOKEN_LIST_1')
     expect(userListStringified).toBeTruthy()
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const userList = JSON.parse(userListStringified!)
-    expect(userList).toEqual([NEW_TOKEN])
+    expect(userList).toEqual(newListOfTokens)
   })
 })
 

--- a/test/api/ExchangeApi/TokenListApiMock.test.ts
+++ b/test/api/ExchangeApi/TokenListApiMock.test.ts
@@ -4,8 +4,6 @@ import TokenListApiMock from 'api/tokenList/TokenListApiMock'
 import { TokenListApiImpl, TokenList } from 'api/tokenList/TokenListApi'
 import { tokenList as testTokenList } from '../../data'
 import SubscriptionBase from 'api/tokenList/Subscriptions'
-import ExchangeApiImpl from 'api/exchange/ExchangeApi'
-import Web3 from 'web3'
 
 class GenericSubscriptions<T> extends SubscriptionBase<T> {
   // expose triggerSubscriptions for testing
@@ -14,26 +12,12 @@ class GenericSubscriptions<T> extends SubscriptionBase<T> {
   }
 }
 
-// Setup to mock exchangeApi
-// Mocking web3
-jest.mock('web3')
-const web3 = new Web3()
-
-// Mocking fetchGasPrice
-const fetchGasPrice = jest.fn(async (): Promise<string | undefined> => undefined)
-
-// Mocking ExchangeApi
-jest.mock('api/exchange/ExchangeApi')
-const exchangeApi = new ExchangeApiImpl({ web3, fetchGasPrice })
-// patching getTokenIdByAddress to always return the same id
-exchangeApi.getTokenIdByAddress = async (_: any): Promise<number> => 87
-
 let instanceMock: TokenList
 let instanceReal: TokenList
 
 beforeEach(() => {
   instanceMock = new TokenListApiMock(testTokenList)
-  instanceReal = new TokenListApiImpl({ networkIds: [Network.Mainnet, Network.Rinkeby], exchangeApi })
+  instanceReal = new TokenListApiImpl({ networkIds: [Network.Mainnet, Network.Rinkeby] })
 })
 
 const NEW_TOKEN = {
@@ -80,29 +64,22 @@ describe('REAL: Basic functions', () => {
     expect(instanceReal.hasToken({ tokenAddress: tokens[0].address, networkId: 1 })).toBe(true)
   })
   test('API Token list can add tokens', () => {
-    // patching ids, updated async on first getTokens invocation
-    const tokens = instanceReal.getTokens(1).map(t => {
-      t.id = 87
-      return t
-    })
-
+    const tokens = instanceReal.getTokens(1)
     instanceReal.addToken({
       token: NEW_TOKEN,
       networkId: 1,
     })
 
-    const newListOfTokens = tokens.concat(NEW_TOKEN)
-
     expect(instanceReal.hasToken({ tokenAddress: NEW_TOKEN.address, networkId: 1 })).toBe(true)
     expect(instanceReal.getTokens(1)).toHaveLength(tokens.length + 1)
-    expect(instanceReal.getTokens(1)).toEqual(newListOfTokens)
+    expect(instanceReal.getTokens(1)).toEqual(tokens.concat(NEW_TOKEN))
 
     const userListStringified = localStorage.getItem('USER_TOKEN_LIST_1')
     expect(userListStringified).toBeTruthy()
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const userList = JSON.parse(userListStringified!)
-    expect(userList).toEqual(newListOfTokens)
+    expect(userList).toEqual([NEW_TOKEN])
   })
 })
 


### PR DESCRIPTION
Part of #467 

See title.

Also, removing tokens which don't exist for given network. Example:

![screenshot_2020-04-02_15-03-02_231436198](https://user-images.githubusercontent.com/43217/78304222-1536a880-74f3-11ea-90be-98191212fc31.png)

Querying sequentially, nice and easy, nothing fancy parallel extra optimized etc.

And, no need for throttle after all...