### PR TITLE
Fix stale tokens

### DIFF
--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -499,6 +499,41 @@ const TradeWidget: React.FC = () => {
       defaultTokenSymbol: 'USDC',
     }),
   )
+
+  useEffect(() => {
+    console.log('TRADE', trade)
+    if (trade.sellToken) {
+      const sellTokenOrFallback = chooseTokenWithFallback({
+        token: tokenListApi.hasToken({ tokenAddress: trade.sellToken.address, networkId: networkIdOrDefault })
+          ? trade.sellToken
+          : null,
+        tokens: tokenListApi.getTokens(networkIdOrDefault),
+        tokenSymbol: sellTokenSymbol,
+        defaultTokenSymbol: 'DAI',
+      })
+      console.log('NEW', { sellTokenOrFallback })
+      setSellToken(sellTokenOrFallback)
+    }
+
+    if (trade.buyToken) {
+      const buyTokenOrFallback = chooseTokenWithFallback({
+        token: tokenListApi.hasToken({ tokenAddress: trade.buyToken.address, networkId: networkIdOrDefault })
+          ? trade.buyToken
+          : null,
+        tokens: tokenListApi.getTokens(networkIdOrDefault),
+        tokenSymbol: receiveTokenSymbol,
+        defaultTokenSymbol: 'USDC',
+      })
+      console.log('NEW', { buyTokenOrFallback })
+      setReceiveToken(buyTokenOrFallback)
+    }
+
+    console.log('networkIdOrDefault', networkIdOrDefault)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [networkIdOrDefault])
+  // don't need to depend on more than network as everything else updates together
+  // also avoids excessive setStates
+
   const [unlimited, setUnlimited] = useState(!defaultValidUntil || !Number(defaultValidUntil))
   const [asap, setAsap] = useState(!defaultValidFrom || !Number(defaultValidFrom))
 

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -502,14 +502,19 @@ const TradeWidget: React.FC = () => {
 
   useEffect(() => {
     console.log('TRADE', trade)
+    //  when switching networks
+    // trade stays filled with last tokens
+    // which may not be available on the new network
     if (trade.sellToken) {
+      // check if it should be different
       const sellTokenOrFallback = chooseTokenWithFallback({
+        // don't consider token from trade from wrong network valid
         token: tokenListApi.hasToken({ tokenAddress: trade.sellToken.address, networkId: networkIdOrDefault })
           ? trade.sellToken
           : null,
-        tokens: tokenListApi.getTokens(networkIdOrDefault),
-        tokenSymbol: sellTokenSymbol,
-        defaultTokenSymbol: 'DAI',
+        tokens: tokenListApi.getTokens(networkIdOrDefault), // get immediate new tokens
+        tokenSymbol: sellTokenSymbol, // from url params
+        defaultTokenSymbol: 'DAI', // default sellToken
       })
       console.log('NEW', { sellTokenOrFallback })
       setSellToken(sellTokenOrFallback)
@@ -522,7 +527,7 @@ const TradeWidget: React.FC = () => {
           : null,
         tokens: tokenListApi.getTokens(networkIdOrDefault),
         tokenSymbol: receiveTokenSymbol,
-        defaultTokenSymbol: 'USDC',
+        defaultTokenSymbol: 'USDC', // default buyToken
       })
       console.log('NEW', { buyTokenOrFallback })
       setReceiveToken(buyTokenOrFallback)

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -501,7 +501,6 @@ const TradeWidget: React.FC = () => {
   )
 
   useEffect(() => {
-    console.log('TRADE', trade)
     //  when switching networks
     // trade stays filled with last tokens
     // which may not be available on the new network
@@ -516,7 +515,6 @@ const TradeWidget: React.FC = () => {
         tokenSymbol: sellTokenSymbol, // from url params
         defaultTokenSymbol: 'DAI', // default sellToken
       })
-      console.log('NEW', { sellTokenOrFallback })
       setSellToken(sellTokenOrFallback)
     }
 
@@ -529,11 +527,8 @@ const TradeWidget: React.FC = () => {
         tokenSymbol: receiveTokenSymbol,
         defaultTokenSymbol: 'USDC', // default buyToken
       })
-      console.log('NEW', { buyTokenOrFallback })
       setReceiveToken(buyTokenOrFallback)
     }
-
-    console.log('networkIdOrDefault', networkIdOrDefault)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [networkIdOrDefault])
   // don't need to depend on more than network as everything else updates together

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -428,21 +428,21 @@ const preprocessTokenAddressesToAdd = (addresses: (string | undefined)[], networ
 interface ChooseTokenInput {
   tokens: TokenDetails[]
   token: TokenDetails | null
-  tokenSymbol?: string
+  tokenSymbolFromUrl?: string
   defaultTokenSymbol: 'DAI' | 'USDC'
 }
 
 const chooseTokenWithFallback = ({
   tokens,
   token,
-  tokenSymbol,
+  tokenSymbolFromUrl,
   defaultTokenSymbol,
 }: ChooseTokenInput): TokenDetails => {
   return (
     token ||
-    (tokenSymbol && isAddress(tokenSymbol?.toLowerCase())
-      ? getToken('address', tokenSymbol, tokens)
-      : getToken('symbol', tokenSymbol, tokens)) ||
+    (tokenSymbolFromUrl && isAddress(tokenSymbolFromUrl?.toLowerCase())
+      ? getToken('address', tokenSymbolFromUrl, tokens)
+      : getToken('symbol', tokenSymbolFromUrl, tokens)) ||
     (getToken('symbol', defaultTokenSymbol, tokens) as Required<TokenDetails>)
   )
 }
@@ -487,7 +487,7 @@ const TradeWidget: React.FC = () => {
     chooseTokenWithFallback({
       token: trade.sellToken,
       tokens,
-      tokenSymbol: sellTokenSymbol,
+      tokenSymbolFromUrl: sellTokenSymbol,
       defaultTokenSymbol: 'DAI',
     }),
   )
@@ -495,7 +495,7 @@ const TradeWidget: React.FC = () => {
     chooseTokenWithFallback({
       token: trade.buyToken,
       tokens,
-      tokenSymbol: receiveTokenSymbol,
+      tokenSymbolFromUrl: receiveTokenSymbol,
       defaultTokenSymbol: 'USDC',
     }),
   )
@@ -512,7 +512,7 @@ const TradeWidget: React.FC = () => {
           ? trade.sellToken
           : null,
         tokens: tokenListApi.getTokens(networkIdOrDefault), // get immediate new tokens
-        tokenSymbol: sellTokenSymbol, // from url params
+        tokenSymbolFromUrl: sellTokenSymbol, // from url params
         defaultTokenSymbol: 'DAI', // default sellToken
       })
       setSellToken(sellTokenOrFallback)
@@ -524,7 +524,7 @@ const TradeWidget: React.FC = () => {
           ? trade.buyToken
           : null,
         tokens: tokenListApi.getTokens(networkIdOrDefault),
-        tokenSymbol: receiveTokenSymbol,
+        tokenSymbolFromUrl: receiveTokenSymbol,
         defaultTokenSymbol: 'USDC', // default buyToken
       })
       setReceiveToken(buyTokenOrFallback)


### PR DESCRIPTION
When switching from mainnet to rinkeby old tokens stay in TokenSelector even if they are not available on rinkeby
Same when starting on rinkeby with URL containing mainnet-only token
try https://dex.dev.gnosisdev.com/trade/DAI-PAN?sell=0&price=0&from=&expires=2880 on rinkeby

![ezgif-3-19cb5151a038](https://user-images.githubusercontent.com/5121491/79456082-8ba8cf80-7ff6-11ea-9b5b-eae7f958bd42.gif)

This PR adds a check for tokens from url on network change