### PR TITLE
918/url encode token symbols

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/react-fontawesome": "^0.1.8",
     "@gnosis.pm/dapp-ui": "^0.5.3",
-    "@gnosis.pm/dex-js": "0.2.2",
+    "@gnosis.pm/dex-js": "0.2.3-RC.0",
     "@hapi/joi": "^17.1.1",
     "@hot-loader/react-dom": "^16.11.0",
     "@popperjs/core": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/react-fontawesome": "^0.1.8",
     "@gnosis.pm/dapp-ui": "^0.5.3",
-    "@gnosis.pm/dex-js": "0.2.3-RC.0",
+    "@gnosis.pm/dex-js": "0.2.3-RC.2",
     "@hapi/joi": "^17.1.1",
     "@hot-loader/react-dom": "^16.11.0",
     "@popperjs/core": "^2.0.6",

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -57,6 +57,7 @@ import { tokenListApi } from 'api'
 
 import validationSchema from './validationSchema'
 import { useBetterAddTokenModal } from 'hooks/useBetterAddTokenModal'
+import { encodeTokenSymbol, decodeSymbol } from '@gnosis.pm/dex-js'
 
 const WrappedWidget = styled(Widget)`
   overflow-x: visible;
@@ -452,10 +453,10 @@ function buildUrl(params: {
   price: string
   from: string
   expires: string
-  sellSymbol: string
-  buySymbol: string
+  sellToken: TokenDetails
+  buyToken: TokenDetails
 }): string {
-  const { sell, price, from, expires, sellSymbol, buySymbol } = params
+  const { sell, price, from, expires, sellToken, buyToken } = params
 
   const searchQuery = buildSearchQuery({
     sell,
@@ -464,7 +465,10 @@ function buildUrl(params: {
     expires,
   })
 
-  return `/trade/${encodeURIComponent(sellSymbol)}-${encodeURIComponent(buySymbol)}?${searchQuery}`
+  const url = `/trade/${encodeTokenSymbol(sellToken)}-${encodeTokenSymbol(buyToken)}?${searchQuery}`
+
+  console.log(`new url`, url)
+  return url
 }
 
 const TradeWidget: React.FC = () => {
@@ -489,9 +493,9 @@ const TradeWidget: React.FC = () => {
       : tokenListApi.getTokens(networkIdOrDefault)
 
   // Listen on manual changes to URL search query
-  const { sell: dirtySellTokenSymbol, buy: dirtyReceiveTokenSymbol } = useParams()
-  const sellTokenSymbol = decodeURIComponent(dirtySellTokenSymbol || '')
-  const receiveTokenSymbol = decodeURIComponent(dirtyReceiveTokenSymbol || '')
+  const { sell: encodedSellTokenSymbol, buy: decodeReceiveTokenSymbol } = useParams()
+  const sellTokenSymbol = decodeSymbol(encodedSellTokenSymbol || '')
+  const receiveTokenSymbol = decodeSymbol(decodeReceiveTokenSymbol || '')
   const {
     sellAmount: sellParam,
     price: priceParam,
@@ -648,8 +652,8 @@ const TradeWidget: React.FC = () => {
     price: priceValue,
     from: validFromValue,
     expires: validUntilValue,
-    sellSymbol: sellToken.symbol as string,
-    buySymbol: receiveToken.symbol as string,
+    sellToken: sellToken,
+    buyToken: receiveToken,
   })
   // Updates page URL with parameters from context
   useURLParams(url, true)

--- a/test/api/ExchangeApi/TokenListApiMock.test.ts
+++ b/test/api/ExchangeApi/TokenListApiMock.test.ts
@@ -33,9 +33,9 @@ const NEW_TOKEN = {
 // TODO: These tests are dumb. Either do something meaningful or remove them entirely
 
 describe('MOCK: Basic functions', () => {
-  test('Mock API Token list has length 7', () => {
+  test('Mock API Token list has length 8', () => {
     const tokens = instanceMock.getTokens(1)
-    expect(tokens.length).toBe(7)
+    expect(tokens.length).toBe(8)
   })
   test('Mock API Token list has expected token', () => {
     const tokens = instanceMock.getTokens(1)

--- a/test/data/tokenList.ts
+++ b/test/data/tokenList.ts
@@ -1,5 +1,5 @@
 import { TokenDetails } from 'types'
-import { TOKEN_1, TOKEN_2, TOKEN_3, TOKEN_4, TOKEN_5, TOKEN_6, TOKEN_7 } from './basic'
+import { TOKEN_1, TOKEN_2, TOKEN_3, TOKEN_4, TOKEN_5, TOKEN_6, TOKEN_7, TOKEN_8 } from './basic'
 
 // Ether, Tether, TrueUSD, USD Coin, Paxos, Gemini, Dai
 const tokens: TokenDetails[] = [
@@ -97,6 +97,17 @@ const tokens: TokenDetails[] = [
     addressMainnet: '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359',
     image: `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359/logo.png`,
     address: TOKEN_7,
+  },
+
+  // Fake token (FTK)
+  //  for testing token with problematic characters for the URL
+  {
+    id: 77,
+    name: 'Fake token',
+    symbol: 'FTK /21/10-DAI $99 & +|-',
+    decimals: 18,
+    addressMainnet: TOKEN_8,
+    address: TOKEN_8,
   },
 ]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,10 +1160,10 @@
   dependencies:
     bn.js "^5.1.1"
 
-"@gnosis.pm/dex-js@0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.2.2.tgz#1a61f5659c8de9ae16edfa517c67d95273832b6f"
-  integrity sha512-fGfAb6qW+0pPlX9QOb0LYib6e7mbEVEyUmXCO978YBZFeXIY403s4SKoT94Bd3szyqbClq8MAwgupZZpYyiehw==
+"@gnosis.pm/dex-js@0.2.3-RC.0":
+  version "0.2.3-RC.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.2.3-RC.0.tgz#4014cd8beccb3d5f46c8b855451522f492c494da"
+  integrity sha512-rEP7T3RULGH8w5nWJPGUomPt84Xy5UbHqm2iPqxBh3q19Wktwu6s5SOh5cMFg6/fOb9ItmBXMod9BvcKOdf3zQ==
   dependencies:
     "@gnosis.pm/dex-contracts" "^0.2.0"
     bignumber.js "^9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,10 +1160,10 @@
   dependencies:
     bn.js "^5.1.1"
 
-"@gnosis.pm/dex-js@0.2.3-RC.0":
-  version "0.2.3-RC.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.2.3-RC.0.tgz#4014cd8beccb3d5f46c8b855451522f492c494da"
-  integrity sha512-rEP7T3RULGH8w5nWJPGUomPt84Xy5UbHqm2iPqxBh3q19Wktwu6s5SOh5cMFg6/fOb9ItmBXMod9BvcKOdf3zQ==
+"@gnosis.pm/dex-js@0.2.3-RC.2":
+  version "0.2.3-RC.2"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.2.3-RC.2.tgz#8fbbf81330f99e1b33bfd9f229b3e63a776785e1"
+  integrity sha512-WbJh3utuS3GpNj0aHUmjWa1f4jIaCmCh5cJ+3UVbp4vqoXMhHlypD0kS1YdMMEmit94habDcfTcMBTMPWyt9Zw==
   dependencies:
     "@gnosis.pm/dex-contracts" "^0.2.0"
     bignumber.js "^9.0.0"


### PR DESCRIPTION
Closes #918 

Tested using `yarn mock` and selecting the new `Fake token`:

![screenshot_2020-04-15_14-05-34](https://user-images.githubusercontent.com/43217/79389993-c55cd600-7f23-11ea-9f23-39fcdd880638.png)

![screenshot_2020-04-15_14-20-04](https://user-images.githubusercontent.com/43217/79390241-34d2c580-7f24-11ea-8917-7d900522e925.png)


Certainly does not look good, but works now.

Not part of this PR: to make it look good.


### Edit 1:

Updated how we encode a possible dash (`-`) in the token symbol to avoid issues with the token symbol separator in the URL (`/trade/tokenA-tokenB/...`)

![screenshot_2020-04-17_10-29-23](https://user-images.githubusercontent.com/43217/79597569-5d2f0100-8097-11ea-808a-9c929d2d4216.png)

Inserting a circle dash (`⊝`) to remove ambiguity and keep somewhat the same semantics.

*Note*: this only affects the displayed URL, nothing else.