### PR TITLE
Volume: Leave only accumulated volume in the tooltip

### DIFF
--- a/src/components/OrderBookWidget.tsx
+++ b/src/components/OrderBookWidget.tsx
@@ -164,7 +164,7 @@ const draw = (
   bidCurve.fill = bidCurve.stroke
   bidCurve.startLocation = 0.5
   bidCurve.fillOpacity = 0.1
-  bidCurve.tooltipText = 'Bid: [bold]{categoryX}[/]\nTotal volume: [bold]{totalVolume}[/]\nVolume: [bold]{volume}[/]'
+  bidCurve.tooltipText = 'Bid: [bold]{categoryX}[/]\nVolume: [bold]{totalVolume}[/]'
 
   const askCurve = chart.series.push(new am4charts.StepLineSeries())
   askCurve.dataFields.categoryX = 'price'
@@ -174,7 +174,7 @@ const draw = (
   askCurve.fill = askCurve.stroke
   askCurve.fillOpacity = 0.1
   askCurve.startLocation = 0.5
-  askCurve.tooltipText = 'Ask: [bold]{categoryX}[/]\nTotal volume: [bold]{totalVolume}[/]\nVolume: [bold]{volume}[/]'
+  askCurve.tooltipText = 'Ask: [bold]{categoryX}[/]\nVolume: [bold]{totalVolume}[/]'
 
   const series3 = chart.series.push(new am4charts.ColumnSeries())
   series3.dataFields.categoryX = 'price'

--- a/src/components/OrderBookWidget.tsx
+++ b/src/components/OrderBookWidget.tsx
@@ -177,20 +177,6 @@ const draw = (
   askCurve.startLocation = 0.5
   askCurve.tooltipText = `Ask: [bold]{categoryX}[/]\nVolume: [bold]{totalVolume} ${baseTokenLabel}[/]`
 
-  const series3 = chart.series.push(new am4charts.ColumnSeries())
-  series3.dataFields.categoryX = 'price'
-  series3.dataFields.valueY = 'bidValueY'
-  series3.strokeWidth = 0
-  series3.fill = am4core.color(colors.green)
-  series3.fillOpacity = 0.2
-
-  const series4 = chart.series.push(new am4charts.ColumnSeries())
-  series4.dataFields.categoryX = 'price'
-  series4.dataFields.valueY = 'askValueY'
-  series4.strokeWidth = 0
-  series4.fill = am4core.color(colors.red)
-  series4.fillOpacity = 0.2
-
   // Add cursor
   chart.cursor = new am4charts.XYCursor()
   return chart

--- a/src/components/OrderBookWidget.tsx
+++ b/src/components/OrderBookWidget.tsx
@@ -4,7 +4,7 @@ import { TokenDetails, Network } from 'types'
 import * as am4core from '@amcharts/amcharts4/core'
 import * as am4charts from '@amcharts/amcharts4/charts'
 import am4themesSpiritedaway from '@amcharts/amcharts4/themes/spiritedaway'
-import { getNetworkFromId } from '@gnosis.pm/dex-js'
+import { getNetworkFromId, safeTokenName } from '@gnosis.pm/dex-js'
 
 interface OrderBookProps {
   baseToken: TokenDetails
@@ -123,6 +123,7 @@ const draw = (
   dataSource: string,
   networkId: number,
 ): am4charts.XYChart => {
+  const baseTokenLabel = safeTokenName(baseToken)
   am4core.useTheme(am4themesSpiritedaway)
   am4core.options.autoSetClassName = true
   const chart = am4core.create(chartElement, am4charts.XYChart)
@@ -164,7 +165,7 @@ const draw = (
   bidCurve.fill = bidCurve.stroke
   bidCurve.startLocation = 0.5
   bidCurve.fillOpacity = 0.1
-  bidCurve.tooltipText = 'Bid: [bold]{categoryX}[/]\nVolume: [bold]{totalVolume}[/]'
+  bidCurve.tooltipText = `Bid: [bold]{categoryX}[/]\nVolume: [bold]{totalVolume} ${baseTokenLabel}[/]`
 
   const askCurve = chart.series.push(new am4charts.StepLineSeries())
   askCurve.dataFields.categoryX = 'price'
@@ -174,7 +175,7 @@ const draw = (
   askCurve.fill = askCurve.stroke
   askCurve.fillOpacity = 0.1
   askCurve.startLocation = 0.5
-  askCurve.tooltipText = 'Ask: [bold]{categoryX}[/]\nVolume: [bold]{totalVolume}[/]'
+  askCurve.tooltipText = `Ask: [bold]{categoryX}[/]\nVolume: [bold]{totalVolume} ${baseTokenLabel}[/]`
 
   const series3 = chart.series.push(new am4charts.ColumnSeries())
   series3.dataFields.categoryX = 'price'
@@ -214,7 +215,8 @@ const OrderBookWidget: React.FC<OrderBookProps> = props => {
 
   return (
     <Wrapper ref={mountPoint}>
-      Show order book for token {baseToken.symbol} ({baseToken.id}) and {quoteToken.symbol} ({quoteToken.id})
+      Show order book for token {safeTokenName(baseToken)} ({baseToken.id}) and {safeTokenName(baseToken)} (
+      {quoteToken.id})
     </Wrapper>
   )
 }


### PR DESCRIPTION
The current order book looks like this:
![image](https://user-images.githubusercontent.com/2352112/79223343-70548d80-7e59-11ea-9bd8-f14900ae669c.png)


This PR is a proposal to remove the "Volume" and just show the "Accumulated volume" like in this picture:
![image](https://user-images.githubusercontent.com/2352112/79223026-e0164880-7e58-11ea-8999-1c94fd78a0b3.png)

The "plain Volume" is the sum of orders at that price point (not the sum of that price point and all better price points). Imo, the "plain volume" is not super relevant and make the UX more confusing. It was very confusing for me that the "Volume" was not a monotonous function, so you could see that even if you go left in the bids, the volume can decrease. 

As a user, I'd be interested to get how much I can sell for a give price. So my understanding is that I only need the accumulated volume, that in this PR is renamed as just "Volume"

Additionally, as it can also be seen in the picture, this PR adds the currency for the volume. 
Units can always be confusing, because although normally the base token is used to measure the volume, in a market like ETHUSD, normally the volumes are given in USD, so not sure if an user might expect ETHUSDC to have the volumes expressed in USDC. In any case, adding units, makes it more clear.

Lastly, in this PR, I make use of the function `safeTokenName` since we cannot assume the token will have a symbol.