### PR TITLE
797/improve orders state

### DIFF
--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -202,12 +202,20 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
     clear()
 
     const ms = getTimeRemainingInBatch(true)
-    console.log(`timeout useEffect activated, ${ms}ms left`)
 
     if (isActiveNextBatch) {
       refreshTimeout.current = setTimeout(() => forceUpdate({}), ms)
     } else if (isFirstActiveBatch) {
-      refreshTimeout.current = setTimeout(() => forceUpdate({}), Math.max(0, ms - 60 * 1000))
+      // we want to display this for 4min (1min less than batch duration)
+      const timeout = ms - 60 * 1000
+
+      if (timeout <= 0) {
+        // already less than 1min less left, update right now
+        forceUpdate({})
+      } else {
+        // more than 1min left, update when it's over
+        refreshTimeout.current = setTimeout(() => forceUpdate({}), timeout)
+      }
     }
 
     return clear

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -225,7 +225,7 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
         </>
       ) : isFirstActiveBatch ? (
         <>
-          {`Waiting for settlement: `} <StatusCountdown />
+          {`Pending solver submission: `} <StatusCountdown />
         </>
       ) : isScheduled ? (
         <>

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -234,6 +234,8 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
         pending
       ) : isExpiredOrder ? (
         'Expired'
+      ) : isFilled ? (
+        'Filled'
       ) : isActiveNextBatch ? (
         <>
           {`Active in next batch: `} <StatusCountdown />
@@ -248,8 +250,6 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
           <br />
           {formatDateFromBatchId(order.validFrom)}
         </>
-      ) : isFilled ? (
-        'Filled'
       ) : isActive ? (
         'Active'
       ) : (

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -141,11 +141,18 @@ const Expires: React.FC<Pick<Props, 'order' | 'pending' | 'isPendingOrder'>> = (
   return <td data-label="Expires">{isNeverExpires ? <span>Never</span> : <span>{expiresOn}</span>}</td>
 }
 
-const StatusCountdown: React.FC = () => {
+const StatusCountdown: React.FC<{ timeoutDelta?: number }> = ({ timeoutDelta }) => {
   // If it's rendered, it means it should display the countdown
   const timeRemainingInBatch = useTimeRemainingInBatch()
 
-  return <>{formatSeconds(timeRemainingInBatch)}</>
+  // `timeoutDelta` use case is for a countdown that's shorter than batch duration
+  // instead of counting all the way down to (currently 5min) batch time, we count instead to
+  // batchTime - timeoutDelta.
+  // When this countdown is over but there's still time left in the batch, return 0 for safety.
+  // Up to parent component to stop rendering at that time
+  const timeRemaining = timeoutDelta ? Math.max(0, timeRemainingInBatch - timeoutDelta) : timeRemainingInBatch
+
+  return <>{formatSeconds(timeRemaining)}</>
 }
 
 const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash' | 'isPendingOrder'>> = ({
@@ -233,7 +240,7 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
         </>
       ) : isFirstActiveBatch ? (
         <>
-          {`Pending solver submission: `} <StatusCountdown />
+          {`Pending solver submission: `} <StatusCountdown timeoutDelta={60} />
         </>
       ) : isScheduled ? (
         <>

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -163,7 +163,7 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
 }) => {
   const now = new Date()
   const batchId = dateToBatchId(now)
-  const msRemainingInBatch = getTimeRemainingInBatch(true)
+  const msRemainingInBatch = getTimeRemainingInBatch({ inMilliseconds: true })
 
   const isExpiredOrder = batchIdToDate(order.validUntil) <= now
   const isScheduled = batchIdToDate(order.validFrom) > now
@@ -208,7 +208,7 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
 
     clear()
 
-    const ms = getTimeRemainingInBatch(true)
+    const ms = getTimeRemainingInBatch({ inMilliseconds: true })
 
     if (isActiveNextBatch) {
       refreshTimeout.current = setTimeout(() => forceUpdate({}), ms)

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -149,7 +149,6 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
   const now = new Date()
   const batchId = dateToBatchId(now)
   const secondsRemainingInBatch = getSecondsRemainingInBatch()
-  const secondsCountdown = formatSeconds(secondsRemainingInBatch)
 
   const isExpiredOrder = batchIdToDate(order.validUntil) <= now
   const isScheduled = batchIdToDate(order.validFrom) > now
@@ -205,9 +204,9 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
       ) : isExpiredOrder ? (
         'Expired'
       ) : isActiveNextBatch ? (
-        `Active in next batch: ${secondsCountdown}`
+        `Active in next batch: ${formatSeconds(secondsRemainingInBatch)}`
       ) : isFirstActiveBatch ? (
-        `Waiting for settlement: ${secondsCountdown}`
+        `Waiting for settlement: ${formatSeconds(secondsRemainingInBatch)}`
       ) : isScheduled ? (
         <>
           Scheduled

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -23,7 +23,7 @@ import {
   isOrderFilled,
   dateToBatchId,
   formatSeconds,
-  getSecondsRemainingInBatch,
+  getTimeRemainingInBatch,
 } from 'utils'
 import { onErrorFactory } from 'utils/onError'
 import { AuctionElement } from 'api/exchange/ExchangeApi'
@@ -148,12 +148,12 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
 }) => {
   const now = new Date()
   const batchId = dateToBatchId(now)
-  const secondsRemainingInBatch = getSecondsRemainingInBatch()
+  const msRemainingInBatch = getTimeRemainingInBatch(true)
 
   const isExpiredOrder = batchIdToDate(order.validUntil) <= now
   const isScheduled = batchIdToDate(order.validFrom) > now
   const isActiveNextBatch = batchId === order.validFrom
-  const isFirstActiveBatch = batchId === order.validFrom + 1 && secondsRemainingInBatch > 60 // up until minute 4
+  const isFirstActiveBatch = batchId === order.validFrom + 1 && msRemainingInBatch > 60 * 1000 // up until minute 4
 
   const isUnlimited = useMemo(() => isOrderUnlimited(order.priceNumerator, order.priceDenominator), [
     order.priceDenominator,

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -148,11 +148,13 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
 }) => {
   const now = new Date()
   const batchId = dateToBatchId(now)
+  const secondsRemainingInBatch = getSecondsRemainingInBatch()
+  const secondsCountdown = formatSeconds(secondsRemainingInBatch)
 
   const isExpiredOrder = batchIdToDate(order.validUntil) <= now
   const isScheduled = batchIdToDate(order.validFrom) > now
   const isActiveNextBatch = batchId === order.validFrom
-  const isFirstActiveBatch = batchId === order.validFrom + 1
+  const isFirstActiveBatch = batchId === order.validFrom + 1 && secondsRemainingInBatch > 60 // up until minute 4
   const isUnlimited = useMemo(() => isOrderUnlimited(order.priceNumerator, order.priceDenominator), [
     order.priceDenominator,
     order.priceNumerator,
@@ -194,8 +196,6 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
       if (timer) clearTimeout(timer)
     }
   }, [forceUpdate, isActiveNextBatch, isFirstActiveBatch])
-
-  const secondsCountdown = formatSeconds(getSecondsRemainingInBatch())
 
   return (
     <td className="status">

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -147,11 +147,12 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
   transactionHash,
 }) => {
   const now = new Date()
+  const batchId = dateToBatchId(now)
 
   const isExpiredOrder = batchIdToDate(order.validUntil) <= now
   const isScheduled = batchIdToDate(order.validFrom) > now
-  const isActiveNextBatch = dateToBatchId(now) === order.validFrom
-  const isFirstActiveBatch = dateToBatchId(now) === order.validFrom + 1
+  const isActiveNextBatch = batchId === order.validFrom
+  const isFirstActiveBatch = batchId === order.validFrom + 1
   const isUnlimited = useMemo(() => isOrderUnlimited(order.priceNumerator, order.priceDenominator), [
     order.priceDenominator,
     order.priceNumerator,

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -207,7 +207,7 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
       ) : isActiveNextBatch ? (
         `Active in next batch: ${secondsCountdown}`
       ) : isFirstActiveBatch ? (
-        `Looking for match: ${secondsCountdown}`
+        `Waiting for settlement: ${secondsCountdown}`
       ) : isScheduled ? (
         <>
           Scheduled

--- a/src/const.ts
+++ b/src/const.ts
@@ -11,6 +11,9 @@ export {
   DEFAULT_PRECISION,
 } from '@gnosis.pm/dex-js'
 export { ZERO, ONE, TWO, TEN, ALLOWANCE_MAX_VALUE, ALLOWANCE_FOR_ENABLED_TOKEN } from '@gnosis.pm/dex-js'
+import { BATCH_TIME } from '@gnosis.pm/dex-js'
+
+export const BATCH_TIME_IN_MS = BATCH_TIME * 1000
 
 export const ZERO_BIG_NUMBER = new BigNumber(0)
 export const TEN_BIG_NUMBER = new BigNumber(10)

--- a/src/hooks/useTimeRemainingInBatch.ts
+++ b/src/hooks/useTimeRemainingInBatch.ts
@@ -7,7 +7,13 @@ export function useTimeRemainingInBatch(): number {
   const [timeRemaining, setTimeRemaining] = useSafeState(getTimeRemainingInBatch())
 
   useEffect(() => {
-    const interval = setInterval(() => setTimeRemaining(getTimeRemainingInBatch()), 1000)
+    // timeout to start the timer exactly at half second
+    let interval = setTimeout(() => {
+      // update once
+      setTimeRemaining(getTimeRemainingInBatch())
+      // update every second from now on
+      interval = setInterval(() => setTimeRemaining(getTimeRemainingInBatch()), 1000)
+    }, Date.now() % 500)
 
     return (): void => clearInterval(interval)
   }, [setTimeRemaining])

--- a/src/hooks/useTimeRemainingInBatch.ts
+++ b/src/hooks/useTimeRemainingInBatch.ts
@@ -28,6 +28,7 @@ export function useTimeRemainingInBatch(): number {
     }
 
     return (): void => {
+      // `clearInterval` works for both interval AND timeouts
       if (interval) clearInterval(interval)
     }
   }, [setTimeRemaining])

--- a/src/hooks/useTimeRemainingInBatch.ts
+++ b/src/hooks/useTimeRemainingInBatch.ts
@@ -1,13 +1,13 @@
 import useSafeState from './useSafeState'
-import { getSecondsRemainingInBatch } from 'utils'
+import { getTimeRemainingInBatch } from 'utils'
 import { useEffect, useRef } from 'react'
 import { BATCH_TIME } from 'const'
 
 export function useTimeRemainingInBatch(): number {
-  const [timeRemaining, setTimeRemaining] = useSafeState(getSecondsRemainingInBatch())
+  const [timeRemaining, setTimeRemaining] = useSafeState(getTimeRemainingInBatch())
 
   useEffect(() => {
-    const interval = setInterval(() => setTimeRemaining(getSecondsRemainingInBatch()), 1000)
+    const interval = setInterval(() => setTimeRemaining(getTimeRemainingInBatch()), 1000)
 
     return (): void => clearInterval(interval)
   }, [setTimeRemaining])
@@ -21,7 +21,7 @@ interface SecondsRemainingResult {
 }
 
 const checkIfTime = (seconds: number): SecondsRemainingResult => {
-  const secondsRemaining = getSecondsRemainingInBatch()
+  const secondsRemaining = getTimeRemainingInBatch()
   return {
     secondsRemaining,
     checkTime: secondsRemaining < seconds,

--- a/src/hooks/useTimeRemainingInBatch.ts
+++ b/src/hooks/useTimeRemainingInBatch.ts
@@ -16,11 +16,11 @@ export function useTimeRemainingInBatch(): number {
       interval = setInterval(() => setTimeRemaining(getTimeRemainingInBatch()), 1000)
     }
 
-    // timeout to start the timer exactly at half second
-    const intervalStart = Date.now() % 500
+    // timeout to start the timer exactly at second mark
+    const intervalStart = Date.now() % 1000
 
     if (intervalStart === 0) {
-      // to avoid possible scheduling delays, execute right now if exactly at 500ms mark
+      // to avoid possible scheduling delays, execute right now if exactly at second mark
       updateImmediatelyAndStartInterval()
     } else {
       // otherwise, schedule starting

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -42,7 +42,9 @@ export function formatDateFromBatchId(batchId: number): string {
  *
  * @param inMilliseconds  Optional parameter indicating time unit. Defaults to false == in seconds
  */
-export function getTimeRemainingInBatch(inMilliseconds = false): number {
+export function getTimeRemainingInBatch(params?: { inMilliseconds: boolean }): number {
+  const { inMilliseconds = false } = params || {}
+
   const timeRemainingInMs = BATCH_TIME_IN_MS - (Date.now() % BATCH_TIME_IN_MS)
 
   return inMilliseconds ? timeRemainingInMs : Math.floor(timeRemainingInMs / 1000)

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,6 +1,6 @@
 import { formatDistanceToNow } from 'date-fns'
 
-import { BATCH_TIME } from 'const'
+import { BATCH_TIME, BATCH_TIME_IN_MS } from 'const'
 
 /**
  * Epoch in seconds
@@ -26,7 +26,7 @@ export function dateToBatchId(date?: Date): number {
 }
 
 export function batchIdToDate(batchId: number): Date {
-  const timestamp = batchId * BATCH_TIME * 1000
+  const timestamp = batchId * BATCH_TIME_IN_MS
   return new Date(timestamp)
 }
 
@@ -36,11 +36,16 @@ export function formatDateFromBatchId(batchId: number): string {
 }
 
 /**
- * Calculates seconds remaining in current batch
- * Assumes local time is accurate and can be used as source of truth
+ * Calculates time remaining in current batch.
+ * Assumes local time is accurate and can be used as source of truth.
+ * By default returns time in seconds.
+ *
+ * @param inMilliseconds  Optional parameter indicating time unit. Defaults to false == in seconds
  */
-export function getSecondsRemainingInBatch(): number {
-  return BATCH_TIME - (getEpoch() % BATCH_TIME)
+export function getTimeRemainingInBatch(inMilliseconds = false): number {
+  const timeRemainingInMs = BATCH_TIME_IN_MS - (Date.now() % BATCH_TIME_IN_MS)
+
+  return inMilliseconds ? timeRemainingInMs : Math.floor(timeRemainingInMs / 1000)
 }
 
 export function formatSeconds(seconds: number): string {

--- a/test/data/userOrders.ts
+++ b/test/data/userOrders.ts
@@ -34,7 +34,25 @@ export const exchangeOrders = {
       buyTokenId: 7, // DAI
       sellTokenId: 5, // PAX
       validFrom: BATCH_ID,
-      validUntil: dateToBatchId(addMinutes(NOW, 2)),
+      validUntil: dateToBatchId(addMinutes(NOW, 2)), // about to expire
+      priceNumerator: new BN('10500000000000000000000'),
+      priceDenominator: new BN('10000000000000000000000'),
+      remainingAmount: new BN('5876842900000000000000'),
+    },
+    {
+      buyTokenId: 7, // DAI
+      sellTokenId: 5, // PAX
+      validFrom: dateToBatchId(new Date()), // first batch active
+      validUntil: dateToBatchId(addDays(NOW, 5)),
+      priceNumerator: new BN('10500000000000000000000'),
+      priceDenominator: new BN('10000000000000000000000'),
+      remainingAmount: new BN('5876842900000000000000'),
+    },
+    {
+      buyTokenId: 7, // DAI
+      sellTokenId: 5, // PAX
+      validFrom: dateToBatchId(addMinutes(NOW, 6)), // active next batch
+      validUntil: dateToBatchId(addDays(NOW, 5)),
       priceNumerator: new BN('10500000000000000000000'),
       priceDenominator: new BN('10000000000000000000000'),
       remainingAmount: new BN('5876842900000000000000'),


### PR DESCRIPTION
Closes #797 

Step 1: pending

![screenshot_2020-04-16_16-12-45](https://user-images.githubusercontent.com/43217/79515488-99ae1e80-7ffd-11ea-8d09-bc816fd1a2ad.png)

Step 2: Active next batch

![screenshot_2020-04-16_16-15-00](https://user-images.githubusercontent.com/43217/79515511-a6cb0d80-7ffd-11ea-9b85-975c2f3d1eda.png)

Step 3: Looking for match

![screenshot_2020-04-16_16-15-20](https://user-images.githubusercontent.com/43217/79515521-afbbdf00-7ffd-11ea-8899-ae22af49df78.png)

From then on, follow regular states

### Update 1

- [x] `Looking for match` countdown stops at 4min. `Active` from then on.
- [x] Renamed `Looking for match` to `Waiting for settlement`
- [x] `clearInterval` instead of `clearTimeout`
- [x] Small refactoring
- [x] Order row component now only updates once time is up
- [x] New Status countdown component updates every second using `useTimeRemainingInBatch` hook
- [x] Starting countdowns at half a second mark, to try and keep all in sync

### Update 2

- [x] Renamed `Waiting for settlement` to `Pending solver submission`
- [x] Besides countdown stopping at 4min on `Pending solver submission`, now actually counting for 4min instead of 5min
- [x] Addressed Dima's comments

Notice the time difference between `Active in next batch` and `Pending solver submission` countdowns:
![screenshot_2020-04-20_10-15-39](https://user-images.githubusercontent.com/43217/79780398-b9409200-82f0-11ea-8aa0-a68a7570c90a.png)
