### PR TITLE
Fix 875 token address on rinkeby

### DIFF
--- a/src/api/wallet/WalletApi.ts
+++ b/src/api/wallet/WalletApi.ts
@@ -147,8 +147,12 @@ const subscribeToBlockchainUpdate = ({
       callback(blockchainPrompt)
     })
 
-    const unsubBlock = blockUpdate(blockHeader => {
-      blockchainPrompt = { ...blockchainPrompt, blockHeader }
+    const unsubBlock = blockUpdate(async blockHeader => {
+      // oftentimes on network change newBlockHeaders fires first
+      // reaffirm correct id
+      const chainId = await web3.eth.net.getId()
+
+      blockchainPrompt = { ...blockchainPrompt, blockHeader, chainId }
       logDebug('[WalletApiImpl] block changed:', blockHeader.number)
       callback(blockchainPrompt)
     })

--- a/src/api/wallet/WalletApi.ts
+++ b/src/api/wallet/WalletApi.ts
@@ -393,12 +393,31 @@ export class WalletApiImpl implements WalletApi {
   }
 
   private async _notifyListeners(blockchainUpdate?: BlockchainUpdatePrompt): Promise<void> {
-    if (blockchainUpdate) this.blockchainState = blockchainUpdate
+    let chainIdChanged = false
+    if (blockchainUpdate) {
+      chainIdChanged = this.blockchainState.chainId !== blockchainUpdate.chainId
+      this.blockchainState = blockchainUpdate
+    }
 
     await Promise.resolve()
 
     const walletInfo = await (this.getWalletInfo() || this._getAsyncWalletInfo())
     const wInfoExtended = { ...walletInfo, blockNumber: blockchainUpdate?.blockHeader?.number }
+
+    if (
+      // listeners called because of blockchain update
+      blockchainUpdate &&
+      // networkId is defined and not 0, meaning there's no connection lost
+      wInfoExtended.networkId &&
+      // but chainId from blockchain update is different
+      wInfoExtended.networkId !== blockchainUpdate.chainId &&
+      // and that chainId just changed
+      chainIdChanged
+    ) {
+      // then consider blockchainUpdate.chainId a fresher value
+      wInfoExtended.networkId = blockchainUpdate.chainId
+      logDebug('[WalletApiImpl] chainId changed:', blockchainUpdate.chainId)
+    }
 
     this._listeners.forEach(listener => listener(wInfoExtended))
   }

--- a/src/hooks/useTokenList.ts
+++ b/src/hooks/useTokenList.ts
@@ -16,7 +16,7 @@ export const useTokenList = (networkId?: number): TokenDetails[] => {
 
   useEffect(() => {
     return subscribeToTokenList(() => forceUpdate({}))
-  }, [networkId, forceUpdate])
+  }, [forceUpdate])
 
   return tokens
 }

--- a/src/hooks/useTokenList.ts
+++ b/src/hooks/useTokenList.ts
@@ -8,12 +8,16 @@ import { getTokens, subscribeToTokenList } from 'services'
 const emptyArray: TokenDetails[] = []
 
 export const useTokenList = (networkId?: number): TokenDetails[] => {
-  const [tokens, setTokens] = useSafeState(networkId === undefined ? emptyArray : getTokens(networkId))
+  // sync get tokenList
+  const tokens = networkId === undefined ? emptyArray : getTokens(networkId)
+
+  // force update with a new value each time
+  const [, forceUpdate] = useSafeState({})
 
   useEffect(() => {
-    if (networkId === undefined) return setTokens(emptyArray)
-    return subscribeToTokenList(setTokens)
-  }, [networkId, setTokens])
+    // if (networkId === undefined) return setTokens(emptyArray)
+    return subscribeToTokenList(() => forceUpdate({}))
+  }, [networkId, forceUpdate])
 
   return tokens
 }

--- a/src/hooks/useTokenList.ts
+++ b/src/hooks/useTokenList.ts
@@ -15,7 +15,6 @@ export const useTokenList = (networkId?: number): TokenDetails[] => {
   const [, forceUpdate] = useSafeState({})
 
   useEffect(() => {
-    // if (networkId === undefined) return setTokens(emptyArray)
     return subscribeToTokenList(() => forceUpdate({}))
   }, [networkId, forceUpdate])
 


### PR DESCRIPTION
Even after numerous workarounds by me and @alfetopito  the problem remained
Problem is stemming from the fact that oftentimes on network change `newBlockHeaders` fires first, before `onNetworkChanged`. Sync nature of `useTokenList` didn't help either.
So we get stale network in `WalletInfo`

This solution is hacky, but so is the problem