### PR TITLE
Fix path for to the fileMock in the tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     ],
     "moduleNameMapper": {
       "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test/mocks/fileMock.js",
-      "\\.(css|less)$": "<rootDir>/mocks/fileMock.js"
+      "\\.(css|less)$": "<rootDir>/test/mocks/fileMock.js"
     },
     "globalSetup": "<rootDir>/test/globalSetup.ts"
   },


### PR DESCRIPTION
There's an issue with using CSS in the tests because the path to the mock JS is wrong.

I saw this in other branch, it only broke cause I included modali (which imports CSS) in the row component which that contains tests. I assume we never attempted a import of CSS before in a test :)