### PR TITLE
Remove tooltip in trade widget

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components'
+
+export const Input = styled.input<{ $error?: boolean }>`
+  ${({ $error }): string | undefined | false =>
+    $error &&
+    `
+    box-shadow: 0px 0px 0px 2px var(--color-error);
+    color: var(--color-error) !important;
+  `}
+
+  transition: all 0.15s ease-in-out;
+  &:focus {
+    ${({ $error }): string | undefined | false => $error && 'border-color: var(--color-error) !important;'}
+    box-shadow: none;
+    color: initial;
+  }
+`

--- a/src/components/InputWithTooltip.tsx
+++ b/src/components/InputWithTooltip.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useMemo } from 'react'
 import { usePopperDefault } from 'hooks/usePopper'
 import { Placement } from '@popperjs/core'
 import { Tooltip } from 'components/Tooltip'
-import styled from 'styled-components'
+import { Input } from 'components/Input'
 
 interface InputProps extends Partial<React.ComponentPropsWithRef<'input'>> {
   tooltip: ReactNode
@@ -15,22 +15,6 @@ type TargetProps = Pick<
   React.ComponentPropsWithRef<'input'>,
   'onBlur' | 'onFocus' | 'onMouseEnter' | 'onMouseLeave' | 'ref'
 >
-
-const Input = styled.input<{ $error?: boolean }>`
-  ${({ $error }): string | undefined | false =>
-    $error &&
-    `
-    box-shadow: 0px 0px 0px 2px var(--color-error);
-    color: var(--color-error) !important;
-  `}
-
-  transition: all 0.15s ease-in-out;
-  &:focus {
-    ${({ $error }): string | undefined | false => $error && 'border-color: var(--color-error) !important;'}
-    box-shadow: none;
-    color: initial;
-  }
-`
 
 const InputWithTooltip: React.RefForwardingComponent<HTMLInputElement, InputProps> = (
   { tooltip, tooltipBgColor, placement, onFocus, onBlur, onMouseEnter, onMouseLeave, showErrorStyle, ...props },

--- a/src/components/PoolingWidget/DefineSpread.tsx
+++ b/src/components/PoolingWidget/DefineSpread.tsx
@@ -2,11 +2,10 @@ import React from 'react'
 
 import { DefineSpreadWrapper } from './DefineSpread.styled'
 
-import InputWithTooltip from '../InputWithTooltip'
-
 import { useFormContext, FieldError } from 'react-hook-form'
 import { FormInputError } from 'components/TradeWidget/FormMessage'
 import { HelpTooltipContainer, HelpTooltip } from 'components/Tooltip'
+import { Input } from 'components/Input'
 
 interface DefineSpreadProps {
   isSubmitting: boolean
@@ -33,14 +32,13 @@ const DefineSpread: React.FC<DefineSpreadProps> = ({ isSubmitting }) => {
         <small>percentage you want to sell above $1, and buy below $1 between all selected tokens</small>{' '}
         <HelpTooltip tooltip={SpreadTooltip} />
       </p>
-      <InputWithTooltip
+      <Input
         className={errorMessage ? 'error' : ''}
         name="spread"
         type="number"
         step="0.1"
         disabled={isSubmitting}
         ref={register}
-        tooltip="Value between 0 and 100, not inclusive"
       />
       <FormInputError errorMessage={errorMessage} />
     </DefineSpreadWrapper>

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -13,7 +13,7 @@ import { TradeFormTokenId, TradeFormData } from './'
 import { TooltipWrapper, HelpTooltipContainer, HelpTooltip } from 'components/Tooltip'
 import FormMessage, { FormInputError } from './FormMessage'
 import { useNumberInput } from './useNumberInput'
-import InputWithTooltip from '../InputWithTooltip'
+import { Input } from 'components/Input'
 import { MEDIA, WETH_ADDRESS_MAINNET } from 'const'
 import { WrapEtherBtn } from 'components/WrapEtherBtn'
 import { Link } from 'react-router-dom'
@@ -130,7 +130,6 @@ interface Props {
   validateMaxAmount?: true
   tabIndex: number
   readOnly: boolean
-  tooltipText: string
   autoFocus?: boolean
 }
 
@@ -152,7 +151,6 @@ const TokenRow: React.FC<Props> = ({
   validateMaxAmount,
   tabIndex,
   readOnly = false,
-  tooltipText,
   autoFocus,
 }) => {
   const isEditable = isDisabled || readOnly
@@ -265,10 +263,9 @@ const TokenRow: React.FC<Props> = ({
         </span>
       </div>
       <InputBox>
-        <InputWithTooltip
+        <Input
           autoFocus={!readOnly && autoFocus}
           className={inputClassName}
-          tooltip={tooltipText}
           placeholder="0"
           name={inputId}
           type="text"

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -329,21 +329,6 @@ export const DEFAULT_FORM_STATE = {
   validUntil: '2880',
 }
 
-function _getReceiveTokenTooltipText(sellValue: string, receiveValue: string): string {
-  const sellAmount = parseBigNumber(sellValue)
-
-  if (!sellAmount || sellAmount.isZero()) {
-    return 'First input the sell amount'
-  }
-
-  const receiveAmount = parseBigNumber(receiveValue)
-  if (!receiveAmount || receiveAmount.isZero()) {
-    return 'Input the price to get the receive tokens'
-  } else {
-    return 'Minimum amount of tokens you will receive if the order is fully executed at the given price'
-  }
-}
-
 function calculateReceiveAmount(priceValue: string, sellValue: string): string {
   let receiveAmount = ''
   if (priceValue && sellValue) {
@@ -457,7 +442,6 @@ const TradeWidget: React.FC = () => {
   const priceValue = watch(priceInputId)
   const priceInverseValue = watch(priceInverseInputId)
   const sellValue = watch(sellInputId)
-  const receiveValue = watch(receiveInputId)
   const validFromValue = watch(validFromId)
   const validUntilValue = watch(validUntilId)
 
@@ -778,11 +762,6 @@ const TradeWidget: React.FC = () => {
     }
   }
 
-  const receiveTokenTooltipText = useMemo(() => _getReceiveTokenTooltipText(sellValue, receiveValue), [
-    sellValue,
-    receiveValue,
-  ])
-
   const { needToAddSellToken, needToAddReceiveToken } = useMemo(() => {
     const needToAddSellToken =
       sellTokenSymbol &&
@@ -837,7 +816,6 @@ const TradeWidget: React.FC = () => {
             validateMaxAmount
             tabIndex={1}
             readOnly={false}
-            tooltipText="Maximum amount of tokens you want to sell"
           />
           <IconWrapper onClick={swapTokens}>
             <SwitcherSVG />
@@ -852,7 +830,6 @@ const TradeWidget: React.FC = () => {
             isDisabled={isSubmitting}
             tabIndex={1}
             readOnly
-            tooltipText={receiveTokenTooltipText}
           />
           <Price
             priceInputId={priceInputId}


### PR DESCRIPTION
We agreed on removing the tooltips for the trade widget, they are too intrusive

This PR:
* [X]  Removes the tooltips for sell token and buy token in the trade widget
* [X] Removes the tooltip in the spread of the liquidity page
* [X] Extract the styled component `Input` from component `InputWithTooltip.tsx`. The idea is to have our own custom input instead of styling it everty time. In the future, maybe we want to implement some features in the input too, but for now is good enough to promote it to "Component