### PR TITLE
No options message change

### DIFF
--- a/src/components/TokenSelector.tsx
+++ b/src/components/TokenSelector.tsx
@@ -15,6 +15,7 @@ import { useWalletConnection } from 'hooks/useWalletConnection'
 import { tokenListApi } from 'api'
 import Modali from 'modali'
 import { useAddTokenModal } from 'hooks/useAddTokenModal'
+import useSafeState from 'hooks/useSafeState'
 
 const Wrapper = styled.div`
   display: flex;
@@ -301,7 +302,10 @@ const customSelectStyles = {
 
 const components = { MenuList }
 
-const noOptionsMessage = (): string => 'No results'
+const enum NO_OPTIONS_MESSAGE {
+  NO_RESULTS = 'No results',
+  ADD_TOKEN = 'Press Enter to add Token',
+}
 
 interface Props {
   label?: string
@@ -342,6 +346,15 @@ const TokenSelector: React.FC<Props> = ({ isDisabled, tokens, selected, onChange
 
   const addTokenModalOpen = useRef(modalProps.isShown)
   addTokenModalOpen.current = modalProps.isShown
+
+  const [noOptionsMessage, setNoOptionsMessage] = useSafeState(NO_OPTIONS_MESSAGE.NO_RESULTS)
+
+  const onInputChange = useCallback(
+    (value: string) => {
+      setNoOptionsMessage(isAddress(value.toLowerCase()) ? NO_OPTIONS_MESSAGE.ADD_TOKEN : NO_OPTIONS_MESSAGE.NO_RESULTS)
+    },
+    [setNoOptionsMessage],
+  )
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement> & { target: HTMLInputElement }): void => {
@@ -399,7 +412,7 @@ const TokenSelector: React.FC<Props> = ({ isDisabled, tokens, selected, onChange
         styles={customSelectStyles}
         className="tokenSelectBox"
         classNamePrefix="react-select"
-        noOptionsMessage={noOptionsMessage}
+        noOptionsMessage={(): string => noOptionsMessage}
         formatOptionLabel={formatOptionLabel}
         options={options}
         value={{ token: selected }}
@@ -410,6 +423,7 @@ const TokenSelector: React.FC<Props> = ({ isDisabled, tokens, selected, onChange
         menuIsOpen={isFocused || undefined} // set to `true` to make it permanently open and work with styles
         onMenuInputFocus={onMenuInputFocus}
         onKeyDown={onKeyDown}
+        onInputChange={onInputChange}
       />
     </Wrapper>
   )


### PR DESCRIPTION
We can change NoOptionsMessage dynamically to give user hints that a token can be added

![ezgif-4-7a67f43d3fd3](https://user-images.githubusercontent.com/5121491/78361605-585f4d00-75c1-11ea-8859-1e3a1fcdedd4.gif)

Can even do 
![localhost_8080_trade_DAI-USDC_sell=0 price=1 01955 from=0 expires=2880](https://user-images.githubusercontent.com/5121491/78361942-e4717480-75c1-11ea-9b2c-eddc41a85c80.png)
but will be hacky and will have to rewrite `useAddTokenModal` logic a lot
Let's first discuss UX across all ways to add a token
