### PR TITLE
Inline config test

### DIFF
--- a/src/actualUseCase.ts
+++ b/src/actualUseCase.ts
@@ -1,0 +1,37 @@
+import { TcrApi } from 'api/tcr/TcrApi'
+
+// src/const.ts
+let ethNodeUrl
+if (CONFIG.defaultProviderConfig.type === 'infura') {
+  const { config } = CONFIG.defaultProviderConfig
+  ethNodeUrl = config.infuraEndpoint + config.infuraId
+} else if (CONFIG.defaultProviderConfig.type === 'url') {
+  const { config } = CONFIG.defaultProviderConfig
+  ethNodeUrl = config.ethNodeUrl
+} else {
+  throw new Error('Default provider URL is not set. Either provide ETH_NODE_URL env var or use the config.')
+}
+console.log('ethNodeUrl', ethNodeUrl)
+
+// src/api/index.ts
+function createTcrApi(): TcrApi | undefined {
+  const { type } = CONFIG.tcr
+  let tcrApi: TcrApi | undefined
+  switch (CONFIG.tcr.type) {
+    case 'none':
+      tcrApi = undefined
+      break
+    case 'multi-tcr':
+      const multiTcrApiConfig = CONFIG.tcr
+      tcrApi = /* new MultiTcrApiProxy({ web3, ...multiTcrApiConfig.config }) */ multiTcrApiConfig as any
+      break
+
+    default:
+      throw new Error('Unknown implementation for DexPriceEstimatorApi: ' + type)
+  }
+
+  window['tcrApi'] = tcrApi
+  return tcrApi
+}
+
+createTcrApi()

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -150,11 +150,12 @@ function createDexPriceEstimatorApi(): DexPriceEstimatorApi {
 function createTcrApi(web3: Web3): TcrApi | undefined {
   const { type } = CONFIG.tcr
   let tcrApi: TcrApi | undefined
-  switch (type) {
+  switch (CONFIG.tcr.type) {
     case 'none':
       tcrApi = undefined
+      break
     case 'multi-tcr':
-      const multiTcrApiConfig = CONFIG.tcr as MultiTcrConfig
+      const multiTcrApiConfig = CONFIG.tcr
       tcrApi = new MultiTcrApiProxy({ web3, ...multiTcrApiConfig.config })
       break
 

--- a/src/compiled/actualUseCase.js
+++ b/src/compiled/actualUseCase.js
@@ -1,0 +1,37 @@
+(window.webpackJsonp = window.webpackJsonp || []),
+  )
+  .push([
+  [0],
+  [
+    function (n, d) {
+      let a, c, i
+        ; (a =
+          (c = {
+            infuraId: '607a7dfcb1ad4a0b83152e30ce20cfc5',
+            infuraEndpoint: 'wss://mainnet.infura.io/ws/v3/',
+          }).infuraEndpoint + c.infuraId),
+          console.log('ethNodeUrl', a),
+          // webpack was smart enough to statically unfurl switch-case
+          // to plain assignment
+          (i = {
+            type: 'multi-tcr',
+            config: {
+              lists: [
+                {
+                  networkId: 1,
+                  listId: 1,
+                  contractAddress: '0x1854dae560abb0f399d8badca456663ca5c309d0',
+                },
+                {
+                  networkId: 4,
+                  contractAddress: '0xBb840456546496E7640DC09ba9fE06E67C157E1b',
+                },
+              ],
+            },
+          }),
+          (window.tcrApi = i)
+    },
+  ],
+  [[0, 2]],
+])
+//# sourceMappingURL=actualUseCase~3111bff6.0b2a.js.map

--- a/src/compiled/destructure.js
+++ b/src/compiled/destructure.js
@@ -1,0 +1,26 @@
+;(window.webpackJsonp = window.webpackJsonp || []).push([
+  [1],
+  {
+    2: function(c, o) {
+      const t = {
+        type: 'multi-tcr',
+        config: {
+          lists: [
+            {
+              networkId: 1,
+              listId: 1,
+              contractAddress: '0x1854dae560abb0f399d8badca456663ca5c309d0',
+            },
+            {
+              networkId: 4,
+              contractAddress: '0xBb840456546496E7640DC09ba9fE06E67C157E1b',
+            },
+          ],
+        },
+      } // inlined once
+      console.log('tcr', t), console.log('tcr', t)
+    },
+  },
+  [[2, 5]],
+])
+//# sourceMappingURL=destructure~4909f61f.daed.js.map

--- a/src/compiled/duplication.js
+++ b/src/compiled/duplication.js
@@ -1,0 +1,42 @@
+;(window.webpackJsonp = window.webpackJsonp || []).push([
+  [2],
+  [
+    ,
+    function(c, t) {
+      console.log('CONFIG.tcr', {
+        type: 'multi-tcr',
+        config: {
+          lists: [
+            {
+              networkId: 1,
+              listId: 1,
+              contractAddress: '0x1854dae560abb0f399d8badca456663ca5c309d0',
+            },
+            {
+              networkId: 4,
+              contractAddress: '0xBb840456546496E7640DC09ba9fE06E67C157E1b',
+            },
+          ],
+        },
+      }), // inlined once
+        console.log('CONFIG.tcr', {
+          type: 'multi-tcr',
+          config: {
+            lists: [
+              {
+                networkId: 1,
+                listId: 1,
+                contractAddress: '0x1854dae560abb0f399d8badca456663ca5c309d0',
+              },
+              {
+                networkId: 4,
+                contractAddress: '0xBb840456546496E7640DC09ba9fE06E67C157E1b',
+              },
+            ],
+          },
+        }) // inlined twice
+    },
+  ],
+  [[1, 6]],
+])
+//# sourceMappingURL=duplication~87bd892e.5bca.js.map

--- a/src/compiled/inlinedConfig.js
+++ b/src/compiled/inlinedConfig.js
@@ -1,0 +1,56 @@
+;(window.webpackJsonp = window.webpackJsonp || []).push([
+  [0],
+  [
+    // // this is from inlinedConfig.ts
+    function(o, a, n) {
+      'use strict'
+      n.r(a)
+      const c = {
+        infuraId: '607a7dfcb1ad4a0b83152e30ce20cfc5',
+        infuraEndpoint: 'wss://mainnet.infura.io/ws/v3/',
+      } // const { config } = CONFIG.defaultProviderConfig
+      console.log('ID:', c),
+        console.log('list 1', {
+          networkId: 1,
+          listId: 1,
+          contractAddress: '0x1854dae560abb0f399d8badca456663ca5c309d0',
+        }), // console.log('list 1', (CONFIG.tcr as MultiTcrConfig).config.lists[0])
+        // this is from imported1.ts
+        (function() {
+          const o = {
+            infuraId: '607a7dfcb1ad4a0b83152e30ce20cfc5',
+            infuraEndpoint: 'wss://mainnet.infura.io/ws/v3/',
+          } // const { config } = CONFIG.defaultProviderConfig
+          console.log('ID:', o),
+            console.log('lists', {
+              networkId: 1,
+              listId: 1,
+              contractAddress: '0x1854dae560abb0f399d8badca456663ca5c309d0',
+            }) // console.log('lists', (CONFIG.tcr as MultiTcrConfig).config.lists[0])
+        })(),
+        // this is from imported2.ts
+        (function() {
+          console.log('./src/assets/img/logo.svg'), // console.log(CONFIG.logoPath)
+            console.log('Mesa - Gnosis Protocol DApp'), // console.log(CONFIG.name)
+            console.log({
+              infuraId: '607a7dfcb1ad4a0b83152e30ce20cfc5',
+              infuraEndpoint: 'wss://mainnet.infura.io/ws/v3/',
+            }) // console.log(CONFIG.defaultProviderConfig.config)
+          const o = [
+            {
+              networkId: 1,
+              listId: 1,
+              contractAddress: '0x1854dae560abb0f399d8badca456663ca5c309d0',
+            },
+            {
+              networkId: 4,
+              contractAddress: '0xBb840456546496E7640DC09ba9fE06E67C157E1b',
+            },
+          ] // const {config: { lists }} = CONFIG.tcr as MultiTcrConfig
+          console.log('list 1', o[0]) // console.log('list 1', lists[0])
+        })()
+    },
+  ],
+  [[0, 1]],
+])
+//# sourceMappingURL=inlinedConfig~d145723b.e52a.js.map

--- a/src/compiled/wrongUseCase.js
+++ b/src/compiled/wrongUseCase.js
@@ -1,0 +1,42 @@
+;(window.webpackJsonp = window.webpackJsonp || []).push([
+  [9],
+  [
+    ,
+    function(t, n) {
+      !(function() {
+        let t,
+          n = {
+            type: 'multi-tcr',
+            config: {
+              lists: [
+                {
+                  networkId: 1,
+                  listId: 1,
+                  contractAddress: '0x1854dae560abb0f399d8badca456663ca5c309d0',
+                },
+                {
+                  networkId: 4,
+                  contractAddress: '0xBb840456546496E7640DC09ba9fE06E67C157E1b',
+                },
+              ],
+            },
+          }, // destructure here
+          e = n.type
+        // can't treeshake here
+        switch (n.type) {
+          case 'none':
+            t = void 0
+            break
+          case 'multi-tcr':
+            t = n
+            break
+          default:
+            throw new Error('Unknown implementation for DexPriceEstimatorApi: ' + e)
+        }
+        window.tcrApi = t
+      })()
+    },
+  ],
+  [[1, 8]],
+])
+//# sourceMappingURL=wrongUseCase~89388015.cab5.js.map

--- a/src/const.ts
+++ b/src/const.ts
@@ -102,7 +102,7 @@ let infuraId
 if (process.env.INFURA_ID) {
   infuraId = process.env.INFURA_ID
 } else if (CONFIG.defaultProviderConfig.type === 'infura') {
-  const { config } = CONFIG.defaultProviderConfig as InfuraProviderConfig
+  const { config } = CONFIG.defaultProviderConfig
   infuraId = config.infuraId
 } else {
   infuraId = ''
@@ -114,10 +114,10 @@ let ethNodeUrl
 if (process.env.ETH_NODE_URL) {
   ethNodeUrl = process.env.ETH_NODE_URL
 } else if (CONFIG.defaultProviderConfig.type === 'infura') {
-  const { config } = CONFIG.defaultProviderConfig as InfuraProviderConfig
+  const { config } = CONFIG.defaultProviderConfig
   ethNodeUrl = config.infuraEndpoint + config.infuraId
 } else if (CONFIG.defaultProviderConfig.type === 'url') {
-  const { config } = CONFIG.defaultProviderConfig as UrlProviderConfig
+  const { config } = CONFIG.defaultProviderConfig
   ethNodeUrl = config.ethNodeUrl
 } else {
   throw new Error('Default provider URL is not set. Either provide ETH_NODE_URL env var or use the config.')

--- a/src/destructure.ts
+++ b/src/destructure.ts
@@ -1,0 +1,3 @@
+const { tcr } = CONFIG
+console.log('tcr', tcr)
+console.log('tcr', tcr)

--- a/src/duplication.ts
+++ b/src/duplication.ts
@@ -1,0 +1,2 @@
+console.log('CONFIG.tcr', CONFIG.tcr)
+console.log('CONFIG.tcr', CONFIG.tcr)

--- a/src/imported1.ts
+++ b/src/imported1.ts
@@ -1,0 +1,8 @@
+import { MultiTcrConfig } from 'types/config'
+
+export const log = (): void => {
+  const { config } = CONFIG.defaultProviderConfig
+  console.log('ID:', config)
+
+  console.log('lists', (CONFIG.tcr as MultiTcrConfig).config.lists[0])
+}

--- a/src/imported2.ts
+++ b/src/imported2.ts
@@ -1,0 +1,13 @@
+import { MultiTcrConfig } from 'types/config'
+
+export const log = (): void => {
+  console.log(CONFIG.logoPath)
+  console.log(CONFIG.name)
+  console.log(CONFIG.defaultProviderConfig.config)
+
+  const {
+    config: { lists },
+  } = CONFIG.tcr as MultiTcrConfig
+
+  console.log('list 1', lists[0])
+}

--- a/src/inlineConfig.ts
+++ b/src/inlineConfig.ts
@@ -1,0 +1,9 @@
+import { MultiTcrConfig } from 'types/config'
+import { log as log1 } from './imported1'
+import { log as log2 } from './imported2'
+const { config } = CONFIG.defaultProviderConfig
+console.log('ID:', config)
+
+console.log('list 1', (CONFIG.tcr as MultiTcrConfig).config.lists[0])
+log1()
+log2()

--- a/src/wrongUseCase.ts
+++ b/src/wrongUseCase.ts
@@ -1,0 +1,25 @@
+import { TcrApi } from 'api/tcr/TcrApi'
+
+// src/api/index.ts
+function createTcrApi(): TcrApi | undefined {
+  const tcr = CONFIG.tcr
+  const { type } = tcr
+  let tcrApi: TcrApi | undefined
+  switch (tcr.type) {
+    case 'none':
+      tcrApi = undefined
+      break
+    case 'multi-tcr':
+      const multiTcrApiConfig = tcr
+      tcrApi = /* new MultiTcrApiProxy({ web3, ...multiTcrApiConfig.config }) */ multiTcrApiConfig as any
+      break
+
+    default:
+      throw new Error('Unknown implementation for DexPriceEstimatorApi: ' + type)
+  }
+
+  window['tcrApi'] = tcrApi
+  return tcrApi
+}
+
+createTcrApi()

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -22,6 +22,12 @@ const { name: appName } = config
 
 module.exports = ({ stats = false } = {}) => ({
   devtool: isProduction ? 'source-map' : 'eval-source-map',
+  entry: {
+    inlinedConfig: './src/inlineConfig.ts',
+    actualUseCase: './src/actualUseCase.ts',
+    duplication: './src/duplication.ts',
+    destructure: './src/destructure.ts',
+  },
   output: {
     path: __dirname + '/dist',
     chunkFilename: isProduction ? '[name].[chunkhash:4].js' : '[name].js',

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -25,6 +25,7 @@ module.exports = ({ stats = false } = {}) => ({
   entry: {
     inlinedConfig: './src/inlineConfig.ts',
     actualUseCase: './src/actualUseCase.ts',
+    wrongUseCase: './src/wrongUseCase.ts',
     duplication: './src/duplication.ts',
     destructure: './src/destructure.ts',
   },


### PR DESCRIPTION
So inlining objects is done rather smartly
In case of 
```js
console.log('CONFIG.tcr', CONFIG.tcr)
console.log('CONFIG.tcr', CONFIG.tcr)
```
`CONFIG.tcr` will be inlined twice in whole

So it's better to use
```js
const { tcr } = CONFIG
console.log('tcr', tcr)
console.log('tcr', tcr)
```

But when used in conditions (including `switch-case`), need to use full path for better treeshaking
```js
if (CONFIG.defaultProviderConfig.type === 'infura')
// or
switch (CONFIG.tcr.type)
```
When doing
```js
const {tcr}= CONFIG
switch (tcr.type)
```
doesn't treeshake.

All in all inlining `CONFIG` works all right, unless we start spamming `CONFIG.tcr` in many files, no need for a loader.


This PR isn't for merging, of course, but to illustrate inlining.
Still, @alfetopito, cherry-pick 46ef5f9 into your PR for treeshaking and better type inference.