### PR TITLE
Different separator

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/react-fontawesome": "^0.1.8",
     "@gnosis.pm/dapp-ui": "^0.5.3",
-    "@gnosis.pm/dex-js": "0.2.2",
+    "@gnosis.pm/dex-js": "0.2.3-RC.0",
     "@hapi/joi": "^17.1.1",
     "@hot-loader/react-dom": "^16.11.0",
     "@popperjs/core": "^2.0.6",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,14 +88,14 @@ const App: React.FC = () => (
         <React.Suspense fallback={null}>
           <Switch>
             <PrivateRoute path="/orders" exact component={Orders} />
-            <Route path="/trade/:sell-:buy" component={Trade} />
+            <Route path="/trade/:sell\+:buy" component={Trade} />
             <PrivateRoute path="/liquidity" exact component={Strategies} />
             <PrivateRoute path="/wallet" exact component={Wallet} />
             <Route path="/about" exact component={About} />
             <Route path="/faq" exact component={FAQ} />
             <Route path="/book" exact component={OrderBook} />
             <Route path="/connect-wallet" exact component={ConnectWallet} />
-            <Redirect from="/" to="/trade/DAI-USDC?sell=0&price=0" />
+            <Redirect from="/" to="/trade/DAI\+USDC?sell=0&price=0" />
             <Route component={NotFound} />
           </Switch>
         </React.Suspense>

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -57,6 +57,7 @@ import { tokenListApi } from 'api'
 
 import validationSchema from './validationSchema'
 import { useBetterAddTokenModal } from 'hooks/useBetterAddTokenModal'
+import { encodeTokenSymbol, decodeSymbol } from '@gnosis.pm/dex-js'
 
 const WrappedWidget = styled(Widget)`
   overflow-x: visible;
@@ -430,10 +431,10 @@ function buildUrl(params: {
   price: string
   from: string
   expires: string
-  sellSymbol: string
-  buySymbol: string
+  sellToken: TokenDetails
+  buyToken: TokenDetails
 }): string {
-  const { sell, price, from, expires, sellSymbol, buySymbol } = params
+  const { sell, price, from, expires, sellToken, buyToken } = params
 
   const searchQuery = buildSearchQuery({
     sell,
@@ -442,7 +443,10 @@ function buildUrl(params: {
     expires,
   })
 
-  return `/trade/${encodeURIComponent(sellSymbol)}-${encodeURIComponent(buySymbol)}?${searchQuery}`
+  const url = `/trade/${encodeTokenSymbol(sellToken)}-${encodeTokenSymbol(buyToken)}?${searchQuery}`
+
+  console.log(`new url`, url)
+  return url
 }
 
 const TradeWidget: React.FC = () => {
@@ -467,9 +471,9 @@ const TradeWidget: React.FC = () => {
       : tokenListApi.getTokens(networkIdOrDefault)
 
   // Listen on manual changes to URL search query
-  const { sell: dirtySellTokenSymbol, buy: dirtyReceiveTokenSymbol } = useParams()
-  const sellTokenSymbol = decodeURIComponent(dirtySellTokenSymbol || '')
-  const receiveTokenSymbol = decodeURIComponent(dirtyReceiveTokenSymbol || '')
+  const { sell: encodedSellTokenSymbol, buy: decodeReceiveTokenSymbol } = useParams()
+  const sellTokenSymbol = decodeSymbol(encodedSellTokenSymbol || '')
+  const receiveTokenSymbol = decodeSymbol(decodeReceiveTokenSymbol || '')
   const {
     sellAmount: sellParam,
     price: priceParam,
@@ -591,8 +595,8 @@ const TradeWidget: React.FC = () => {
     price: priceValue,
     from: validFromValue,
     expires: validUntilValue,
-    sellSymbol: sellToken.symbol as string,
-    buySymbol: receiveToken.symbol as string,
+    sellToken: sellToken,
+    buyToken: receiveToken,
   })
   // Updates page URL with parameters from context
   useURLParams(url, true)

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -435,6 +435,8 @@ function buildUrl(params: {
   buyToken: TokenDetails
 }): string {
   const { sell, price, from, expires, sellToken, buyToken } = params
+  console.log('sellToken', sellToken)
+  console.log('buyToken', buyToken)
 
   const searchQuery = buildSearchQuery({
     sell,
@@ -443,7 +445,7 @@ function buildUrl(params: {
     expires,
   })
 
-  const url = `/trade/${encodeTokenSymbol(sellToken)}-${encodeTokenSymbol(buyToken)}?${searchQuery}`
+  const url = `/trade/${encodeTokenSymbol(sellToken)}\+${encodeTokenSymbol(buyToken)}?${searchQuery}`
 
   console.log(`new url`, url)
   return url
@@ -472,8 +474,12 @@ const TradeWidget: React.FC = () => {
 
   // Listen on manual changes to URL search query
   const { sell: encodedSellTokenSymbol, buy: decodeReceiveTokenSymbol } = useParams()
+  console.log('encodedSellTokenSymbol', encodedSellTokenSymbol)
+  console.log('decodeReceiveTokenSymbol', decodeReceiveTokenSymbol)
   const sellTokenSymbol = decodeSymbol(encodedSellTokenSymbol || '')
+  console.log('sellTokenSymbol', sellTokenSymbol)
   const receiveTokenSymbol = decodeSymbol(decodeReceiveTokenSymbol || '')
+  console.log('receiveTokenSymbol', receiveTokenSymbol)
   const {
     sellAmount: sellParam,
     price: priceParam,

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -425,6 +425,26 @@ const preprocessTokenAddressesToAdd = (addresses: (string | undefined)[], networ
   return tokenAddresses
 }
 
+function buildUrl(params: {
+  sell: string
+  price: string
+  from: string
+  expires: string
+  sellSymbol: string
+  buySymbol: string
+}): string {
+  const { sell, price, from, expires, sellSymbol, buySymbol } = params
+
+  const searchQuery = buildSearchQuery({
+    sell,
+    price,
+    from,
+    expires,
+  })
+
+  return `/trade/${encodeURIComponent(sellSymbol)}-${encodeURIComponent(buySymbol)}?${searchQuery}`
+}
+
 const TradeWidget: React.FC = () => {
   const { networkId, networkIdOrDefault, isConnected, userAddress } = useWalletConnection()
   const { connectWallet } = useConnectWallet()
@@ -447,7 +467,9 @@ const TradeWidget: React.FC = () => {
       : tokenListApi.getTokens(networkIdOrDefault)
 
   // Listen on manual changes to URL search query
-  const { sell: sellTokenSymbol, buy: receiveTokenSymbol } = useParams()
+  const { sell: dirtySellTokenSymbol, buy: dirtyReceiveTokenSymbol } = useParams()
+  const sellTokenSymbol = decodeURIComponent(dirtySellTokenSymbol || '')
+  const receiveTokenSymbol = decodeURIComponent(dirtyReceiveTokenSymbol || '')
   const {
     sellAmount: sellParam,
     price: priceParam,
@@ -564,13 +586,15 @@ const TradeWidget: React.FC = () => {
     setValue(receiveInputId, calculateReceiveAmount(priceValue, sellValue))
   }, [priceValue, priceInverseValue, setValue, receiveInputId, sellValue])
 
-  const searchQuery = buildSearchQuery({
+  const url = buildUrl({
     sell: sellValue,
     price: priceValue,
     from: validFromValue,
     expires: validUntilValue,
+    sellSymbol: sellToken.symbol as string,
+    buySymbol: receiveToken.symbol as string,
   })
-  const url = `/trade/${sellToken.symbol}-${receiveToken.symbol}?${searchQuery}`
+  // Updates page URL with parameters from context
   useURLParams(url, true)
 
   // TESTING

--- a/test/api/ExchangeApi/TokenListApiMock.test.ts
+++ b/test/api/ExchangeApi/TokenListApiMock.test.ts
@@ -33,9 +33,9 @@ const NEW_TOKEN = {
 // TODO: These tests are dumb. Either do something meaningful or remove them entirely
 
 describe('MOCK: Basic functions', () => {
-  test('Mock API Token list has length 7', () => {
+  test('Mock API Token list has length 8', () => {
     const tokens = instanceMock.getTokens(1)
-    expect(tokens.length).toBe(7)
+    expect(tokens.length).toBe(8)
   })
   test('Mock API Token list has expected token', () => {
     const tokens = instanceMock.getTokens(1)

--- a/test/data/tokenList.ts
+++ b/test/data/tokenList.ts
@@ -1,5 +1,5 @@
 import { TokenDetails } from 'types'
-import { TOKEN_1, TOKEN_2, TOKEN_3, TOKEN_4, TOKEN_5, TOKEN_6, TOKEN_7 } from './basic'
+import { TOKEN_1, TOKEN_2, TOKEN_3, TOKEN_4, TOKEN_5, TOKEN_6, TOKEN_7, TOKEN_8 } from './basic'
 
 // Ether, Tether, TrueUSD, USD Coin, Paxos, Gemini, Dai
 const tokens: TokenDetails[] = [
@@ -97,6 +97,17 @@ const tokens: TokenDetails[] = [
     addressMainnet: '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359',
     image: `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359/logo.png`,
     address: TOKEN_7,
+  },
+
+  // Fake token (FTK)
+  //  for testing token with problematic characters for the URL
+  {
+    id: 77,
+    name: 'Fake token',
+    symbol: 'FTK /21/10-DAI $99 & +|-',
+    decimals: 18,
+    addressMainnet: TOKEN_8,
+    address: TOKEN_8,
   },
 ]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,10 +1160,10 @@
   dependencies:
     bn.js "^5.1.1"
 
-"@gnosis.pm/dex-js@0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.2.2.tgz#1a61f5659c8de9ae16edfa517c67d95273832b6f"
-  integrity sha512-fGfAb6qW+0pPlX9QOb0LYib6e7mbEVEyUmXCO978YBZFeXIY403s4SKoT94Bd3szyqbClq8MAwgupZZpYyiehw==
+"@gnosis.pm/dex-js@0.2.3-RC.0":
+  version "0.2.3-RC.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.2.3-RC.0.tgz#4014cd8beccb3d5f46c8b855451522f492c494da"
+  integrity sha512-rEP7T3RULGH8w5nWJPGUomPt84Xy5UbHqm2iPqxBh3q19Wktwu6s5SOh5cMFg6/fOb9ItmBXMod9BvcKOdf3zQ==
   dependencies:
     "@gnosis.pm/dex-contracts" "^0.2.0"
     bignumber.js "^9.0.0"


### PR DESCRIPTION
Trying a different separator
`:sell\+:buy` , + must be escaped because it has special meaning in [path-to-regex](https://github.com/pillarjs/path-to-regexp/tree/v1.7.0#one-or-more)

Safe separator can be any of `$&:<>[]{}"+%@/;=^|',` symbols

http://localhost:8080/trade/FTK%20%2F21%2F10-DAI%20%2499%20%26%20%2B%7C-+DAI?sell=0&price=0&from=&expires=2880
http://localhost:8080/trade/DAI+FTK%20%2F21%2F10-DAI%20%2499%20%26%20%2B%7C-?sell=0&price=0&from=&expires=2880
with `yarn mock`