### PR TITLE
redirect to https

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -6,7 +6,14 @@
   <base href="/">
   <script>
     (function () {
-      const { pathname, hostname } = window.location
+      const { pathname, hostname, protocol } = window.location
+
+      // redirect to https on non-localhost
+      if (protocol === 'http:' && hostname !== 'localhost') {
+        window.location.protocol = 'https'
+        return
+      }
+
       const ipfsMatch = /.*\/Qm\w{44}/.exec(pathname)
       let arweaveMatch = false
 


### PR DESCRIPTION
Redirects to `https` whether server supports it or not
Reasons for -- some wallets don't work on insecure origins, like Opera wallet and Wallet Connect
Also, `http` is a bad idea in general

Why in `index.html`?
Because should do it as early as possible, before browser starts fetching, every resource will be redownloaded from new origin anyway

Closes #816, closes #828