### PR TITLE
960/dynamic token fetching

### DIFF
--- a/src/api/erc20/Erc20Api.ts
+++ b/src/api/erc20/Erc20Api.ts
@@ -268,19 +268,6 @@ export class Erc20ApiImpl implements Erc20Api {
 
     return erc20Details ? erc20Details[prop] : undefined
   }
-
-  private async withLocalErc20Details<P extends keyof Erc20Props>(
-    params: BaseParams,
-    fn: (params: BaseParams) => Promise<Erc20Props[P]>,
-    prop: P,
-  ): Promise<Erc20Props[P]> {
-    const erc20Prop = this._getLocalErc20Property(params.tokenAddress, prop)
-
-    if (erc20Prop) {
-      return erc20Prop
-    }
-    return fn(params)
-  }
 }
 
 export default Erc20ApiImpl

--- a/src/api/erc20/Erc20Api.ts
+++ b/src/api/erc20/Erc20Api.ts
@@ -139,7 +139,7 @@ export class Erc20ApiImpl implements Erc20Api {
 
     const erc20 = this._getERC20AtAddress(networkId, tokenAddress)
 
-    return await erc20.methods.symbol().call()
+    return erc20.methods.symbol().call()
   }
 
   public async decimals({ tokenAddress, networkId }: DecimalsParams): Promise<number> {

--- a/src/api/erc20/Erc20Api.ts
+++ b/src/api/erc20/Erc20Api.ts
@@ -7,7 +7,19 @@ import { TxOptionalParams, Receipt } from 'types'
 import { ZERO } from 'const'
 import { toBN } from 'utils'
 
+import ERC20_DETAILS from './erc20Details.json'
+
 import Web3 from 'web3'
+
+export interface Erc20Props {
+  name: string
+  symbol: string
+  decimals: number
+}
+
+export interface Erc20Details {
+  [address: string]: Erc20Props
+}
 
 interface BaseParams {
   tokenAddress: string
@@ -77,6 +89,7 @@ export interface Params {
 export class Erc20ApiImpl implements Erc20Api {
   private _contractPrototype: Erc20Contract
   private web3: Web3
+  private readonly localErc20Details: Erc20Details
 
   private static _contractsCache: { [network: number]: { [address: string]: Erc20Contract } } = {}
 
@@ -84,6 +97,11 @@ export class Erc20ApiImpl implements Erc20Api {
 
   public constructor(injectedDependencies: Params) {
     Object.assign(this, injectedDependencies)
+
+    // Local overwrites for token details
+    // Usually that shouldn't be needed but some tokens do not abide by the standard
+    // and return symbol/name as bytes32 as opposed to string
+    this.localErc20Details = ERC20_DETAILS
 
     this._contractPrototype = new this.web3.eth.Contract(erc20Abi as AbiItem[]) as Erc20Contract
 
@@ -103,23 +121,38 @@ export class Erc20ApiImpl implements Erc20Api {
   }
 
   public async name({ tokenAddress, networkId }: NameParams): Promise<string> {
+    const name = this._getLocalErc20Property(tokenAddress, 'name')
+    if (name) {
+      return name
+    }
+
     const erc20 = this._getERC20AtAddress(networkId, tokenAddress)
 
     return await erc20.methods.name().call()
   }
 
   public async symbol({ tokenAddress, networkId }: SymbolParams): Promise<string> {
+    const symbol = this._getLocalErc20Property(tokenAddress, 'symbol')
+    if (symbol) {
+      return symbol
+    }
+
     const erc20 = this._getERC20AtAddress(networkId, tokenAddress)
 
     return await erc20.methods.symbol().call()
   }
 
   public async decimals({ tokenAddress, networkId }: DecimalsParams): Promise<number> {
+    const decimals = this._getLocalErc20Property(tokenAddress, 'decimals')
+    if (decimals) {
+      return decimals
+    }
+
     const erc20 = this._getERC20AtAddress(networkId, tokenAddress)
 
-    const decimals = await erc20.methods.decimals().call()
+    const decimalsString = await erc20.methods.decimals().call()
 
-    return Number(decimals)
+    return Number(decimalsString)
   }
 
   public async totalSupply({ tokenAddress, networkId }: TotalSupplyParams): Promise<BN> {
@@ -228,6 +261,25 @@ export class Erc20ApiImpl implements Erc20Api {
     newERC20.options.address = address
 
     return (Erc20ApiImpl._contractsCache[networkId][address] = newERC20)
+  }
+
+  private _getLocalErc20Property<P extends keyof Erc20Props>(address: string, prop: P): Erc20Props[P] | undefined {
+    const erc20Details = this.localErc20Details[address]
+
+    return erc20Details ? erc20Details[prop] : undefined
+  }
+
+  private async withLocalErc20Details<P extends keyof Erc20Props>(
+    params: BaseParams,
+    fn: (params: BaseParams) => Promise<Erc20Props[P]>,
+    prop: P,
+  ): Promise<Erc20Props[P]> {
+    const erc20Prop = this._getLocalErc20Property(params.tokenAddress, prop)
+
+    if (erc20Prop) {
+      return erc20Prop
+    }
+    return fn(params)
   }
 }
 

--- a/src/api/erc20/Erc20Api.ts
+++ b/src/api/erc20/Erc20Api.ts
@@ -128,7 +128,7 @@ export class Erc20ApiImpl implements Erc20Api {
 
     const erc20 = this._getERC20AtAddress(networkId, tokenAddress)
 
-    return await erc20.methods.name().call()
+    return erc20.methods.name().call()
   }
 
   public async symbol({ tokenAddress, networkId }: SymbolParams): Promise<string> {

--- a/src/api/erc20/erc20Details.json
+++ b/src/api/erc20/erc20Details.json
@@ -1,0 +1,4 @@
+{
+  "0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359": { "name": "Sai Stablecoin v1.0", "symbol": "SAI", "decimals": 18 },
+  "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2": { "name": "Maker", "symbol": "MKR", "decimals": 18 }
+}

--- a/src/api/tokenList/TokenListApi.ts
+++ b/src/api/tokenList/TokenListApi.ts
@@ -143,6 +143,10 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
     // update copy in local storage
     const storageKey = TokenListApiImpl.getLocalStorageKey(networkId)
     localStorage.setItem(storageKey, JSON.stringify(tokenList))
+    // update address network set
+    tokenList.forEach(({ address: tokenAddress }) =>
+      this._tokenAddressNetworkSet.add(TokenListApiImpl.constructAddressNetworkKey({ tokenAddress, networkId })),
+    )
     // notify subscribers
     this.triggerSubscriptions(tokenList)
   }

--- a/src/api/tokenList/TokenListApi.ts
+++ b/src/api/tokenList/TokenListApi.ts
@@ -55,8 +55,10 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
     networkIds.forEach(networkId => {
       // initial value
       const tokenList = TokenListApiImpl.mergeTokenLists(
-        getTokensByNetwork(networkId),
+        // load first the local list, as this might be more up to date
         this.loadUserTokenList(networkId),
+        // then default list
+        getTokensByNetwork(networkId),
       )
       this._tokensByNetwork[networkId] = tokenList
 

--- a/src/services/factories/tokenList.ts
+++ b/src/services/factories/tokenList.ts
@@ -117,13 +117,15 @@ export function getTokensFactory(
   async function fetchAddressesAndIds(networkId: number, numTokens: number): Promise<Map<string, number>> {
     logDebug(`[tokenListFactory][${networkId}] Fetching addresses for ids from 0 to ${numTokens - 1}`)
 
-    const promises = Array.from({ length: numTokens }, (_, tokenId) =>
-      exchangeApi.getTokenAddressById({ networkId, tokenId }),
+    const promises = Array.from({ length: numTokens }, async (_, tokenId) => {
+        const tokenAddress = await exchangeApi.getTokenAddressById({ networkId, tokenId })
+        return [tokenAddress, tokenId]
+      }
     )
 
-    const tokenAddresses = await Promise.all(promises)
+    const tokenAddressIdPairs = await Promise.all(promises)
 
-    return new Map(tokenAddresses.map((tokenAddress, id) => [tokenAddress, id]))
+    return new Map(tokenAddressIdPairs)
   }
 
   async function updateTokenDetails(networkId: number, numTokens: number): Promise<void> {

--- a/src/services/factories/tokenList.ts
+++ b/src/services/factories/tokenList.ts
@@ -4,11 +4,21 @@ import { ExchangeApi } from 'api/exchange/ExchangeApi'
 import { TokenDetails, Command } from 'types'
 import { logDebug } from 'utils'
 
-export function getTokensFactory(factoryParams: {
-  tokenListApi: TokenList
-  exchangeApi: ExchangeApi
-}): (tokenId: number) => TokenDetails[] {
+import { TokenFromErc20Params, TokenFromErc20 } from './'
+
+interface Injects {
+  getTokenFromErc20(params: TokenFromErc20Params): Promise<TokenFromErc20>
+}
+
+export function getTokensFactory(
+  factoryParams: {
+    tokenListApi: TokenList
+    exchangeApi: ExchangeApi
+  },
+  injects: Injects,
+): (tokenId: number) => TokenDetails[] {
   const { tokenListApi, exchangeApi } = factoryParams
+  const { getTokenFromErc20 } = injects
 
   const updatedIdsForNetwork = new Set<number>()
 

--- a/src/services/factories/tokenList.ts
+++ b/src/services/factories/tokenList.ts
@@ -132,10 +132,8 @@ export function getTokensFactory(
 
   async function updateTokenDetails(networkId: number, numTokens: number): Promise<void> {
     // Fetch addresses from contract given numTokens count
-    const addressesAndIds = await retry({
-      fn: fetchAddressesAndIds,
-      fnParams: [networkId, numTokens],
-    })
+    const addressesAndIds = await retry(() => fetchAddressesAndIds(networkId, numTokens))
+
     logDebug(`[tokenListFactory][${networkId}] Token id and address mapping:`)
     addressesAndIds.forEach((id, address) => logDebug(`[tokenListFactory][${networkId}] ${id} : ${address}`))
 
@@ -198,7 +196,7 @@ export function getTokensFactory(
     areTokensUpdated.add(networkId)
 
     try {
-      const numTokens = await retry<number>({ fn: exchangeApi.getNumTokens.bind(exchangeApi), fnParams: [networkId] })
+      const numTokens = await retry(() => exchangeApi.getNumTokens(networkId))
       const tokens = tokenListApi.getTokens(networkId)
 
       logDebug(`[tokenListFactory][${networkId}] Contract has ${numTokens}; local list has ${tokens.length}`)

--- a/src/services/factories/tokenList.ts
+++ b/src/services/factories/tokenList.ts
@@ -117,10 +117,12 @@ export function getTokensFactory(
   async function fetchAddressesAndIds(networkId: number, numTokens: number): Promise<Map<string, number>> {
     logDebug(`[tokenListFactory][${networkId}] Fetching addresses for ids from 0 to ${numTokens - 1}`)
 
-    const promises = Array.from({ length: numTokens }, async (_, tokenId) => {
+    const promises = Array.from(
+      { length: numTokens },
+      async (_, tokenId): Promise<[string, number]> => {
         const tokenAddress = await exchangeApi.getTokenAddressById({ networkId, tokenId })
         return [tokenAddress, tokenId]
-      }
+      },
     )
 
     const tokenAddressIdPairs = await Promise.all(promises)

--- a/src/services/factories/tokenList.ts
+++ b/src/services/factories/tokenList.ts
@@ -116,7 +116,7 @@ export function getTokensFactory(
   async function fetchAddressesAndIds(networkId: number, numTokens: number): Promise<Map<string, number>> {
     logDebug(`[${networkId}] Fetching addresses for ids from 0 to ${numTokens - 1}`)
 
-    const promises = [...Array(numTokens).keys()].map((_, tokenId) =>
+    const promises = Array.from({ length: numTokens }, (_, tokenId) =>
       exchangeApi.getTokenAddressById({ networkId, tokenId }),
     )
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -36,7 +36,7 @@ export const getPriceEstimation = getPriceEstimationFactory(apis)
 
 export const subscribeToTokenList = subscribeToTokenListFactory(apis)
 
-export const getTokens = getTokensFactory(apis)
+export const getTokens = getTokensFactory(apis, { getTokenFromErc20 })
 
 export interface TokenAndNetwork {
   networkId: number

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -88,7 +88,7 @@ export async function silentPromise<T>(promise: Promise<T>, customMessage?: stri
   try {
     return await promise
   } catch (e) {
-    console.error(customMessage || 'Failed to fetch promise', e)
+    logDebug(customMessage || 'Failed to fetch promise', e.message)
     return
   }
 }

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -100,7 +100,7 @@ interface RetryFnParams<T> {
 
 interface RetryOptions {
   retriesLeft?: number
-  delay?: number
+  interval?: number
   exponentialBackOff?: boolean
 }
 
@@ -112,22 +112,22 @@ interface RetryOptions {
  * @param fn Function to retry
  * @param fnParams Optional parameters list to pass to function
  * @param retriesLeft How many retries. Defaults to 3
- * @param delay How long to wait between retries. Defaults to 1s
+ * @param interval How long to wait between retries. Defaults to 1s
  * @param exponentialBackOff Whether to use exponential back off, doubling wait interval. Defaults to true
  */
 export async function retry<T>(params: RetryFnParams<T>, options?: RetryOptions): Promise<T> {
   const { fn, fnParams } = params
-  const { retriesLeft = 3, delay = 1000, exponentialBackOff = true } = options || {}
+  const { retriesLeft = 3, interval = 1000, exponentialBackOff = true } = options || {}
 
   try {
     return fn(...fnParams)
   } catch (error) {
     if (retriesLeft) {
-      await new Promise(r => setTimeout(r, delay))
+      await delay(interval)
 
       return retry(params, {
         retriesLeft: retriesLeft - 1,
-        delay: exponentialBackOff ? delay * 2 : delay,
+        interval: exponentialBackOff ? interval * 2 : interval,
         exponentialBackOff,
       })
     } else {


### PR DESCRIPTION
Closes #960 

Dynamically loading all tokens from the contract.

When local copy list of tokens length match number of registered token on the contract, update only the token ids.

### Note
1. ~Some tokens do not have symbol/name due to how they are encoded in the contract. For example: https://etherscan.io/address/0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359#readContract (check symbol and name)~
2. Some tokens fail to get the balance https://rinkeby.etherscan.io/address/0x2A642a7D6Fb2be3F2ADbcb3457F7953483c28213#code (don't know yet why)
3. Rinkeby contract has 3 addresses registered which are just plain addresses, not contracts:
```
[4] Address 0x4A642a7d6fb2be3f2adbcb3457F7953483c28223 is not a valid ERC20 token 
[4] Address 0xD0DC005d31C2979CC0d38718e23c82D1A50004C0 is not a valid ERC20 token 
[4] Address 0xAe38b81459d74A8C16eAa968c792207603D84480 is not a valid ERC20 token
```

### Next step: 
Cross reference tokens listed on the contract with whitelisted list of tokens.

### Edit 1

Addressing `1`. Hard coded a local list of token details to overcame issue with tokens not having proper symbol/name set.

So many tokens now:

![screenshot_2020-04-27_13-45-03](https://user-images.githubusercontent.com/43217/80419117-61280380-888d-11ea-9b1a-80088647d029.png)
![screenshot_2020-04-27_13-45-16](https://user-images.githubusercontent.com/43217/80419121-6422f400-888d-11ea-97cd-0d3ffff21066.png)
