### PR TITLE
Liquidity page show orders

### DIFF
--- a/src/components/Layout/Header/Navigation.styled.ts
+++ b/src/components/Layout/Header/Navigation.styled.ts
@@ -33,6 +33,7 @@ export const NavLinksWrapper = styled.div<{ $open?: boolean; $responsive: boolea
     text-align: center;
     box-sizing: border-box;
     height: 5.4rem;
+    min-width: 17.7rem;
     line-height: 1;
     display: flex;
     justify-content: center;
@@ -44,6 +45,7 @@ export const NavLinksWrapper = styled.div<{ $open?: boolean; $responsive: boolea
       padding: 0;
       font-size: 1.3rem;
       width: 100%;
+      min-width: auto;
       height: 4rem;
     }
 

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -21,7 +21,7 @@ export interface HeaderProps {
   }[]
 }
 
-const TopWrapper = styled.div`
+export const TopWrapper = styled.div`
   display: flex;
   flex-flow: row nowrap;
   width: 100%;

--- a/src/components/OrdersWidget/OrdersTable.tsx
+++ b/src/components/OrdersWidget/OrdersTable.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import { AuctionElement, PendingTxObj } from 'api/exchange/ExchangeApi'
+import { CardTable } from 'components/Layout/Card'
+import OrderRow from './OrderRow'
+import { OrderTabs } from '.'
+
+interface OrdersTableProps {
+  displayedOrders: AuctionElement[]
+  displayedPendingOrders: AuctionElement[]
+  networkId: number
+  deleting: boolean
+  selectedTab: OrderTabs
+  markedForDeletion: Set<string>
+  overBalanceOrders: Set<string>
+  toggleSelectAll: (event: React.ChangeEvent<HTMLInputElement>) => void
+  toggleMarkForDeletionFactory: (orderId: string, selectedTab: OrderTabs) => () => void
+}
+
+export const OrdersTable: React.FC<OrdersTableProps> = ({
+  displayedPendingOrders,
+  displayedOrders,
+  toggleSelectAll,
+  markedForDeletion,
+  deleting,
+  networkId,
+  selectedTab,
+  overBalanceOrders,
+  toggleMarkForDeletionFactory,
+}) => {
+  return (
+    <div className="ordersContainer">
+      <CardTable
+        $columns="minmax(2rem,.4fr)  minmax(11rem,1fr)  minmax(11rem,1.3fr)  minmax(5rem,.9fr)  minmax(auto,1.4fr)"
+        $rowSeparation="0"
+      >
+        <thead>
+          <tr>
+            <th className="checked">
+              <input
+                type="checkbox"
+                onChange={toggleSelectAll}
+                checked={markedForDeletion.size === displayedOrders.length}
+                disabled={deleting}
+              />
+            </th>
+            <th>Limit price</th>
+            <th className="filled">Filled / Total</th>
+            <th>Expires</th>
+            <th className="status">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {displayedPendingOrders.map((order: PendingTxObj) => (
+            <OrderRow
+              key={order.id}
+              order={order}
+              networkId={networkId}
+              isOverBalance={false}
+              pending
+              disabled={deleting}
+              isPendingOrder
+              transactionHash={order.txHash}
+            />
+          ))}
+          {displayedOrders.map(order => (
+            <OrderRow
+              key={order.id}
+              order={order}
+              networkId={networkId}
+              isOverBalance={overBalanceOrders.has(order.id)}
+              isMarkedForDeletion={markedForDeletion.has(order.id)}
+              toggleMarkedForDeletion={toggleMarkForDeletionFactory(order.id, selectedTab)}
+              pending={deleting && markedForDeletion.has(order.id)}
+              disabled={deleting}
+            />
+          ))}
+        </tbody>
+      </CardTable>
+    </div>
+  )
+}

--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -1,28 +1,37 @@
 import styled from 'styled-components'
 import { MEDIA } from 'const'
 
-export const OrdersWrapper = styled.div`
+export const OrdersWrapper = styled.div<{ $isWidget?: boolean }>`
   width: 100%;
   display: flex;
   flex-flow: column wrap;
   position: relative;
 
-  /* In use when accessed as a dedicated page and not part of OrdersPanel */
-  background: var(--color-background-pageWrapper);
-  box-shadow: 0 -1rem 4rem 0 rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.02) 0 0.276726rem 0.221381rem 0,
-    rgba(0, 0, 0, 0.027) 0 0.666501rem 0.532008rem 0, rgba(0, 0, 0, 0.035) 0 1.25216rem 1.0172rem 0,
-    rgba(0, 0, 0, 0.043) 0 2.23363rem 1.7869rem 0, rgba(0, 0, 0, 0.05) 0 4.17776rem 3.34221rem 0,
-    rgba(0, 0, 0, 0.07) 0 10rem 8rem 0;
-  border-radius: 0.6rem;
-  min-height: 54rem;
-  min-width: 85rem;
-  max-width: 140rem;
-  /* ====================================================================== */
+  
+  ${({ $isWidget }): string =>
+    $isWidget
+      ? `
+    // Orders component as Widget (e.g inside the OrdersPanel)
+    background: transparent;
+    box-shadow: none;
+    border-radius: 0;
+    min-width: initial;
+    max-width: initial;`
+      : `
+    // As a standalone page
+    background: var(--color-background-pageWrapper);
+    box-shadow: 0 -1rem 4rem 0 rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.02) 0 0.276726rem 0.221381rem 0,
+      rgba(0, 0, 0, 0.027) 0 0.666501rem 0.532008rem 0, rgba(0, 0, 0, 0.035) 0 1.25216rem 1.0172rem 0,
+      rgba(0, 0, 0, 0.043) 0 2.23363rem 1.7869rem 0, rgba(0, 0, 0, 0.05) 0 4.17776rem 3.34221rem 0,
+      rgba(0, 0, 0, 0.07) 0 10rem 8rem 0;
+    border-radius: 0.6rem;
+    min-width: 85rem;
+    max-width: 140rem;
+    `}
 
   @media ${MEDIA.mobile} {
     max-width: 100%;
     min-width: initial;
-    min-height: 25rem;
     width: 100%;
   }
 
@@ -45,17 +54,17 @@ export const OrdersWrapper = styled.div`
   }
 `
 
-export const ButtonWithIcon = styled.button`
+export const ButtonWithIcon = styled.button<{ $color?: string }>`
   padding: 0.5rem 1rem;
   border-radius: 6rem;
-  border: 0.1rem solid var(--color-text-deleteOrders);
+  border: 0.1rem solid;
   transition: background 0.2s ease-in-out, color 0.2s ease-in-out;
   background: transparent;
-  color: var(--color-text-deleteOrders);
+  color: ${({ $color = 'var(--color-text-deleteOrders)' }): string => $color};
   outline: 0;
 
   &:hover {
-    background: var(--color-text-deleteOrders);
+    background: ${({ $color = 'var(--color-text-deleteOrders)' }): string => $color};
     color: var(--color-background-pageWrapper);
   }
 
@@ -64,17 +73,17 @@ export const ButtonWithIcon = styled.button`
   }
 `
 
-export const OrdersForm = styled.div`
-  > form {
-    display: flex;
-    flex-flow: column nowrap;
-    height: 59rem;
+export const OrdersWidgetForm = styled.form`
+  display: flex;
+  flex-flow: column nowrap;
+  height: 59rem;
 
-    @media ${MEDIA.tablet} {
-      height: auto;
-    }
+  @media ${MEDIA.tablet} {
+    height: auto;
   }
+`
 
+export const OrdersWidgetInnerWrapper = styled.div`
   .infoContainer {
     margin: 1rem auto 0;
     display: flex;

--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -1,7 +1,24 @@
 import styled from 'styled-components'
 import { MEDIA } from 'const'
 
-export const OrdersWrapper = styled.div<{ $isWidget?: boolean }>`
+export const OrdersWrapper = styled.div<{
+  $isWidget?: boolean
+  $mobileHeight?: string
+  $tabletHeight?: string
+  $webHeight?: string
+}>`
+  height: ${({ $webHeight = 'auto' }): string | undefined => $webHeight};
+
+  @media ${MEDIA.mobile} {
+    height: ${({ $mobileHeight = 'auto' }): string | undefined => $mobileHeight};
+  }
+
+  @media ${MEDIA.tablet} {
+    height: ${({ $tabletHeight = 'auto' }): string | undefined => $tabletHeight};
+  }
+
+  transition: height 0.2s ease-in;
+
   width: 100%;
   display: flex;
   flex-flow: column wrap;
@@ -39,7 +56,7 @@ export const OrdersWrapper = styled.div<{ $isWidget?: boolean }>`
     width: 100%;
     position: relative;
     display: flex;
-    flex-flow: column wrap;
+    flex-flow: column nowrap;
     flex: 1 1 auto;
     min-width: initial;
   }
@@ -73,25 +90,22 @@ export const ButtonWithIcon = styled.button<{ $color?: string }>`
   }
 `
 
-export const OrdersWidgetForm = styled.form`
+export const OrderWidgetDataWrapper = styled.div`
   display: flex;
   flex-flow: column nowrap;
-  height: 59rem;
-
-  @media ${MEDIA.tablet} {
-    height: auto;
-  }
+  min-height: 5%;
 `
 
 export const OrdersWidgetInnerWrapper = styled.div`
+  height: 100%;
+
   .infoContainer {
-    margin: 1rem auto 0;
+    margin: 0 auto;
     display: flex;
     flex-flow: row nowrap;
     width: 100%;
     justify-content: center;
-    min-height: 6.4rem;
-    border-bottom: 0.1rem solid var(--color-text-secondary);
+    height: 6.4rem;
     align-items: center;
 
     @media ${MEDIA.mobile} {
@@ -122,7 +136,7 @@ export const OrdersWidgetInnerWrapper = styled.div`
         transition: border 0.2s ease-in-out;
         align-items: center;
         border-bottom: 0.3rem solid transparent;
-        min-height: 6.4rem;
+        // min-height: 6.4rem;
 
         @media ${MEDIA.mobile} {
           font-size: 1.3rem;

--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -7,14 +7,14 @@ export const OrdersWrapper = styled.div<{
   $tabletHeight?: string
   $webHeight?: string
 }>`
-  height: ${({ $webHeight = 'auto' }): string | undefined => $webHeight};
+  height: ${({ $webHeight = '60rem' }): string | undefined => $webHeight};
 
   @media ${MEDIA.mobile} {
     height: ${({ $mobileHeight = 'auto' }): string | undefined => $mobileHeight};
   }
 
   @media ${MEDIA.tablet} {
-    height: ${({ $tabletHeight = 'auto' }): string | undefined => $tabletHeight};
+    height: ${({ $tabletHeight = '60rem' }): string | undefined => $tabletHeight};
   }
 
   transition: height 0.2s ease-in;
@@ -66,6 +66,7 @@ export const OrdersWrapper = styled.div<{
   }
 
   .noOrdersInfo {
+    margin: auto;
     text-align: center;
     line-height: 1.4;
   }
@@ -136,7 +137,6 @@ export const OrdersWidgetInnerWrapper = styled.div`
         transition: border 0.2s ease-in-out;
         align-items: center;
         border-bottom: 0.3rem solid transparent;
-        // min-height: 6.4rem;
 
         @media ${MEDIA.mobile} {
           font-size: 1.3rem;

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -13,7 +13,7 @@ import { AuctionElement } from 'api/exchange/ExchangeApi'
 
 import { isOrderActive, isPendingOrderActive } from 'utils'
 
-import { OrdersWrapper, ButtonWithIcon, OrdersWidgetInnerWrapper, OrdersWidgetForm } from './OrdersWidget.styled'
+import { OrdersWrapper, ButtonWithIcon, OrdersWidgetInnerWrapper, OrderWidgetDataWrapper } from './OrdersWidget.styled'
 import { ConnectWalletBanner } from 'components/ConnectWalletBanner'
 import { OrdersTable } from './OrdersTable'
 
@@ -23,7 +23,7 @@ interface ShowOrdersButtonProps {
   type: OrderTabs
   isActive: boolean
   count: number
-  onClick: (event: React.SyntheticEvent<HTMLButtonElement | HTMLFormElement>) => void
+  onClick: (event: React.SyntheticEvent<HTMLButtonElement>) => void
 }
 
 const ShowOrdersButton: React.FC<ShowOrdersButtonProps> = ({ type, isActive, count, onClick }) => (
@@ -73,6 +73,9 @@ interface OrdersWidgetProps {
   orderTabsToShow?: OrderTabs[]
   shouldHideOrders?: boolean
   isWidget?: boolean
+  mobileHeight?: string
+  tabletHeight?: string
+  webHeight?: string
 }
 
 const OrdersWidget: React.FC<OrdersWidgetProps> = ({
@@ -80,6 +83,9 @@ const OrdersWidget: React.FC<OrdersWidgetProps> = ({
   orderTabsToShow = ['active', 'liquidity', 'closed'],
   isWidget,
   shouldHideOrders,
+  mobileHeight,
+  tabletHeight,
+  webHeight,
 }) => {
   // this page is behind login wall so networkId should always be set
   const { networkId, isConnected } = useWalletConnection()
@@ -103,8 +109,8 @@ const OrdersWidget: React.FC<OrdersWidgetProps> = ({
   )
 
   const setSelectedTabFactory = useCallback(
-    (type: OrderTabs): ((event: React.SyntheticEvent<HTMLButtonElement | HTMLFormElement>) => void) => (
-      event: React.SyntheticEvent<HTMLButtonElement | HTMLFormElement>,
+    (type: OrderTabs): ((event: React.SyntheticEvent<HTMLButtonElement>) => void) => (
+      event: React.SyntheticEvent<HTMLButtonElement>,
     ): void => {
       // form is being submitted when clicking on tab buttons, thus preventing default
       event.preventDefault()
@@ -180,8 +186,8 @@ const OrdersWidget: React.FC<OrdersWidgetProps> = ({
 
   const { deleteOrders, deleting } = useDeleteOrders()
 
-  const onSubmit = useCallback(
-    async (event: React.SyntheticEvent<HTMLFormElement>): Promise<void> => {
+  const handleClick = useCallback(
+    async (event: React.SyntheticEvent<HTMLButtonElement>): Promise<void> => {
       event.preventDefault()
 
       const success = await deleteOrders(Array.from(markedForDeletion))
@@ -214,7 +220,12 @@ const OrdersWidget: React.FC<OrdersWidgetProps> = ({
   )
 
   return (
-    <OrdersWrapper $isWidget={isWidget}>
+    <OrdersWrapper
+      $isWidget={isWidget}
+      $mobileHeight={hideOrders ? '6.4rem' : mobileHeight}
+      $tabletHeight={hideOrders ? '6.4rem' : tabletHeight}
+      $webHeight={hideOrders ? '6.4rem' : webHeight}
+    >
       {!isConnected ? (
         <ConnectWalletBanner />
       ) : (
@@ -239,20 +250,21 @@ const OrdersWidget: React.FC<OrdersWidgetProps> = ({
               ))}
             </div>
             {isWidget && shouldHideOrders && (
-              <ButtonWithIcon
+              <button
                 onClick={(): void => setHideOrders(hideOrders => !hideOrders)}
-                $color="var(--color-background-CTA)"
+                style={{ borderRadius: 'var(--border-radius)' }}
+                type="button"
               >
-                <FontAwesomeIcon icon={hideOrders ? faChevronCircleDown : faChevronCircleUp} />
-              </ButtonWithIcon>
+                <FontAwesomeIcon icon={hideOrders ? faChevronCircleDown : faChevronCircleUp} size="xs" />
+              </button>
             )}
           </div>
           {/* Show/Hide Orders table */}
           {!hideOrders && (
-            <OrdersWidgetForm action="submit" onSubmit={onSubmit}>
+            <OrderWidgetDataWrapper>
               <div className="deleteContainer" data-disabled={markedForDeletion.size === 0 || deleting}>
                 <b>↴</b>
-                <ButtonWithIcon disabled={markedForDeletion.size === 0 || deleting} type="submit">
+                <ButtonWithIcon disabled={markedForDeletion.size === 0 || deleting} onClick={handleClick} type="button">
                   <FontAwesomeIcon icon={faTrashAlt} />{' '}
                   {['active', 'liquidity'].includes(selectedTab) ? 'Cancel' : 'Delete'} {markedForDeletion.size} orders
                 </ButtonWithIcon>
@@ -274,7 +286,7 @@ const OrdersWidget: React.FC<OrdersWidgetProps> = ({
                   <span>You have no {selectedTab} orders</span>
                 </div>
               )}
-            </OrdersWidgetForm>
+            </OrderWidgetDataWrapper>
           )}
         </OrdersWidgetInnerWrapper>
       )}

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -238,7 +238,7 @@ const OrdersWidget: React.FC<OrdersWidgetProps> = ({
                 />
               ))}
             </div>
-            {isWidget && (
+            {isWidget && shouldHideOrders && (
               <ButtonWithIcon
                 onClick={(): void => setHideOrders(hideOrders => !hideOrders)}
                 $color="var(--color-background-CTA)"

--- a/src/components/PoolingWidget/index.tsx
+++ b/src/components/PoolingWidget/index.tsx
@@ -294,9 +294,7 @@ const PoolingInterface: React.FC = () => {
               shouldHideOrders
               defaultOrderTab="liquidity"
               orderTabsToShow={['liquidity']}
-              webHeight="30rem"
-              tabletHeight="30rem"
-              mobileHeight="30rem"
+              height="30rem"
             />
 
             <LiquidityMessage>

--- a/src/components/PoolingWidget/index.tsx
+++ b/src/components/PoolingWidget/index.tsx
@@ -12,6 +12,7 @@ import SubComponents from './SubComponents'
 import Widget from 'components/Layout/Widget'
 import LiquidityButtons from './LiquidityButtons'
 import { PoolingInterfaceWrapper } from './PoolingWidget.styled'
+import OrdersWidget from 'pages/Orders'
 
 import useSafeState from 'hooks/useSafeState'
 import { useWalletConnection } from 'hooks/useWalletConnection'
@@ -286,6 +287,8 @@ const PoolingInterface: React.FC = () => {
               {/* Main Components here */}
               <SubComponents step={step} {...restProps} />
             </ContentWrapper>
+
+            <OrdersWidget isWidget shouldHideOrders defaultOrderTab="liquidity" orderTabsToShow={['liquidity']} />
 
             <LiquidityMessage>
               <p>

--- a/src/components/PoolingWidget/index.tsx
+++ b/src/components/PoolingWidget/index.tsx
@@ -288,7 +288,16 @@ const PoolingInterface: React.FC = () => {
               <SubComponents step={step} {...restProps} />
             </ContentWrapper>
 
-            <OrdersWidget isWidget shouldHideOrders defaultOrderTab="liquidity" orderTabsToShow={['liquidity']} />
+            <h5>Your current liquidity orders</h5>
+            <OrdersWidget
+              isWidget
+              shouldHideOrders
+              defaultOrderTab="liquidity"
+              orderTabsToShow={['liquidity']}
+              webHeight="30rem"
+              tabletHeight="30rem"
+              mobileHeight="30rem"
+            />
 
             <LiquidityMessage>
               <p>

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -16,7 +16,6 @@ import TokenRow from './TokenRow'
 import OrderValidity from './OrderValidity'
 import Widget from 'components/Layout/Widget'
 import OrdersWidget from 'components/OrdersWidget'
-import { OrdersWrapper } from 'components/OrdersWidget/OrdersWidget.styled'
 import { TopWrapper as CenterWrapper } from 'components/Layout/Header'
 import { TxNotification } from 'components/TxNotification'
 import { Wrapper } from 'components/ConnectWalletBanner'
@@ -216,7 +215,7 @@ const SubmitButton = styled.button`
 `
 
 const OrdersPanel = styled.div`
-  overflow: hidden;
+  height: 100%;
   display: flex;
   flex-flow: column nowrap;
   flex: 1;
@@ -295,9 +294,6 @@ const OrdersPanel = styled.div`
       }
     }
   }
-  // ${OrdersWrapper} {
-  //   height: 92%;
-  // }
 `
 
 const OrdersToggler = styled.button<{ $isOpen?: boolean }>`
@@ -989,7 +985,7 @@ const TradeWidget: React.FC = () => {
         <CenterWrapper>
           <h5>Your orders</h5>
         </CenterWrapper>
-        <OrdersWidget isWidget tabletHeight="58rem" />
+        <OrdersWidget isWidget webHeight="92%" />
       </OrdersPanel>
       {/* React Forms DevTool debugger */}
       {process.env.NODE_ENV === 'development' &&

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -16,7 +16,6 @@ import TokenRow from './TokenRow'
 import OrderValidity from './OrderValidity'
 import Widget from 'components/Layout/Widget'
 import OrdersWidget from 'components/OrdersWidget'
-import { OrdersWrapper } from 'components/OrdersWidget/OrdersWidget.styled'
 import { TxNotification } from 'components/TxNotification'
 import { Wrapper } from 'components/ConnectWalletBanner'
 import FormMessage from './FormMessage'
@@ -243,16 +242,6 @@ const OrdersPanel = styled.div`
   ${Wrapper} {
     background: transparent;
     box-shadow: none;
-  }
-
-  // Orders widget when inside the OrdersPanel
-  ${OrdersWrapper} {
-    background: transparent;
-    box-shadow: none;
-    border-radius: 0;
-    min-height: initial;
-    min-width: initial;
-    max-width: initial;
   }
 
   > div {
@@ -999,7 +988,7 @@ const TradeWidget: React.FC = () => {
         {/* Actual orders content */}
         <div>
           <h5>Your orders</h5>
-          <OrdersWidget />
+          <OrdersWidget isWidget />
         </div>
       </OrdersPanel>
       {/* React Forms DevTool debugger */}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -16,6 +16,8 @@ import TokenRow from './TokenRow'
 import OrderValidity from './OrderValidity'
 import Widget from 'components/Layout/Widget'
 import OrdersWidget from 'components/OrdersWidget'
+import { OrdersWrapper } from 'components/OrdersWidget/OrdersWidget.styled'
+import { TopWrapper as CenterWrapper } from 'components/Layout/Header'
 import { TxNotification } from 'components/TxNotification'
 import { Wrapper } from 'components/ConnectWalletBanner'
 import FormMessage from './FormMessage'
@@ -79,7 +81,7 @@ const WrappedWidget = styled(Widget)`
   line-height: 1;
 
   @media ${MEDIA.tablet}, ${MEDIA.mobile} {
-    flex-flow: column wrap;
+    flex-flow: column nowrap;
     max-height: initial;
     min-height: initial;
     width: 100%;
@@ -216,7 +218,7 @@ const SubmitButton = styled.button`
 const OrdersPanel = styled.div`
   overflow: hidden;
   display: flex;
-  flex-flow: column wrap;
+  flex-flow: column nowrap;
   flex: 1;
   min-width: 48rem;
   max-width: 100%;
@@ -246,7 +248,7 @@ const OrdersPanel = styled.div`
 
   > div {
     width: 100%;
-    width: calc(100% - 1.6rem);
+    // width: calc(100% - 1.6rem);
     box-sizing: border-box;
     display: flex;
     flex-flow: row wrap;
@@ -272,32 +274,30 @@ const OrdersPanel = styled.div`
     }
   }
 
-  > div > h5 {
-    width: 100%;
-    margin: 0 auto;
-    padding: 1.6rem 0 1rem;
-    font-weight: var(--font-weight-bold);
-    font-size: 1.6rem;
-    color: var(--color-text-primary);
-    letter-spacing: 0.03rem;
-    text-align: center;
-    box-sizing: border-box;
-    text-align: center;
-  }
+  > ${CenterWrapper} {
+    height: 8%;
 
-  > div > h5 > a {
-    font-size: 1.3rem;
-    font-weight: var(--font-weight-normal);
-    color: var(--color-text-active);
-    text-decoration: underline;
+    > h5 {
+      width: 100%;
+      margin: 0 auto;
+      font-weight: var(--font-weight-bold);
+      font-size: 1.6rem;
+      color: var(--color-text-primary);
+      letter-spacing: 0.03rem;
+      text-align: center;
+      box-sizing: border-box;
+      text-align: center;
+      > a {
+        font-size: 1.3rem;
+        font-weight: var(--font-weight-normal);
+        color: var(--color-text-active);
+        text-decoration: underline;
+      }
+    }
   }
-
-  > div > h5 > a {
-    font-size: 1.3rem;
-    font-weight: var(--font-weight-normal);
-    color: var(--color-text-active);
-    text-decoration: underline;
-  }
+  // ${OrdersWrapper} {
+  //   height: 92%;
+  // }
 `
 
 const OrdersToggler = styled.button<{ $isOpen?: boolean }>`
@@ -978,18 +978,18 @@ const TradeWidget: React.FC = () => {
           </SubmitButton>
         </WrappedForm>
       </FormContext>
+      {/* Toggle panel visibility (arrow) */}
+      <OrdersToggler
+        type="button"
+        onClick={(): void => setOrdersVisible(ordersVisible => !ordersVisible)}
+        $isOpen={ordersVisible}
+      />
       <OrdersPanel>
-        {/* Toggle panel visibility (arrow) */}
-        <OrdersToggler
-          type="button"
-          onClick={(): void => setOrdersVisible(ordersVisible => !ordersVisible)}
-          $isOpen={ordersVisible}
-        />
         {/* Actual orders content */}
-        <div>
+        <CenterWrapper>
           <h5>Your orders</h5>
-          <OrdersWidget isWidget />
-        </div>
+        </CenterWrapper>
+        <OrdersWidget isWidget tabletHeight="58rem" />
       </OrdersPanel>
       {/* React Forms DevTool debugger */}
       {process.env.NODE_ENV === 'development' &&


### PR DESCRIPTION
Closes #989 

If we want it, we can have it

1. adds Liquidity OrdersWidget to Liquidity page [only the liquidity tab]
2. modalises more the CSS/logic for OrdersWidget to facilitate moving it around
2.5: adds a loading spinner to OrderWidget orders type tab when loading the orders and getting the count - this is only triggered when loading the Active/Liquidity/Closed orders
3. minor CSS fixes that were annoying
    a. Nav menus weren't aligned before
4. refactor OrdersWidget index a bit to move OrdersTable into own comp
5. Change `<form>` inside `OrdersWidget` only responsible for removing orders into a div with onClick to avoid form within form problem from adding OrdersWidget inside of Liquidity (which also uses form)