### PR TITLE
Token preview for register

### DIFF
--- a/src/api/proxy/SimpleCache.ts
+++ b/src/api/proxy/SimpleCache.ts
@@ -5,7 +5,7 @@ export class SimpleCache<StoredValue, KeyParts> {
   private constructKey: (value: KeyParts) => string
 
   public constructor(
-    keyConstructor: (value: KeyParts) => string = String,
+    keyConstructor: (value: KeyParts) => string = JSON.stringify,
     options: NodeCache.Options = { useClones: false },
   ) {
     this.cache = new NodeCache(options)

--- a/src/components/TokenOptionItem.tsx
+++ b/src/components/TokenOptionItem.tsx
@@ -51,7 +51,7 @@ const OptionItemWrapper = styled.div`
   }
 `
 
-const ExtraOptionsMessage = styled.span`
+const ExtraOptionsMessage = styled.a`
   align-self: flex-end;
 `
 
@@ -244,10 +244,21 @@ export const SearchItem: React.FC<SearchItemProps> = ({ value, defaultText, netw
   switch (reason) {
     // not registered --> advise to register
     case TokenFromExchange.NOT_REGISTERED_ON_CONTRACT:
-      if (!token) return <>Register token on Exchange first</>
+      if (!token)
+        return (
+          <a href="https://docs.gnosis.io/protocol/docs/addtoken5/" rel="noopener noreferrer" target="_blank">
+            Register token on Exchange first
+          </a>
+        )
       return (
         <OptionItem name={token.name} symbol={token.symbol} image={token.image}>
-          <ExtraOptionsMessage>Register token on Exchange first</ExtraOptionsMessage>
+          <ExtraOptionsMessage
+            href="https://docs.gnosis.io/protocol/docs/addtoken5/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Register token on Exchange first
+          </ExtraOptionsMessage>
         </OptionItem>
       )
     // not a ERC20 --> can't do much

--- a/src/components/TokenOptionItem.tsx
+++ b/src/components/TokenOptionItem.tsx
@@ -114,10 +114,12 @@ interface FetchTokenResult {
 
 const fetchToken = async (params: TokenAndNetwork): Promise<FetchTokenResult> => {
   try {
-    // check if registered token
-    const tokenInExchange = await exchangeApi.hasToken(params)
-    // get ERC20 data
-    const erc20Token = await getTokenFromErc20(params)
+    const [tokenInExchange, erc20Token] = await Promise.all([
+      // check if registered token
+      exchangeApi.hasToken(params),
+      // get ERC20 data
+      getTokenFromErc20(params),
+    ])
 
     if (!tokenInExchange)
       return {

--- a/src/components/TokenOptionItem.tsx
+++ b/src/components/TokenOptionItem.tsx
@@ -29,6 +29,9 @@ const OptionItemWrapper = styled.div`
     display: flex;
     justify-content: space-between;
     width: inherit;
+    align-items: center;
+    align-content: center;
+    flex-flow: row wrap;
 
     .tokenName {
       display: flex;
@@ -53,6 +56,10 @@ const OptionItemWrapper = styled.div`
 
 const ExtraOptionsMessage = styled.a`
   align-self: flex-end;
+  margin: auto 0;
+  font-size: 1.3rem;
+  line-height: 1.2;
+  text-align: right;
 `
 
 interface OptionItemProps {

--- a/src/components/TokenOptionItem.tsx
+++ b/src/components/TokenOptionItem.tsx
@@ -51,6 +51,10 @@ const OptionItemWrapper = styled.div`
   }
 `
 
+const ExtraOptionsMessage = styled.span`
+  align-self: flex-end;
+`
+
 interface OptionItemProps {
   image?: string
   name?: string
@@ -240,7 +244,12 @@ export const SearchItem: React.FC<SearchItemProps> = ({ value, defaultText, netw
   switch (reason) {
     // not registered --> advise to register
     case TokenFromExchange.NOT_REGISTERED_ON_CONTRACT:
-      return <>Register token on Exchange first</>
+      if (!token) return <>Register token on Exchange first</>
+      return (
+        <OptionItem name={token.name} symbol={token.symbol} image={token.image}>
+          <ExtraOptionsMessage>Register token on Exchange first</ExtraOptionsMessage>
+        </OptionItem>
+      )
     // not a ERC20 --> can't do much
     case TokenFromExchange.NOT_ERC20:
       return <>Not a valid ERC20 token</>

--- a/src/hooks/useAddTokenModal.tsx
+++ b/src/hooks/useAddTokenModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react'
 import { toChecksumAddress } from 'web3-utils'
 import Modali, { useModali, ModalHook } from 'modali'
-import { AddTokenToListParams, getTokenFromExchangeByAddress } from 'services'
+import { TokenAndNetwork, getTokenFromExchangeByAddress } from 'services'
 import { toast } from 'toastify'
 import { safeFilledToken, logDebug, Deferred, createDeferredPromise } from 'utils'
 import { TokenDetails } from 'types'
@@ -14,7 +14,7 @@ import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { unstable_batchedUpdates as batchUpdates } from 'react-dom'
 
 const addTokenFromInput = async (
-  { networkId, tokenAddress }: AddTokenToListParams,
+  { networkId, tokenAddress }: TokenAndNetwork,
   tokenPromised: Promise<TokenDetails | null>,
 ): Promise<TokenDetails | null> => {
   try {


### PR DESCRIPTION
Try with `0x1d9a3cef66b01d44003b9db0e00ec3fd44746988` on mainnet, for example

![localhost_8080_trade_PAXG-USDC_sell=0 price=1 01377 from=0 expires=2880](https://user-images.githubusercontent.com/5121491/78783273-06953900-79ac-11ea-9a9f-52a398114ccf.png)

I'm not a fan of how `react-select` resets input on `blur, then focus back`, but that's a separate issue