### PR TITLE
944/enable token label

### DIFF
--- a/src/assets/md/FAQ.md
+++ b/src/assets/md/FAQ.md
@@ -2,11 +2,11 @@
 
 Mesa is a decentralized application built on the **Gnosis Protocol**, a fully permissionless DEX that enables ring trades to maximize liquidity.  
 Gnosis Protocol enables ring trades to maximize liquidity. Ring trades are order settlements which share liquidity across all orders, rather than a single token pair, and uniquely suited for trading prediction market tokens and the long tail of all tokenized assets.
- Read more about the protocol’s mechanism on the Gnosis [Developer Portal](https://docs.gnosis.io/protocol/docs/introduction1/).
+Read more about the protocol’s mechanism on the Gnosis [Developer Portal](https://docs.gnosis.io/protocol/docs/introduction1/).
 
 **How are trades matched?**
 
-Orders are collected in batches every 5 minutes, and external participants called solvers (everyone can participate as a solver) propose a settlement solution to the smart contract. The smart contract selects the solution that maximizes [trader welfare](https://docs.gnosis.io/protocol/docs/devguide01/). The utility in this optimization function is the difference between what a trader is willing to pay and what they pay once a batch is cleared. After a solution is selected, orders are matched and settled accordingly and on-chain. 
+Orders are collected in batches every 5 minutes, and external participants called solvers (everyone can participate as a solver) propose a settlement solution to the smart contract. The smart contract selects the solution that maximizes [trader welfare](https://docs.gnosis.io/protocol/docs/devguide01/). The utility in this optimization function is the difference between what a trader is willing to pay and what they pay once a batch is cleared. After a solution is selected, orders are matched and settled accordingly and on-chain.
 
 **What advantages do ring trades bring?**
 
@@ -20,6 +20,12 @@ The Gnosis Protocol smart contracts have been audited externally. Check this sec
 
 Indeed, orders can be placed without a corresponding balance in the Exchange Wallet. However, **_only_** orders with a balance in the Exchange Wallet can be matched and filled.
 
+**Why do I need to **Enable Deposit**?**
+
+In order to transfer funds from your wallet into the Exchange Wallet, the Exchange smart contract needs to be allowed to do so. This is what we call **Enable Deposit**.
+Without this, you won't be able to deposit into the contract.
+**Enable Deposit** does not in any way interfere on your capacity to request withdraws.
+
 **What is the Liquidity page?**
 
 Liquidity provision is a way in which Mesa users can easily provide liquidity and get rewarded with little effort and low risk. It works by letting users place standing orders to market-make between selected tokens.
@@ -28,6 +34,6 @@ To provide liquidity, click on the `Liquidity` page, and follow three simple ste
 
 **Users must also have at least one of the tokens of their liquidity provision deposited in their Exchange Wallet to enable trades.**
 
-Importantly, don’t forget that **all** orders placed by an Ethereum address share the same deposited liquidity! Consider participating with separate addresses for separate strategies when partaking in the liquidity provision and when trading normally. 
+Importantly, don’t forget that **all** orders placed by an Ethereum address share the same deposited liquidity! Consider participating with separate addresses for separate strategies when partaking in the liquidity provision and when trading normally.
 
 Learn more about liquidity provision on [this section](https://docs.gnosis.io/protocol/docs/liquidity1/) of the the Gnosis Developer Portal.

--- a/src/assets/md/FAQ.md
+++ b/src/assets/md/FAQ.md
@@ -20,11 +20,10 @@ The Gnosis Protocol smart contracts have been audited externally. Check this sec
 
 Indeed, orders can be placed without a corresponding balance in the Exchange Wallet. However, **_only_** orders with a balance in the Exchange Wallet can be matched and filled.
 
-**Why do I need to **Enable Deposit**?**
+**Why do I need to _Enable Deposit_?**
 
-In order to transfer funds from your wallet into the Exchange Wallet, the Exchange smart contract needs to be allowed to do so. This is what we call **Enable Deposit**.
-Without this, you won't be able to deposit into the contract.
-**Enable Deposit** does not in any way interfere on your capacity to request withdraws.
+In order to participate on the Gnosis Protocol as liquidity provider or as trader, you need to transfer funds from your wallet into the Exchange Wallet. With the button **Enable Deposit**, you set this allowance for the Gnosis Protocol smart contract.
+Note that you only need to **Enable Deposit** for the token(s) you want to actively deposit. You can withdraw any token you receive from trading without having to enable first.
 
 **What is the Liquidity page?**
 

--- a/src/components/DepositWidget/Row.tsx
+++ b/src/components/DepositWidget/Row.tsx
@@ -151,10 +151,10 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
                 {enabling ? (
                   <>
                     <FontAwesomeIcon icon={faSpinner} spin />
-                    Enabling {symbol}
+                    Enabling
                   </>
                 ) : (
-                  <>Enable {symbol} Deposit</>
+                  <>Enable Deposit</>
                 )}
               </button>
             </>

--- a/src/components/DepositWidget/Row.tsx
+++ b/src/components/DepositWidget/Row.tsx
@@ -154,7 +154,7 @@ export const Row: React.FC<RowProps> = (props: RowProps) => {
                     Enabling {symbol}
                   </>
                 ) : (
-                  <>Enable {symbol}</>
+                  <>Enable {symbol} Deposit</>
                 )}
               </button>
             </>


### PR DESCRIPTION
Closes #944 

Given the following options, I picked the third one: *Deposit* after *symbol*

1. This is what we have right now on Mesa:
![screenshot_2020-05-06_13-38-42](https://user-images.githubusercontent.com/43217/81226294-7bee2c80-8f9f-11ea-8439-fac66d8c593d.png)

1. This is what the issue asks for, but for me it looks a bit weird: *Deposit* before *symbol*
![screenshot_2020-05-06_13-38-22](https://user-images.githubusercontent.com/43217/81226298-7c86c300-8f9f-11ea-82cc-aca6bb52b65c.png)

1. So I moved *Deposit* after *symbol*.
![screenshot_2020-05-06_13-37-30](https://user-images.githubusercontent.com/43217/81226303-7db7f000-8f9f-11ea-96e3-bce1d879b411.png)

1. Another option is to have no *symbol*. This info is redundant as the same line already contains which token this refers to.
![screenshot_2020-05-06_13-37-58](https://user-images.githubusercontent.com/43217/81226302-7db7f000-8f9f-11ea-8a3d-2400efd03022.png)

Also, added an FAQ entry regarding what *Enabling a deposit* means/why it's needed.

Also also, should we have something from the *Enable* button linking to the FAQ, like a tooltip?


### Notes
1. Options `2` and `3` break the layout a bit.
1. Avoided touching CSS to adjust the column size and not break anything (else) in the layout. Waiting for input first on what option we'll take.
1. FAQ entry to be reviewed by @c3rnst, @Rafanator and whomever else is needed.