### PR TITLE
948/update orders instead of replacing

### DIFF
--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -3,41 +3,18 @@ import { useEffect, useCallback, useRef } from 'react'
 import { unstable_batchedUpdates } from 'react-dom'
 
 import useGlobalState from './useGlobalState'
-import { overwriteOrders, appendOrders, updateOffset } from 'reducers-actions/orders'
+import { overwriteOrders, updateOffset, updateOrders } from 'reducers-actions/orders'
 
 import { useWalletConnection } from './useWalletConnection'
 import useSafeState from './useSafeState'
 import { exchangeApi } from 'api'
 import { AuctionElement } from 'api/exchange/ExchangeApi'
-import { ZERO } from 'const'
 import { useCheckWhenTimeRemainingInBatch } from './useTimeRemainingInBatch'
 
 interface Result {
   orders: AuctionElement[]
   forceOrdersRefresh: () => void
   isLoading: boolean
-}
-
-/**
- * Filter out deleted orders.
- *
- * When orders are `deleted` from the contract, they are still returned, but with all fields set to zero.
- * We will not display such orders.
- *
- * @param orders all orders returned by the contract
- */
-function filterDeletedOrders(orders: AuctionElement[]): AuctionElement[] {
-  return orders.filter(
-    order =>
-      !(
-        order.buyTokenId === 0 &&
-        order.sellTokenId === 0 &&
-        order.priceDenominator.eq(ZERO) &&
-        order.priceNumerator.eq(ZERO) &&
-        order.validFrom === 0 &&
-        order.validUntil === 0
-      ),
-  )
 }
 
 const REFRESH_WHEN_SECONDS_LEFT = 60 // 1min before batch done
@@ -81,19 +58,13 @@ export function useOrders(): Result {
         // check cancelled bool from parent scope
         if (cancelled) return
 
-        // Apply filters (remove deleted orders)
-        const filteredOrders = filterDeletedOrders(orders)
-
         // ensures we don't have multiple reruns for each update
         // i.e. offset change -> render
         //      isLoading change -> another render
         unstable_batchedUpdates(() => {
-          if (offset === 0) {
-            // fresh start/refresh: replace whatever is stored
-            dispatch(overwriteOrders(filteredOrders))
-          } else if (filteredOrders.length > 0) {
-            // incremental update: append
-            dispatch(appendOrders(filteredOrders))
+          if (orders.length > 0) {
+            // update
+            dispatch(updateOrders(orders))
           }
 
           if (!nextIndex) {

--- a/src/reducers-actions/orders.ts
+++ b/src/reducers-actions/orders.ts
@@ -79,10 +79,14 @@ export const reducer = (state: OrdersState, action: ReducerActionType): OrdersSt
         payload: { orders },
       } = action
 
-      // default sorting order is ascending by order id
-      // since we are starting from 0, reverse to have the latest on top
-      // make a copy first (slice(0)) to avoid mutating current state
-      const reversedOrders = orders.slice(0).reverse()
+      const reversedOrders = orders
+        // make a copy first (slice(0)) to avoid mutating current state
+        .slice(0)
+        // default sorting order is ascending by order id
+        // since we are starting from 0, reverse to have the latest on top
+        .reverse()
+        // remove deleted orders
+        .filter(order => !isOrderDeleted(order))
 
       return { ...state, orders: reversedOrders }
     }
@@ -100,7 +104,7 @@ export const reducer = (state: OrdersState, action: ReducerActionType): OrdersSt
       const filteredAndUpdatedOrders = currentOrders.reduce((acc: AuctionElement[], order) => {
         if (activeOrders[order.id] !== undefined) {
           // It's on activeOrders map? it has been updated.
-          // Get the updated from newOrders by the index in the activeOrders map
+          // Get the updated from newOrders list by the index in the activeOrders map
           acc.push(newOrders[activeOrders[order.id]])
           // Remove from activeOrders map so we know it's not a new order
           delete activeOrders[order.id]
@@ -113,7 +117,7 @@ export const reducer = (state: OrdersState, action: ReducerActionType): OrdersSt
         return acc
       }, [])
 
-      // Anything is left on activeOrders map is a new order
+      // Anything left on activeOrders map is a new order
       const reversedNewOrders = Object.values(activeOrders)
         // Use their indexes to fetch from newOrders list
         .map(index => newOrders[index])
@@ -132,7 +136,10 @@ export const reducer = (state: OrdersState, action: ReducerActionType): OrdersSt
       const { orders: currentOrders } = state
 
       // reverse new orders
-      const reversedNewOrders = newOrders.slice(0).reverse()
+      const reversedNewOrders = newOrders
+        .slice(0)
+        .reverse()
+        .filter(order => !isOrderDeleted(order))
 
       // existing orders are older, so new orders come first
       const orders = reversedNewOrders.concat(currentOrders)


### PR DESCRIPTION
Closes #948 

UX improvement. Was annoyed seeing my orders flash on every 4min mark of the batch.

This change makes so we only reset orders when changing network/address.
All other updates will do it "in place", sort of.

Moved deleted orders filtering logic from `useOrders` hook to orders reducer.