### PR TITLE
Style touch up.

### DIFF
--- a/src/components/TokenOptionItem.tsx
+++ b/src/components/TokenOptionItem.tsx
@@ -29,6 +29,9 @@ const OptionItemWrapper = styled.div`
     display: flex;
     justify-content: space-between;
     width: inherit;
+    align-items: center;
+    align-content: center;
+    flex-flow: row wrap;
 
     .tokenName {
       display: flex;
@@ -53,6 +56,10 @@ const OptionItemWrapper = styled.div`
 
 const ExtraOptionsMessage = styled.a`
   align-self: flex-end;
+  margin: auto 0;
+  font-size: 1.3rem;
+  line-height: 1.2;
+  text-align: right;
 `
 
 interface OptionItemProps {


### PR DESCRIPTION
<img width="539" alt="Screenshot 2020-04-08 at 15 46 51" src="https://user-images.githubusercontent.com/31534717/78791781-9b9a3100-79b0-11ea-8b9b-55093e966334.png">

Minor style touch up.

Noticed an issue, after parsing the custom address, and closing the token selector, some margin/padding seems gone here:
<img width="535" alt="Screenshot 2020-04-08 at 15 48 02" src="https://user-images.githubusercontent.com/31534717/78791836-ac4aa700-79b0-11ea-8a36-9bedc3b7c765.png">
