### PR TITLE
Force resfresh on batch time

### DIFF
--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -137,7 +137,6 @@ export function useOrders(): Result {
   }, [forceOrdersRefresh])
 
   useCheckWhenTimeRemainingInBatch(REFRESH_WHEN_SECONDS_LEFT, forceRefreshUnlessOnMount)
-  useCheckWhenTimeRemainingInBatch(REFRESH_WHEN_SECONDS_LEFT, v => console.log('CHECK:', v, runEffect.current))
 
   useEffect(() => {
     if (!runEffect.current) {

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -40,6 +40,9 @@ function filterDeletedOrders(orders: AuctionElement[]): AuctionElement[] {
   )
 }
 
+const REFRESH_WHEN_SECONDS_LEFT = 60 // 1min before batch done
+// solutions submitted at this point
+
 export function useOrders(): Result {
   const { userAddress, networkId, blockNumber } = useWalletConnection()
   const [
@@ -133,8 +136,8 @@ export function useOrders(): Result {
     if (runEffect.current) forceOrdersRefresh()
   }, [forceOrdersRefresh])
 
-  useCheckWhenTimeRemainingInBatch(60, forceRefreshUnlessOnMount)
-  useCheckWhenTimeRemainingInBatch(60, v => console.log('CHECK:', v, runEffect.current))
+  useCheckWhenTimeRemainingInBatch(REFRESH_WHEN_SECONDS_LEFT, forceRefreshUnlessOnMount)
+  useCheckWhenTimeRemainingInBatch(REFRESH_WHEN_SECONDS_LEFT, v => console.log('CHECK:', v, runEffect.current))
 
   useEffect(() => {
     if (!runEffect.current) {

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -10,6 +10,7 @@ import useSafeState from './useSafeState'
 import { exchangeApi } from 'api'
 import { AuctionElement } from 'api/exchange/ExchangeApi'
 import { ZERO } from 'const'
+import { useCheckWhenTimeRemainingInBatch } from './useTimeRemainingInBatch'
 
 interface Result {
   orders: AuctionElement[]
@@ -125,6 +126,15 @@ export function useOrders(): Result {
   }, [dispatch, setIsLoading])
 
   const runEffect = useRef(false)
+
+  const forceRefreshUnlessOnMount = useCallback(() => {
+    // don't refresh when first mounted
+    // fetchOrders already runs onMount
+    if (runEffect.current) forceOrdersRefresh()
+  }, [forceOrdersRefresh])
+
+  useCheckWhenTimeRemainingInBatch(60, forceRefreshUnlessOnMount)
+  useCheckWhenTimeRemainingInBatch(60, v => console.log('CHECK:', v, runEffect.current))
 
   useEffect(() => {
     if (!runEffect.current) {

--- a/src/hooks/useTimeRemainingInBatch.ts
+++ b/src/hooks/useTimeRemainingInBatch.ts
@@ -49,7 +49,6 @@ export function useCheckWhenTimeRemainingInBatch(
     let id: number
 
     if (currentCheck.checkTime) {
-      // setCheckResult(currentCheck)
       callbackRef.current(currentCheck)
     }
 

--- a/src/hooks/useTimeRemainingInBatch.ts
+++ b/src/hooks/useTimeRemainingInBatch.ts
@@ -52,7 +52,7 @@ export function useCheckWhenTimeRemainingInBatch(
       callbackRef.current(currentCheck)
     }
 
-    // const nextCheckInSeconds = currentCheck.secondsRemaining + checkIntervalSeconds
+
     // first check on timeout not interval
     // as we start at random time in the BATCH
     const nextCheckInSeconds =
@@ -69,7 +69,7 @@ export function useCheckWhenTimeRemainingInBatch(
     }
 
     id = window.setTimeout(() => {
-      // not can go on interval
+      // now can go on interval
       id = window.setInterval(checkAndReport, BATCH_TIME * 1000)
 
       checkAndReport()

--- a/src/hooks/useTimeRemainingInBatch.ts
+++ b/src/hooks/useTimeRemainingInBatch.ts
@@ -70,7 +70,7 @@ export function useCheckWhenTimeRemainingInBatch(
 
     id = window.setTimeout(() => {
       // not can go on interval
-      id = window.setInterval(checkAndReport, checkIntervalSeconds * 1000)
+      id = window.setInterval(checkAndReport, BATCH_TIME * 1000)
 
       checkAndReport()
     }, nextCheckInSeconds * 1000)

--- a/src/hooks/useTimeRemainingInBatch.ts
+++ b/src/hooks/useTimeRemainingInBatch.ts
@@ -39,8 +39,8 @@ export function useCheckWhenTimeRemainingInBatch(
   useEffect(() => {
     // how often to check
     // when there are ${seconds} seconds left in the batch
-    const checkIntervalSeconds = BATCH_TIME - seconds
-    if (checkIntervalSeconds <= 0) {
+    const checkSecondsFromBatchStart = BATCH_TIME - seconds
+    if (checkSecondsFromBatchStart <= 0) {
       console.warn(`seconds given ${seconds} > BATCH_TIME ${BATCH_TIME}`)
       return
     }
@@ -58,7 +58,7 @@ export function useCheckWhenTimeRemainingInBatch(
     const nextCheckInSeconds =
       (currentCheck.checkTime
         ? //  if currently past check time -- interval + seconds remaining in BATCH
-          currentCheck.secondsRemaining + checkIntervalSeconds
+          currentCheck.secondsRemaining + checkSecondsFromBatchStart
         : // if not yet check time -- what's left to that time
           currentCheck.secondsRemaining - seconds) + 1 // plus one second
     // because condition in contract is >= 1 minutes and we check for <

--- a/src/hooks/useTimeRemainingInBatch.ts
+++ b/src/hooks/useTimeRemainingInBatch.ts
@@ -22,7 +22,6 @@ interface SecondsRemainingResult {
 
 const checkIfTime = (seconds: number): SecondsRemainingResult => {
   const secondsRemaining = getSecondsRemainingInBatch()
-  console.log('CHECK:secondsRemaining', secondsRemaining)
   return {
     secondsRemaining,
     checkTime: secondsRemaining < seconds,
@@ -54,8 +53,6 @@ export function useCheckWhenTimeRemainingInBatch(
       callbackRef.current(currentCheck)
     }
 
-    console.log('CHECK:checkIntervalSeconds', checkIntervalSeconds)
-
     // const nextCheckInSeconds = currentCheck.secondsRemaining + checkIntervalSeconds
     // first check on timeout not interval
     // as we start at random time in the BATCH
@@ -67,8 +64,6 @@ export function useCheckWhenTimeRemainingInBatch(
           currentCheck.secondsRemaining - seconds) + 1 // plus one second
     // because condition in contract is >= 1 minutes and we check for <
     // so we don't fall on the exact second and query blockchain
-    console.log('CHECK:check again in', nextCheckInSeconds)
-
     const checkAndReport = (): void => {
       const currentCheck = checkIfTime(seconds)
       callbackRef.current(currentCheck)

--- a/src/hooks/useTimeRemainingInBatch.ts
+++ b/src/hooks/useTimeRemainingInBatch.ts
@@ -1,6 +1,7 @@
 import useSafeState from './useSafeState'
 import { getSecondsRemainingInBatch } from 'utils'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
+import { BATCH_TIME } from 'const'
 
 export function useTimeRemainingInBatch(): number {
   const [timeRemaining, setTimeRemaining] = useSafeState(getSecondsRemainingInBatch())
@@ -12,4 +13,76 @@ export function useTimeRemainingInBatch(): number {
   }, [setTimeRemaining])
 
   return timeRemaining
+}
+
+interface SecondsRemainingResult {
+  secondsRemaining: number
+  checkTime: boolean
+}
+
+const checkIfTime = (seconds: number): SecondsRemainingResult => {
+  const secondsRemaining = getSecondsRemainingInBatch()
+  console.log('CHECK:secondsRemaining', secondsRemaining)
+  return {
+    secondsRemaining,
+    checkTime: secondsRemaining < seconds,
+  }
+}
+
+export function useCheckWhenTimeRemainingInBatch(
+  seconds: number,
+  callback: (SResult: SecondsRemainingResult) => void,
+): void {
+  // allow for fluid callback change without resetting interval
+  const callbackRef = useRef(callback)
+  callbackRef.current = callback
+
+  useEffect(() => {
+    // how often to check
+    // when there are ${seconds} seconds left in the batch
+    const checkIntervalSeconds = BATCH_TIME - seconds
+    if (checkIntervalSeconds <= 0) {
+      console.warn(`seconds given ${seconds} > BATCH_TIME ${BATCH_TIME}`)
+      return
+    }
+
+    const currentCheck = checkIfTime(seconds)
+    let id: number
+
+    if (currentCheck.checkTime) {
+      // setCheckResult(currentCheck)
+      callbackRef.current(currentCheck)
+    }
+
+    console.log('CHECK:checkIntervalSeconds', checkIntervalSeconds)
+
+    // const nextCheckInSeconds = currentCheck.secondsRemaining + checkIntervalSeconds
+    // first check on timeout not interval
+    // as we start at random time in the BATCH
+    const nextCheckInSeconds =
+      (currentCheck.checkTime
+        ? //  if currently past check time -- interval + seconds remaining in BATCH
+          currentCheck.secondsRemaining + checkIntervalSeconds
+        : // if not yet check time -- what's left to that time
+          currentCheck.secondsRemaining - seconds) + 1 // plus one second
+    // because condition in contract is >= 1 minutes and we check for <
+    // so we don't fall on the exact second and query blockchain
+    console.log('CHECK:check again in', nextCheckInSeconds)
+
+    const checkAndReport = (): void => {
+      const currentCheck = checkIfTime(seconds)
+      callbackRef.current(currentCheck)
+    }
+
+    id = window.setTimeout(() => {
+      // not can go on interval
+      id = window.setInterval(checkAndReport, checkIntervalSeconds * 1000)
+
+      checkAndReport()
+    }, nextCheckInSeconds * 1000)
+
+    return (): void => {
+      clearInterval(id)
+    }
+  }, [seconds])
 }


### PR DESCRIPTION
Fixes #909 (more of a workaround than a fix)

Causes rerenders only when needed
Doesn't check on every second but rather being smart about initial timeout + intervals

To test revert a369fb5 with helpful logs still included