### PR TITLE
Fix wrong addresses on rinkeby

### DIFF
--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -391,7 +391,12 @@ const TradeWidget: React.FC = () => {
   const { balances, tokens: tokenList } = useTokenBalances()
 
   // If user is connected, use balances, otherwise get the default list
-  const tokens = isConnected && balances.length > 0 ? balances : tokenList
+  const tokens =
+    isConnected && balances.length > 0
+      ? balances
+      : tokenList.length > 0
+      ? tokenList
+      : tokenListApi.getTokens(networkIdOrDefault)
 
   // Listen on manual changes to URL search query
   const { sell: sellTokenSymbol, buy: receiveTokenSymbol } = useParams()

--- a/src/hooks/useTokenBalances.ts
+++ b/src/hooks/useTokenBalances.ts
@@ -114,7 +114,7 @@ export const useTokenBalances = (): UseTokenBalanceResult => {
   const [balances, setBalances] = useSafeState<TokenBalanceDetails[]>([])
   const [error, setError] = useSafeState(false)
 
-  const tokens = useTokenList(walletInfo.networkIdOrDefault)
+  const tokens = useTokenList(walletInfo.networkId)
 
   useEffect(() => {
     // can return NULL (if no address or network)


### PR DESCRIPTION
Can't use `networkIdOrDefault` everywhere after all
Fixes
```
[useTokenBalances] Error for ...
```
on rinkeby