### PR TITLE
Double claim modal style Fix

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -7,6 +7,8 @@ export const DEFAULT_MODAL_OPTIONS = {
 }
 
 export const ModalBodyWrapper = styled.div`
+  padding: 0.5rem 1.5rem;
+
   div > p {
     font-size: inherit;
     color: inherit;


### PR DESCRIPTION
Added default `.modali-body-style` padding to `ModalBodyWrapper`. Seems ok with other instances of  `ModalBodyWrapper`

Fixes #1020