### PR TITLE
Fix tcr override

### DIFF
--- a/src/api/tokenList/TokenListApi.ts
+++ b/src/api/tokenList/TokenListApi.ts
@@ -36,6 +36,8 @@ export interface PersistTokensParams {
   tokenList: TokenDetails[]
 }
 
+type tokenListType = 'user' | 'service'
+
 /**
  * Basic implementation of Token API
  *
@@ -55,8 +57,9 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
     networkIds.forEach(networkId => {
       // initial value
       const tokenList = TokenListApiImpl.mergeTokenLists(
-        // load first the local list, as this might be more up to date
-        this.loadUserTokenList(networkId),
+        // load first the local lists, as they might be more up to date
+        this.loadTokenList(networkId, 'service'),
+        this.loadTokenList(networkId, 'user'),
         // then default list
         getTokensByNetwork(networkId),
       )
@@ -78,16 +81,18 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
     return this._tokensByNetwork[networkId] || []
   }
 
-  private static mergeTokenLists(baseList: TokenDetails[], newList: TokenDetails[]): TokenDetails[] {
+  private static mergeTokenLists(...lists: TokenDetails[][]): TokenDetails[] {
     const seenAddresses = new Set<string>()
     const result: TokenDetails[] = []
 
-    baseList.concat(newList).forEach(token => {
-      if (!seenAddresses.has(token.address.toLowerCase())) {
-        seenAddresses.add(token.address.toLowerCase())
-        result.push(token)
-      }
-    })
+    lists
+      .reduce((acc, l) => acc.concat(l), [])
+      .forEach(token => {
+        if (!seenAddresses.has(token.address.toLowerCase())) {
+          seenAddresses.add(token.address.toLowerCase())
+          result.push(token)
+        }
+      })
     return result
   }
 
@@ -95,8 +100,8 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
     return tokenAddress.toLowerCase() + '|' + networkId
   }
 
-  private static getLocalStorageKey(networkId: number): string {
-    return 'USER_TOKEN_LIST_' + networkId
+  private static getStorageKey(networkId: number, type: tokenListType): string {
+    return `${type.toString().toUpperCase()}_TOKEN_LIST_${networkId}`
   }
 
   public addToken({ networkId, token }: AddTokenParams): void {
@@ -117,32 +122,39 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
     })
     if (addedTokens.length === 0) return
 
-    this._tokensByNetwork[networkId] = this._tokensByNetwork[networkId].concat(addedTokens)
+    this._tokensByNetwork[networkId] = TokenListApiImpl.mergeTokenLists(this._tokensByNetwork[networkId], addedTokens)
     this.persistNewUserTokens(addedTokens, networkId)
 
     this.triggerSubscriptions(this._tokensByNetwork[networkId])
   }
-
-  private loadUserTokenList(networkId: number): TokenDetails[] {
-    const storageKey = TokenListApiImpl.getLocalStorageKey(networkId)
+  private loadTokenList(networkId: number, type: tokenListType): TokenDetails[] {
+    const storageKey = TokenListApiImpl.getStorageKey(networkId, type)
     const listStringified = localStorage.getItem(storageKey)
     return listStringified ? JSON.parse(listStringified) : []
   }
 
   private persistNewUserTokens(tokens: TokenDetails[], networkId: number): void {
-    const storageKey = TokenListApiImpl.getLocalStorageKey(networkId)
+    const storageKey = TokenListApiImpl.getStorageKey(networkId, 'user')
     const listStringified = localStorage.getItem(storageKey)
-    const currentUserList: TokenDetails[] = (listStringified ? JSON.parse(listStringified) : []).concat(tokens)
+
+    const currentUserList: TokenDetails[] = TokenListApiImpl.mergeTokenLists(
+      listStringified ? JSON.parse(listStringified) : [],
+      tokens,
+    )
 
     localStorage.setItem(storageKey, JSON.stringify(currentUserList))
   }
 
   public persistTokens({ networkId, tokenList }: PersistTokensParams): void {
-    // update copy in memory
-    this._tokensByNetwork[networkId] = tokenList
-    // update copy in local storage
-    const storageKey = TokenListApiImpl.getLocalStorageKey(networkId)
-    localStorage.setItem(storageKey, JSON.stringify(tokenList))
+    // fetch list of user added tokens
+    const userAddedTokens = this.loadTokenList(networkId, 'user')
+    // update copy in memory, appending anything user might have added
+    this._tokensByNetwork[networkId] = TokenListApiImpl.mergeTokenLists(tokenList, userAddedTokens)
+
+    // update copy in local storage for service tokens
+    const serviceStorageKey = TokenListApiImpl.getStorageKey(networkId, 'service')
+    localStorage.setItem(serviceStorageKey, JSON.stringify(tokenList))
+
     // update address network set
     tokenList.forEach(({ address: tokenAddress }) =>
       this._tokenAddressNetworkSet.add(TokenListApiImpl.constructAddressNetworkKey({ tokenAddress, networkId })),

--- a/src/api/tokenList/TokenListApi.ts
+++ b/src/api/tokenList/TokenListApi.ts
@@ -118,7 +118,7 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
     if (addedTokens.length === 0) return
 
     this._tokensByNetwork[networkId] = this._tokensByNetwork[networkId].concat(addedTokens)
-    this.persistNewUserTokens(tokens, networkId)
+    this.persistNewUserTokens(addedTokens, networkId)
 
     this.triggerSubscriptions(this._tokensByNetwork[networkId])
   }

--- a/src/services/factories/tokenList.ts
+++ b/src/services/factories/tokenList.ts
@@ -95,7 +95,7 @@ export function getTokensFactory(
       }, [])
 
       // persist updated list
-      tokenListApi.persistTokens({ networkId, tokenList })
+      tokenListApi.addTokens({ networkId, tokens: tokenList })
     }
 
     // if something failed...
@@ -209,7 +209,7 @@ export function getTokensFactory(
     const tokenList = Array.from(localAddressesMap.values())
 
     // Persist it \o/
-    tokenListApi.persistTokens({ networkId, tokenList })
+    tokenListApi.addTokens({ networkId, tokens: tokenList })
   }
 
   async function updateTokens(networkId: number): Promise<void> {

--- a/src/services/factories/tokenList.ts
+++ b/src/services/factories/tokenList.ts
@@ -95,7 +95,7 @@ export function getTokensFactory(
       }, [])
 
       // persist updated list
-      tokenListApi.addTokens({ networkId, tokens: tokenList })
+      tokenListApi.persistTokens({ networkId, tokenList })
     }
 
     // if something failed...
@@ -209,7 +209,7 @@ export function getTokensFactory(
     const tokenList = Array.from(localAddressesMap.values())
 
     // Persist it \o/
-    tokenListApi.addTokens({ networkId, tokens: tokenList })
+    tokenListApi.persistTokens({ networkId, tokenList })
   }
 
   async function updateTokens(networkId: number): Promise<void> {


### PR DESCRIPTION
On load `USER_TOKEN_LIST` was overridden with tokens from **TCR**.
As a result if user previously added an extra token not in **TCR**, it would disappear on page refresh

[Related](https://github.com/gnosis/dex-react/pull/981#issuecomment-625725927)