### PR TITLE
switch to literal regexp

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -58,9 +58,9 @@ export function sanitizeNegativeAndMakeMultipleOf(value?: string | null, default
 export function validatePositiveConstructor(message: string) {
   return (value: string, constraint = 0): true | string => Number(value) > constraint || message
 }
-export const validInputPattern = new RegExp(/^\d+\.?\d*$/) // allows leading and trailing zeros
-export const leadingAndTrailingZeros = new RegExp(/(^0*(?=\d)|\.0*$)/, 'g') // removes leading zeros and trailing '.' followed by zeros
-export const trailingZerosAfterDot = new RegExp(/(.*\.\d+?)0*$/) // selects valid input without leading zeros after '.'
+export const validInputPattern = /^\d+\.?\d*$/ // allows leading and trailing zeros
+export const leadingAndTrailingZeros = /(^0*(?=\d)|\.0*$)/g // removes leading zeros and trailing '.' followed by zeros
+export const trailingZerosAfterDot = /(.*\.\d+?)0*$/ // selects valid input without leading zeros after '.'
 
 /**
  * Removes extra leading and trailing zeros, while allowing for partial numbers, so users can input decimals manually


### PR DESCRIPTION
A pet peeve of mine.
Let's use literal notation for regexp when possible

- `new RegExp(string)` is useful when string is dynamically constructed
- `new RegExp(/reg_exp/)` is copy-constructed
- `/pattern/` is genrally prefered for static patterns

[Reference 1](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Description), [2](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Creating_a_regular_expression)