### PR TITLE
Order Book: Show network name for testnets

### DIFF
--- a/src/components/OrderBookBtn.tsx
+++ b/src/components/OrderBookBtn.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components'
 import { DEFAULT_MODAL_OPTIONS, ModalBodyWrapper } from 'components/Modal'
 import Modali, { useModali } from 'modali'
 import OrderBookWidget from './OrderBookWidget'
-import { TokenDetails } from 'types'
+import { TokenDetails, Network } from 'types'
 import { useWalletConnection } from 'hooks/useWalletConnection'
-import { safeTokenName } from '@gnosis.pm/dex-js'
+import { safeTokenName, getNetworkFromId } from '@gnosis.pm/dex-js'
 import TokenSelector from './TokenSelector'
 import useSafeState from 'hooks/useSafeState'
 import { useTokenList } from 'hooks/useTokenList'
@@ -86,11 +86,12 @@ export const OrderBookBtn: React.FC<OrderBookBtnProps> = (props: OrderBookBtnPro
   const tokenList = useTokenList(networkId)
   const [baseToken, setBaseToken] = useSafeState<TokenDetails>(baseTokenDefault)
   const [quoteToken, setQuoteToken] = useSafeState<TokenDetails>(quoteTokenDefault)
+  const networkDescription = networkId !== Network.Mainnet ? ` (${getNetworkFromId(networkId)})` : ''
 
   const [modalHook, toggleModal] = useModali({
     ...DEFAULT_MODAL_OPTIONS,
     large: true,
-    title: `${safeTokenName(baseToken)}-${safeTokenName(quoteToken)} Order book`,
+    title: `${safeTokenName(baseToken)}-${safeTokenName(quoteToken)} Order book${networkDescription}`,
     message: (
       <ModalWrapper>
         <span>

--- a/src/components/OrderBookWidget.tsx
+++ b/src/components/OrderBookWidget.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import styled from 'styled-components'
-import { TokenDetails } from 'types'
+import { TokenDetails, Network } from 'types'
 import * as am4core from '@amcharts/amcharts4/core'
 import * as am4charts from '@amcharts/amcharts4/charts'
 import am4themesSpiritedaway from '@amcharts/amcharts4/themes/spiritedaway'
@@ -121,10 +121,12 @@ const draw = (
   baseToken: TokenDetails,
   quoteToken: TokenDetails,
   dataSource: string,
+  networkId: number,
 ): am4charts.XYChart => {
   am4core.useTheme(am4themesSpiritedaway)
   am4core.options.autoSetClassName = true
   const chart = am4core.create(chartElement, am4charts.XYChart)
+  const networkDescription = networkId !== Network.Mainnet ? `${getNetworkFromId(networkId)} ` : ''
 
   // Add data
   chart.dataSource.url = dataSource
@@ -148,7 +150,7 @@ const draw = (
   // Create axes
   const xAxis = chart.xAxes.push(new am4charts.CategoryAxis())
   xAxis.dataFields.category = 'price'
-  xAxis.title.text = `Price (${baseToken.symbol}/${quoteToken.symbol})`
+  xAxis.title.text = `${networkDescription} Price (${baseToken.symbol}/${quoteToken.symbol})`
 
   const yAxis = chart.yAxes.push(new am4charts.ValueAxis())
   yAxis.title.text = 'Volume'
@@ -199,8 +201,13 @@ const OrderBookWidget: React.FC<OrderBookProps> = props => {
 
   useEffect(() => {
     if (!mountPoint.current) return
-
-    const chart = draw(mountPoint.current, baseToken, quoteToken, orderbookUrl(baseToken, quoteToken, networkId))
+    const chart = draw(
+      mountPoint.current,
+      baseToken,
+      quoteToken,
+      orderbookUrl(baseToken, quoteToken, networkId),
+      networkId,
+    )
 
     return (): void => chart.dispose()
   }, [baseToken, quoteToken, networkId])


### PR DESCRIPTION
I left this commit/branch unpushed, pushing now :) 

Mainnet:
![image](https://user-images.githubusercontent.com/2352112/79117948-c9a2bb00-7d8c-11ea-9c7d-7eeb2bf3669b.png)


Rinkeby:
![image](https://user-images.githubusercontent.com/2352112/79117911-b0017380-7d8c-11ea-904a-942c0fac1400.png)


If you are in a testnet (Rinkeby) and you are not very aware, the Order Book can be weird, because it uses the data from the smart contract in that network.

To make it more clear, I just show the name of the testnet if we are in a testnet, otherwise I don't show the name of the network (implying mainnet)