### PR TITLE
Orders widget - keep order tabs visible

### DIFF
--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -65,6 +65,12 @@ export const ButtonWithIcon = styled.button`
 `
 
 export const OrdersForm = styled.div`
+  > form {
+    display: flex;
+    flex-flow: column nowrap;
+    height: 54rem;
+  }
+
   .infoContainer {
     margin: 1rem auto 0;
     display: flex;
@@ -77,9 +83,6 @@ export const OrdersForm = styled.div`
 
     @media ${MEDIA.mobile} {
       margin: 0 auto;
-    }
-
-    .warning {
     }
 
     .countContainer {
@@ -145,6 +148,7 @@ export const OrdersForm = styled.div`
     display: grid;
     padding: 0 0 5rem;
     box-sizing: border-box;
+    overflow-y: scroll;
   }
 
   .checked {

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -213,7 +213,6 @@ const OrdersPanel = styled.div`
     display: flex;
     flex-flow: row wrap;
     border-radius: 0 0.6rem 0.6rem 0;
-    overflow-y: auto;
 
     @media ${MEDIA.mobile} {
       display: none;


### PR DESCRIPTION
Closes #823 

Changes setup of `overflow-y: scroll` onto `.orderContainer`