### PR TITLE
Use absolute path for importing components

### DIFF
--- a/src/components/DepositWidget/Form.tsx
+++ b/src/components/DepositWidget/Form.tsx
@@ -3,15 +3,21 @@ import BN from 'bn.js'
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons'
 import plus from 'assets/img/plus.svg'
 
+// Types and utils
+import { TokenBalanceDetails } from 'types'
+import { formatAmountFull, parseAmount, abbreviateString } from 'utils'
+
+// Components
 import { CardDrawer } from 'components/Layout/Card'
-import { WalletDrawerInnerWrapper } from './Form.styled'
 import { Spinner } from 'components/Spinner'
 
+// DepositWidget: subcomponents
+import { WalletDrawerInnerWrapper } from 'components/DepositWidget/Form.styled'
+
+// Hooks
 import useSafeState from 'hooks/useSafeState'
 import useScrollIntoView from 'hooks/useScrollIntoView'
 
-import { TokenBalanceDetails } from 'types'
-import { formatAmountFull, parseAmount, abbreviateString } from 'utils'
 import useKeyPress from 'hooks/useKeyDown'
 import { useWalletConnection } from 'hooks/useWalletConnection'
 import { Link } from 'react-router-dom'

--- a/src/components/DepositWidget/Row.tsx
+++ b/src/components/DepositWidget/Row.tsx
@@ -1,21 +1,28 @@
 import React, { useState } from 'react'
 import BN from 'bn.js'
+
+// Assets
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faClock, faPlus, faMinus } from '@fortawesome/free-solid-svg-icons'
 import { MinusSVG, PlusSVG } from 'assets/img/SVG'
 
-import Form from './Form'
-import TokenImg from 'components/TokenImg'
-import { TokenRow, RowClaimButton, RowClaimSpan } from './Styled'
-import { Spinner } from 'components/Spinner'
-
-import useNoScroll from 'hooks/useNoScroll'
-
+// const, utils, types
 import { ZERO, MEDIA, WETH_ADDRESS_MAINNET } from 'const'
 import { formatAmount, formatAmountFull } from 'utils'
 import { TokenBalanceDetails, Command } from 'types'
-import { TokenLocalState } from 'reducers-actions'
+
+// Components
+import TokenImg from 'components/TokenImg'
 import { WrapEtherBtn, UnwrapEtherBtn } from 'components/WrapEtherBtn'
+import { Spinner } from 'components/Spinner'
+
+// DepositWidget: subcomponents
+import Form from 'components/DepositWidget/Form'
+import { TokenRow, RowClaimButton, RowClaimSpan } from 'components/DepositWidget/Styled'
+
+// Hooks and reducers
+import useNoScroll from 'hooks/useNoScroll'
+import { TokenLocalState } from 'reducers-actions'
 
 export interface RowProps extends Record<keyof TokenLocalState, boolean> {
   ethBalance: BN | null

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -1,28 +1,35 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import Modali from 'modali'
+import styled from 'styled-components'
 import BN from 'bn.js'
 
-import styled from 'styled-components'
+// Assets
 import searchIcon from 'assets/img/search.svg'
-import { CardTable } from 'components/Layout/Card'
-import { Row } from './Row'
-import ErrorMsg from 'components/ErrorMsg'
-import Widget from 'components/Layout/Widget'
 
-import { useTokenBalances } from 'hooks/useTokenBalances'
-import { useRowActions } from './useRowActions'
-import { useDepositModals } from './useDepositModals'
-import useSafeState from 'hooks/useSafeState'
-import useWindowSizes from 'hooks/useWindowSizes'
-
+// Utils, const, types
 import { logDebug, getToken } from 'utils'
 import { ZERO, MEDIA } from 'const'
 import { TokenBalanceDetails } from 'types'
+
+// Components
+import { CardTable } from 'components/Layout/Card'
+import ErrorMsg from 'components/ErrorMsg'
+import Widget from 'components/Layout/Widget'
+
+// DepositWidget: subcomponents
+import { Row } from 'components/DepositWidget/Row'
+import { useRowActions } from 'components/DepositWidget/useRowActions'
+import { useDepositModals } from 'components/DepositWidget/useDepositModals'
+
+// Hooks and reducers
+import { useTokenBalances } from 'hooks/useTokenBalances'
+import useSafeState from 'hooks/useSafeState'
+import useWindowSizes from 'hooks/useWindowSizes'
 import { useDebounce } from 'hooks/useDebounce'
-import { TokenLocalState } from 'reducers-actions'
 import { useManageTokens } from 'hooks/useManageTokens'
 import useGlobalState from 'hooks/useGlobalState'
 import { useEthBalances } from 'hooks/useEthBalance'
+import { TokenLocalState } from 'reducers-actions'
 
 interface WithdrawState {
   amount: BN

--- a/src/components/DepositWidget/useDepositModals.tsx
+++ b/src/components/DepositWidget/useDepositModals.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback } from 'react'
 import BN from 'bn.js'
-
-import { DEFAULT_MODAL_OPTIONS, ModalBodyWrapper } from '../Modal'
 import Modali, { useModali, ModalHook, toggleModaliComponent } from 'modali'
+
+// Components
+import { DEFAULT_MODAL_OPTIONS, ModalBodyWrapper } from 'components/Modal'
 
 const OverwriteModalBody: React.FC = () => {
   return (

--- a/src/components/DepositWidget/useRowActions.tsx
+++ b/src/components/DepositWidget/useRowActions.tsx
@@ -1,15 +1,19 @@
+import { useMemo } from 'react'
 import { toast } from 'toastify'
 import BN from 'bn.js'
 import { assert } from '@gnosis.pm/dex-js'
 
-import { depositApi, erc20Api } from 'api'
+// types, consts and utils
 import { TokenBalanceDetails } from 'types'
 import { ALLOWANCE_MAX_VALUE } from 'const'
-import { useWalletConnection } from 'hooks/useWalletConnection'
-
 import { formatAmount, formatAmountFull, logDebug, getToken, safeFilledToken } from 'utils'
 import { composeOptionalParams } from 'utils/transaction'
 
+// Api
+import { depositApi, erc20Api } from 'api'
+
+// Hooks and reducers
+import { useWalletConnection } from 'hooks/useWalletConnection'
 import useGlobalState from 'hooks/useGlobalState'
 import {
   TokenLocalState,
@@ -19,7 +23,6 @@ import {
   setHighlightAndWithdrawing,
   setEnabledAction,
 } from 'reducers-actions'
-import { useMemo } from 'react'
 
 const ON_ERROR_MESSAGE = 'No logged in user found. Please check wallet connectivity status and try again.'
 

--- a/src/components/Layout/Card/index.tsx
+++ b/src/components/Layout/Card/index.tsx
@@ -1,1 +1,1 @@
-export * from './Card'
+export * from 'components/Layout/Card/Card'

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -1,12 +1,19 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Link } from 'react-router-dom'
-import ThemeToggler from 'components/ThemeToggler'
+
 import { MEDIA } from 'const'
 import { depositApi } from 'api'
-import { useWalletConnection } from 'hooks/useWalletConnection'
-import { EtherscanLink } from 'components/EtherscanLink'
+
+// Assets
 import verified from 'assets/img/verified.svg'
+
+// Components
+import ThemeToggler from 'components/ThemeToggler'
+import { EtherscanLink } from 'components/EtherscanLink'
+
+// Hooks
+import { useWalletConnection } from 'hooks/useWalletConnection'
 
 const Wrapper = styled.footer`
   position: relative;

--- a/src/components/Layout/Header/Navigation.tsx
+++ b/src/components/Layout/Header/Navigation.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
 import { NavLink } from 'react-router-dom'
 
+// Components
 import LinkWithPastLocation from 'components/LinkWithPastLocation'
-import { OrderedNavLinkDiv, NavLinksWrapper } from './Navigation.styled'
+
+// Header: subcomponents
+import { OrderedNavLinkDiv, NavLinksWrapper } from 'components/Layout/Header/Navigation.styled'
 
 export interface HeaderNavLinksInterface {
   label: string

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -1,16 +1,21 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import UserWallet from 'components/UserWallet'
-import { NavigationLinks } from './Navigation'
-import { HeaderWrapper } from './Header.styled'
-
-import useNavigation from './useNavigation'
-import useOpenCloseNav from './useOpenCloseNav'
-
+// utils, const
 import { formatSeconds } from 'utils'
-import { useTimeRemainingInBatch } from 'hooks/useTimeRemainingInBatch'
 import { MEDIA } from 'const'
+
+// Components
+import UserWallet from 'components/UserWallet'
+
+// Header: Subcomponents
+import { NavigationLinks } from 'components/Layout/Header/Navigation'
+import { HeaderWrapper } from 'components/Layout/Header/Header.styled'
+import useNavigation from 'components/Layout/Header/useNavigation'
+import useOpenCloseNav from 'components/Layout/Header/useOpenCloseNav'
+
+// hooks
+import { useTimeRemainingInBatch } from 'hooks/useTimeRemainingInBatch'
 
 export interface HeaderProps {
   [key: string]: {

--- a/src/components/Layout/Widget.tsx
+++ b/src/components/Layout/Widget.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { PageWrapper } from './PageWrapper'
+import { PageWrapper } from 'components/Layout/PageWrapper'
 
 const Wrapper = styled(PageWrapper)`
   display: flex;

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,13 +1,16 @@
 import React from 'react'
 import styled from 'styled-components'
+
+import { MEDIA } from 'const'
+
+// Assets
 import { faSkull } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
-import Header from './Header'
-import Footer from './Footer'
-import LegalBanner from '../LegalBanner'
-
-import { MEDIA } from 'const'
+// Layout: Subcomponents
+import Header from 'components/Layout/Header'
+import Footer from 'components/Layout/Footer'
+import LegalBanner from 'components/LegalBanner'
 
 const Wrapper = styled.div`
   width: 100%;

--- a/src/components/OrderBookBtn.tsx
+++ b/src/components/OrderBookBtn.tsx
@@ -1,17 +1,25 @@
 import React, { useEffect } from 'react'
 import styled from 'styled-components'
-import { DEFAULT_MODAL_OPTIONS, ModalBodyWrapper } from 'components/Modal'
 import Modali, { useModali } from 'modali'
-import OrderBookWidget from './OrderBookWidget'
-import { TokenDetails, Network } from 'types'
-import { useWalletConnection } from 'hooks/useWalletConnection'
-import { safeTokenName, getNetworkFromId } from '@gnosis.pm/dex-js'
-import TokenSelector from './TokenSelector'
-import useSafeState from 'hooks/useSafeState'
-import { useTokenList } from 'hooks/useTokenList'
-import { MEDIA } from 'const'
+
+// assets
 import { faChartLine } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+
+// const, types, utils
+import { MEDIA } from 'const'
+import { TokenDetails, Network } from 'types'
+import { safeTokenName, getNetworkFromId } from '@gnosis.pm/dex-js'
+
+// components
+import { DEFAULT_MODAL_OPTIONS, ModalBodyWrapper } from 'components/Modal'
+import OrderBookWidget from 'components/OrderBookWidget'
+import TokenSelector from 'components/TokenSelector'
+
+// hooks
+import useSafeState from 'hooks/useSafeState'
+import { useTokenList } from 'hooks/useTokenList'
+import { useWalletConnection } from 'hooks/useWalletConnection'
 
 const ViewOrderBookBtn = styled.button`
   margin: 0 0 0 auto;

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -1,20 +1,22 @@
 import React, { useMemo, useEffect, useRef } from 'react'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-
-import lowBalanceIcon from 'assets/img/lowBalance.svg'
-
-import { faChevronUp, faChevronDown } from '@fortawesome/free-solid-svg-icons'
 import { toast } from 'toastify'
 
-import { isOrderUnlimited, isNeverExpiresOrder, calculatePrice, formatPrice, invertPrice } from '@gnosis.pm/dex-js'
-
-// import Highlight from 'components/Highlight'
-import { EtherscanLink } from 'components/EtherscanLink'
-
-import { getTokenFromExchangeById } from 'services'
-import useSafeState from 'hooks/useSafeState'
+// types, utils and services
 import { TokenDetails } from 'types'
+import { isOrderUnlimited, isNeverExpiresOrder, calculatePrice, formatPrice, invertPrice } from '@gnosis.pm/dex-js'
+import { getTokenFromExchangeById } from 'services'
+
+// assets
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import lowBalanceIcon from 'assets/img/lowBalance.svg'
+import { faChevronUp, faChevronDown } from '@fortawesome/free-solid-svg-icons'
+
+// components
+import { EtherscanLink } from 'components/EtherscanLink'
 import { Spinner } from 'components/Spinner'
+
+// hooks
+import useSafeState from 'hooks/useSafeState'
 
 import {
   safeTokenName,
@@ -84,7 +86,6 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({ buyToken, sellToken, order 
   return (
     <td data-label="Price">
       <div className="order-details">
-        {/* <Highlight color={pending ? 'grey' : ''} /> */}
         {price} {displayTokenSymbolOrLink(sellToken)}
         {'/'}
         {displayTokenSymbolOrLink(buyToken)}

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -1,24 +1,32 @@
 import React, { useMemo, useCallback, useEffect } from 'react'
 // eslint-disable-next-line @typescript-eslint/camelcase
 import { unstable_batchedUpdates } from 'react-dom'
+
+// Assets
 import { faTrashAlt } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { isOrderUnlimited } from '@gnosis.pm/dex-js'
 
+// Const and utils
+import { isOrderUnlimited } from '@gnosis.pm/dex-js'
+import { isOrderActive, isPendingOrderActive } from 'utils'
+
+// Hooks
 import { useOrders } from 'hooks/useOrders'
 import useSafeState from 'hooks/useSafeState'
-import { useDeleteOrders } from './useDeleteOrders'
 import usePendingOrders from 'hooks/usePendingOrders'
 import { useWalletConnection } from 'hooks/useWalletConnection'
 
+// Api
 import { AuctionElement, PendingTxObj } from 'api/exchange/ExchangeApi'
 
-import { isOrderActive, isPendingOrderActive } from 'utils'
-
-import { CardTable } from 'components/Layout/Card'
-import OrderRow from './OrderRow'
-import { OrdersWrapper, ButtonWithIcon, OrdersForm } from './OrdersWidget.styled'
+// Components
 import { ConnectWalletBanner } from 'components/ConnectWalletBanner'
+import { CardTable } from 'components/Layout/Card'
+
+// OrderWidget
+import { useDeleteOrders } from 'components/OrdersWidget/useDeleteOrders'
+import OrderRow from 'components/OrdersWidget/OrderRow'
+import { OrdersWrapper, ButtonWithIcon, OrdersForm } from 'components/OrdersWidget/OrdersWidget.styled'
 
 type OrderTabs = 'active' | 'liquidity' | 'closed'
 

--- a/src/components/OrdersWidget/useDeleteOrders.tsx
+++ b/src/components/OrdersWidget/useDeleteOrders.tsx
@@ -1,14 +1,17 @@
+import { useCallback } from 'react'
 import { toast } from 'toastify'
+
+// assets
 import { assert } from '@gnosis.pm/dex-js'
-
-import useSafeState from 'hooks/useSafeState'
-import { useWalletConnection } from 'hooks/useWalletConnection'
-
-import { exchangeApi } from 'api'
-
 import { logDebug } from 'utils'
 import { txOptionalParams } from 'utils/transaction'
-import { useCallback } from 'react'
+
+// api
+import { exchangeApi } from 'api'
+
+// hooks
+import useSafeState from 'hooks/useSafeState'
+import { useWalletConnection } from 'hooks/useWalletConnection'
 
 interface Result {
   deleteOrders: (orderIds: string[]) => Promise<boolean>

--- a/src/components/PoolingWidget/AddFunding.styled.ts
+++ b/src/components/PoolingWidget/AddFunding.styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { HighlightDiv } from './PoolingWidget.styled'
+import { HighlightDiv } from 'components/PoolingWidget/PoolingWidget.styled'
 
 export const AddFundingWrapper = styled.div`
   display: flex;

--- a/src/components/PoolingWidget/AddFunding.tsx
+++ b/src/components/PoolingWidget/AddFunding.tsx
@@ -1,12 +1,18 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+
+import { Receipt } from 'types'
+
+// asset
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSpinner, faCheckCircle } from '@fortawesome/free-solid-svg-icons'
 
+// componet
 import { EtherscanLink } from 'components/EtherscanLink'
-import { HighlightDiv } from './PoolingWidget.styled'
-import { AddFundingWrapper } from './AddFunding.styled'
-import { Receipt } from 'types'
+
+// PoolingWidget: subcomponent
+import { HighlightDiv } from 'components/PoolingWidget/PoolingWidget.styled'
+import { AddFundingWrapper } from 'components/PoolingWidget/AddFunding.styled'
 
 interface AddFundingProps {
   txIdentifier: string

--- a/src/components/PoolingWidget/CreateStrategy.tsx
+++ b/src/components/PoolingWidget/CreateStrategy.tsx
@@ -1,13 +1,16 @@
 import React from 'react'
 import { TokenDetails } from '@gnosis.pm/dex-js'
 
-import { BlueBoldText, SpreadInformationWrapper } from './DefineSpread.styled'
-import DefineSpread from './DefineSpread'
-import { CreateStrategyWrapper } from './CreateStrategy.styled'
-import AddFunding from './AddFunding'
+// types, util, const
 import { Receipt } from 'types'
 import { formatPartialNumber } from 'utils'
 import { INPUT_PRECISION_SIZE } from 'const'
+
+// PoolingWidget: subcomponents
+import { BlueBoldText, SpreadInformationWrapper } from 'components/PoolingWidget/DefineSpread.styled'
+import DefineSpread from 'components/PoolingWidget/DefineSpread'
+import { CreateStrategyWrapper } from 'components/PoolingWidget/CreateStrategy.styled'
+import AddFunding from 'components/PoolingWidget/AddFunding'
 
 export interface CreateStrategyProps {
   isSubmitting: boolean

--- a/src/components/PoolingWidget/DefineSpread.styled.ts
+++ b/src/components/PoolingWidget/DefineSpread.styled.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
-import { ProgressStepText } from './PoolingWidget.styled'
 import InputBox from 'components/InputBox'
+import { ProgressStepText } from 'components/PoolingWidget/PoolingWidget.styled'
 
 export const DefineSpreadWrapper = styled(InputBox)`
   flex-flow: column nowrap;

--- a/src/components/PoolingWidget/DefineSpread.tsx
+++ b/src/components/PoolingWidget/DefineSpread.tsx
@@ -1,11 +1,15 @@
 import React from 'react'
 
-import { DefineSpreadWrapper } from './DefineSpread.styled'
+import { DefineSpreadWrapper } from 'components/PoolingWidget/DefineSpread.styled'
 
-import { useFormContext, FieldError } from 'react-hook-form'
-import { FormInputError } from 'components/TradeWidget/FormMessage'
+// components
 import { HelpTooltipContainer, HelpTooltip } from 'components/Tooltip'
 import { Input } from 'components/Input'
+
+// TradeWidget: subcomponent
+import { FormInputError } from 'components/TradeWidget/FormMessage'
+
+import { useFormContext, FieldError } from 'react-hook-form'
 
 interface DefineSpreadProps {
   isSubmitting: boolean

--- a/src/components/PoolingWidget/LiquidityButtons.tsx
+++ b/src/components/PoolingWidget/LiquidityButtons.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 
-import { SubComponentProps } from './SubComponents'
-import { StepButtonsWrapper } from './PoolingWidget.styled'
+// component
 import { TooltipWrapper } from 'components/Tooltip'
 import { Spinner } from 'components/Spinner'
+
+// PoolingWidget
+import { SubComponentProps } from 'components/PoolingWidget/SubComponents'
+import { StepButtonsWrapper } from 'components/PoolingWidget/PoolingWidget.styled'
 
 interface LiquidityButtonsProps extends Pick<SubComponentProps, 'step' | 'txReceipt' | 'nextStep' | 'isSubmitting'> {
   disableBack: boolean

--- a/src/components/PoolingWidget/PoolingWidget.styled.ts
+++ b/src/components/PoolingWidget/PoolingWidget.styled.ts
@@ -1,8 +1,11 @@
 import styled from 'styled-components'
+import { MEDIA } from 'const'
+
 import { PageWrapper } from 'components/Layout/PageWrapper'
+
+// assets
 import arrowBlue from 'assets/img/arrow-blue.svg'
 import arrowWhite from 'assets/img/arrow-white.svg'
-import { MEDIA } from 'const'
 
 export const PoolingInterfaceWrapper = styled(PageWrapper)`
   display: flex;

--- a/src/components/PoolingWidget/ProgressBar.tsx
+++ b/src/components/PoolingWidget/ProgressBar.tsx
@@ -1,5 +1,10 @@
 import React from 'react'
-import { BarWrapper, ProgressStep, ProgressStepText, StepSeparator } from './PoolingWidget.styled'
+import {
+  BarWrapper,
+  ProgressStep,
+  ProgressStepText,
+  StepSeparator,
+} from 'components/PoolingWidget/PoolingWidget.styled'
 import { LAST_STEP } from '.'
 
 export interface ProgressBarProps {

--- a/src/components/PoolingWidget/StepDescriptors.tsx
+++ b/src/components/PoolingWidget/StepDescriptors.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo } from 'react'
-import { StepDescriptionWrapper, ProgressStepText } from './PoolingWidget.styled'
-import { ProgressBarProps } from './ProgressBar'
+
+// PoolingWidge: subcomponent
+import { StepDescriptionWrapper, ProgressStepText } from 'components/PoolingWidget/PoolingWidget.styled'
+import { ProgressBarProps } from 'components/PoolingWidget/ProgressBar'
 
 import checkIcon from 'assets/img/li-check.svg'
 

--- a/src/components/PoolingWidget/SubComponents.tsx
+++ b/src/components/PoolingWidget/SubComponents.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 
-import TokenSelector from './TokenSelector'
-import { TokenSelectorProps } from './TokenSelector'
-
-import { TokenDetails } from '@gnosis.pm/dex-js'
-import { CreateStrategy } from './CreateStrategy'
+// types
 import { Receipt } from 'types'
+import { TokenDetails } from '@gnosis.pm/dex-js'
+
+// PoolingWidget: subcomponents
+import TokenSelector from 'components/PoolingWidget/TokenSelector'
+import { TokenSelectorProps } from 'components/PoolingWidget/TokenSelector'
+import { CreateStrategy } from 'components/PoolingWidget/CreateStrategy'
 
 export interface SubComponentProps extends TokenSelectorProps {
   isSubmitting: boolean

--- a/src/components/PoolingWidget/TokenSelector.tsx
+++ b/src/components/PoolingWidget/TokenSelector.tsx
@@ -1,12 +1,15 @@
 import React from 'react'
 
+// assets
 import TokenImg from 'components/TokenImg'
-import { ProgressStepText } from './PoolingWidget.styled'
-import { TokenSelectorWrapper, TokenBox, CheckboxWrapper } from './TokenSelector.styled'
-
 import checkIcon from 'assets/img/li-check.svg'
 
+// types
 import { TokenDetails } from '@gnosis.pm/dex-js'
+
+// PoolingWidget: subcomponent
+import { ProgressStepText } from 'components/PoolingWidget/PoolingWidget.styled'
+import { TokenSelectorWrapper, TokenBox, CheckboxWrapper } from 'components/PoolingWidget/TokenSelector.styled'
 
 export interface TokenSelectorProps {
   handleTokenSelect: (tokenData: TokenDetails) => void

--- a/src/components/PoolingWidget/index.tsx
+++ b/src/components/PoolingWidget/index.tsx
@@ -1,32 +1,35 @@
 /* eslint-disable @typescript-eslint/ban-ts-ignore */
 import React, { useCallback, useMemo, useEffect } from 'react'
 import { unstable_batchedUpdates as batchedUpdates } from 'react-dom'
+import { Link } from 'react-router-dom'
+import { useForm, FormContext } from 'react-hook-form'
 import { toast } from 'toastify'
 import styled from 'styled-components'
-import { TokenDetails, ZERO } from '@gnosis.pm/dex-js'
 import joi from '@hapi/joi'
 
-import ProgressBar from './ProgressBar'
-import { StepDescription } from './StepDescriptors'
-import SubComponents from './SubComponents'
-import Widget from 'components/Layout/Widget'
-import LiquidityButtons from './LiquidityButtons'
-import { PoolingInterfaceWrapper } from './PoolingWidget.styled'
+// const, type, utils
+import { DEFAULT_PRECISION, LIQUIDITY_TOKEN_LIST, INPUT_PRECISION_SIZE } from 'const'
+import { Receipt } from 'types'
+import { TokenDetails, ZERO } from '@gnosis.pm/dex-js'
+import { maxAmountsForSpread, resolverFactory, NUMBER_VALIDATION_KEYS } from 'utils'
 
+// components
+import Widget from 'components/Layout/Widget'
+
+// PoolingWidget: subcomponents
+import ProgressBar from 'components/PoolingWidget/ProgressBar'
+import { StepDescription } from 'components/PoolingWidget/StepDescriptors'
+import SubComponents from 'components/PoolingWidget/SubComponents'
+import LiquidityButtons from 'components/PoolingWidget/LiquidityButtons'
+import { PoolingInterfaceWrapper } from 'components/PoolingWidget/PoolingWidget.styled'
+
+// Hooks and actions
 import useSafeState from 'hooks/useSafeState'
 import { useWalletConnection } from 'hooks/useWalletConnection'
 import { usePlaceOrder, MultipleOrdersOrder } from 'hooks/usePlaceOrder'
 import useGlobalState from 'hooks/useGlobalState'
-import { useForm, FormContext } from 'react-hook-form'
-
-import { savePendingOrdersAction, removePendingOrdersAction } from 'reducers-actions/pendingOrders'
-
-import { Receipt } from 'types'
-
-import { maxAmountsForSpread, resolverFactory, NUMBER_VALIDATION_KEYS } from 'utils'
-import { DEFAULT_PRECISION, LIQUIDITY_TOKEN_LIST, INPUT_PRECISION_SIZE } from 'const'
 import { useTokenList } from 'hooks/useTokenList'
-import { Link } from 'react-router-dom'
+import { savePendingOrdersAction, removePendingOrdersAction } from 'reducers-actions/pendingOrders'
 
 export const FIRST_STEP = 1
 export const LAST_STEP = 2

--- a/src/components/TokenOptionItem.tsx
+++ b/src/components/TokenOptionItem.tsx
@@ -1,16 +1,22 @@
 import React, { useEffect } from 'react'
 import { unstable_batchedUpdates as batchedUpdates } from 'react-dom'
 import { isAddress } from 'web3-utils'
-import { TokenImgWrapper } from './TokenImg'
-import { tokenListApi } from 'api'
 import styled from 'styled-components'
-import useSafeState from 'hooks/useSafeState'
-import { TokenDetails } from 'types'
-import { TokenFromExchange } from 'services/factories'
-import { fetchTokenData, FetchTokenResult, TokenAndNetwork } from 'services'
-import { safeFilledToken } from 'utils'
 import { toast } from 'toastify'
+
+// types, utils, services, api
+import { TokenDetails } from 'types'
+import { safeFilledToken } from 'utils'
+import { fetchTokenData, FetchTokenResult, TokenAndNetwork } from 'services'
 import { SimpleCache } from 'api/proxy/SimpleCache'
+import { TokenFromExchange } from 'services/factories'
+import { tokenListApi } from 'api'
+
+// components
+import { TokenImgWrapper } from 'components/TokenImg'
+
+// hooks
+import useSafeState from 'hooks/useSafeState'
 import { UseAddTokenModalResult } from 'hooks/useBetterAddTokenModal'
 
 const OptionItemWrapper = styled.div`

--- a/src/components/TokenSelector.tsx
+++ b/src/components/TokenSelector.tsx
@@ -1,21 +1,27 @@
 import React, { CSSProperties, useMemo, useState, useCallback, useRef, useEffect } from 'react'
 import styled from 'styled-components'
 import Select, { ActionMeta } from 'react-select'
-import { MEDIA } from 'const'
-
-import { formatAmount } from '@gnosis.pm/dex-js'
-import { isAddress } from 'web3-utils'
 import Modali from 'modali'
-
-import { TokenDetails, TokenBalanceDetails, Network } from 'types'
-import { TokenImgWrapper } from './TokenImg'
 import { FormatOptionLabelContext } from 'react-select/src/Select'
-import { MenuList } from './TokenSelectorComponents'
+
+// assets
 import searchIcon from 'assets/img/search.svg'
-import { useWalletConnection } from 'hooks/useWalletConnection'
+
+// const, type, utils
+import { MEDIA } from 'const'
+import { TokenDetails, TokenBalanceDetails, Network } from 'types'
+import { isAddress } from 'web3-utils'
+import { formatAmount } from '@gnosis.pm/dex-js'
 import { tokenListApi } from 'api'
+
+// components
+import { TokenImgWrapper } from 'components/TokenImg'
+import { MenuList } from 'components/TokenSelectorComponents'
+import { SearchItem, OptionItem } from 'components/TokenOptionItem'
+
+// hooks
+import { useWalletConnection } from 'hooks/useWalletConnection'
 import useSafeState from 'hooks/useSafeState'
-import { SearchItem, OptionItem } from './TokenOptionItem'
 import { useBetterAddTokenModal } from 'hooks/useBetterAddTokenModal'
 
 const Wrapper = styled.div`

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,11 +1,17 @@
 import React, { ReactNode, CSSProperties, useCallback } from 'react'
-import Portal from './Portal'
-import { usePopperOnClick, usePopperDefault, TOOLTIP_OFFSET } from 'hooks/usePopper'
 import { State, Placement } from '@popperjs/core'
 import styled from 'styled-components'
 import { isElement, isFragment } from 'react-is'
+
+// assets
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons'
+
+// components
+import Portal from 'components/Portal'
+
+// hooks
+import { usePopperOnClick, usePopperDefault, TOOLTIP_OFFSET } from 'hooks/usePopper'
 
 // visibility necessary for correct boundingRect calculation by popper
 const TooltipOuter = styled.div<Pick<TooltipBaseProps, 'isShown'>>`

--- a/src/components/TradeWidget/OrderValidity.tsx
+++ b/src/components/TradeWidget/OrderValidity.tsx
@@ -3,18 +3,25 @@ import React, { useCallback, Dispatch, SetStateAction, useRef, useEffect } from 
 import { unstable_batchedUpdates as batchedUpdates } from 'react-dom'
 import styled from 'styled-components'
 import { useFormContext } from 'react-hook-form'
-import { ZERO } from '@gnosis.pm/dex-js'
 
-import { TradeFormTokenId, TradeFormData } from './'
-import { PriceInputBox } from './Price'
-
-import useSafeState from 'hooks/useSafeState'
-import { formatTimeInHours, makeMultipleOf } from 'utils'
-
+// assets
 import cog from 'assets/img/cog.svg'
+
+// utils, const
+import { ZERO } from '@gnosis.pm/dex-js'
+import { formatTimeInHours, makeMultipleOf } from 'utils'
 import { MEDIA, VALID_UNTIL_DEFAULT, VALID_FROM_DEFAULT } from 'const'
+
+// components
 import { HelpTooltipContainer, HelpTooltip } from 'components/Tooltip'
-import { FormInputError } from './FormMessage'
+
+// TradeWidget: subcomponents
+import { TradeFormTokenId, TradeFormData } from 'components/TradeWidget'
+import { PriceInputBox } from 'components/TradeWidget/Price'
+import { FormInputError } from 'components/TradeWidget/FormMessage'
+
+// hooks
+import useSafeState from 'hooks/useSafeState'
 
 const Wrapper = styled.div`
   display: flex;

--- a/src/components/TradeWidget/Price.tsx
+++ b/src/components/TradeWidget/Price.tsx
@@ -3,14 +3,18 @@ import styled from 'styled-components'
 import { useFormContext } from 'react-hook-form'
 import { invertPrice } from '@gnosis.pm/dex-js'
 
+// types, utils
 import { TokenDetails } from 'types'
 import { parseBigNumber } from 'utils'
 import { DEFAULT_PRECISION, MEDIA } from 'const'
 
-import { TradeFormData } from '.'
-import { FormInputError } from './FormMessage'
-import { useNumberInput } from './useNumberInput'
+// Components
 import { OrderBookBtn } from 'components/OrderBookBtn'
+
+// TradeWidget: subcomponents
+import { TradeFormData } from 'components/TradeWidget/'
+import { FormInputError } from 'components/TradeWidget//FormMessage'
+import { useNumberInput } from 'components/TradeWidget//useNumberInput'
 
 const Wrapper = styled.div`
   display: flex;

--- a/src/components/TradeWidget/Price.tsx
+++ b/src/components/TradeWidget/Price.tsx
@@ -12,9 +12,9 @@ import { DEFAULT_PRECISION, MEDIA } from 'const'
 import { OrderBookBtn } from 'components/OrderBookBtn'
 
 // TradeWidget: subcomponents
-import { TradeFormData } from 'components/TradeWidget/'
-import { FormInputError } from 'components/TradeWidget//FormMessage'
-import { useNumberInput } from 'components/TradeWidget//useNumberInput'
+import { TradeFormData } from 'components/TradeWidget'
+import { FormInputError } from 'components/TradeWidget/FormMessage'
+import { useNumberInput } from 'components/TradeWidget/useNumberInput'
 
 const Wrapper = styled.div`
   display: flex;

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -1,21 +1,24 @@
 import React, { useMemo } from 'react'
+import { Link } from 'react-router-dom'
 import BN from 'bn.js'
 import styled from 'styled-components'
 import { useFormContext } from 'react-hook-form'
+
+// types, const and utils
+import { TokenDetails, TokenBalanceDetails } from 'types'
+import { ZERO, MEDIA } from 'const'
+import { formatAmount, formatAmountFull, parseAmount, validInputPattern, validatePositiveConstructor } from 'utils'
+
+// components
 import TokenSelector from 'components/TokenSelector'
 import { InputBox } from 'components/InputBox'
-import { TokenDetails, TokenBalanceDetails } from 'types'
-import { formatAmount, formatAmountFull, parseAmount, validInputPattern, validatePositiveConstructor } from 'utils'
-import { ZERO } from 'const'
-
-import { TradeFormTokenId, TradeFormData } from './'
-
 import { TooltipWrapper, HelpTooltipContainer, HelpTooltip } from 'components/Tooltip'
-import FormMessage, { FormInputError } from './FormMessage'
-import { useNumberInput } from './useNumberInput'
 import { Input } from 'components/Input'
-import { MEDIA } from 'const'
-import { Link } from 'react-router-dom'
+
+// TradeWidget: subcomponents
+import { TradeFormTokenId, TradeFormData } from 'components/TradeWidget'
+import FormMessage, { FormInputError } from 'components/TradeWidget/FormMessage'
+import { useNumberInput } from 'components/TradeWidget/useNumberInput'
 
 const Wrapper = styled.div`
   display: flex;

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -1,26 +1,35 @@
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react'
 import { unstable_batchedUpdates as batchUpdateState } from 'react-dom'
-
+import { useForm, FormContext } from 'react-hook-form'
+import { useParams } from 'react-router'
 import styled from 'styled-components'
-import { SwitcherSVG } from 'assets/img/SVG'
-import arrow from 'assets/img/arrow.svg'
 import { FieldValues } from 'react-hook-form/dist/types'
 import { toast } from 'toastify'
-import BN from 'bn.js'
 import Modali from 'modali'
+import BN from 'bn.js'
 import { isAddress } from 'web3-utils'
 
-import TokenRow from './TokenRow'
-import OrderValidity from './OrderValidity'
+// assets
+import { SwitcherSVG } from 'assets/img/SVG'
+import arrow from 'assets/img/arrow.svg'
+
+// const, types
+import { MEDIA, PRICE_ESTIMATION_PRECISION, PRICE_ESTIMATION_DEBOUNCE_TIME } from 'const'
+import { TokenDetails, Network } from 'types'
+
+// components
 import Widget from 'components/Layout/Widget'
 import OrdersWidget from 'components/OrdersWidget'
 import { OrdersWrapper } from 'components/OrdersWidget/OrdersWidget.styled'
 import { TxNotification } from 'components/TxNotification'
 import { Wrapper } from 'components/ConnectWalletBanner'
-import FormMessage from './FormMessage'
 
-import { useForm, FormContext } from 'react-hook-form'
-import { useParams } from 'react-router'
+// TradeWidget: subcomponents
+import TokenRow from 'components/TradeWidget/TokenRow'
+import OrderValidity from 'components/TradeWidget/OrderValidity'
+import FormMessage from 'components/TradeWidget/FormMessage'
+
+// hooks and reducers
 import useURLParams from 'hooks/useURLParams'
 import { useTokenBalances } from 'hooks/useTokenBalances'
 import { useWalletConnection } from 'hooks/useWalletConnection'
@@ -30,10 +39,6 @@ import { useDebounce } from 'hooks/useDebounce'
 import useGlobalState from 'hooks/useGlobalState'
 import { savePendingOrdersAction, removePendingOrdersAction } from 'reducers-actions/pendingOrders'
 import { Spinner } from 'components/Spinner'
-
-import { MEDIA, PRICE_ESTIMATION_PRECISION, PRICE_ESTIMATION_DEBOUNCE_TIME } from 'const'
-
-import { TokenDetails, Network } from 'types'
 
 import {
   getToken,

--- a/src/components/TradeWidget/useNumberInput.tsx
+++ b/src/components/TradeWidget/useNumberInput.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { adjustPrecision, formatPartialNumber, preventInvalidChars } from 'utils'
-import { TradeFormData } from '.'
+
+import { TradeFormData } from 'components/TradeWidget'
 
 interface Params {
   inputId: string

--- a/src/components/TxNotification.tsx
+++ b/src/components/TxNotification.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { EtherscanLink } from './EtherscanLink'
+import { EtherscanLink } from 'components/EtherscanLink'
 
 interface TxNotificationProps {
   txHash: string

--- a/src/components/UserWallet/WalletComponent.tsx
+++ b/src/components/UserWallet/WalletComponent.tsx
@@ -2,10 +2,14 @@ import React, { useCallback } from 'react'
 import { RouteComponentProps, useRouteMatch } from 'react-router'
 import CopyToClipboard from 'react-copy-to-clipboard'
 import QRCode from 'qrcode.react'
+
+// assets
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSignOutAlt, faSignInAlt, faCopy, faCheck } from '@fortawesome/free-solid-svg-icons'
 
-import { EtherscanLink } from '../EtherscanLink'
+// components
+import { EtherscanLink } from 'components/EtherscanLink'
+
 import {
   UserWalletItem,
   UserWalletWrapper,

--- a/src/components/UserWallet/index.tsx
+++ b/src/components/UserWallet/index.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense } from 'react'
 import { withRouter, RouteComponentProps } from 'react-router'
 
-import { UserWalletWrapper } from './UserWallet.styled'
+import { UserWalletWrapper } from 'components/UserWallet/UserWallet.styled'
 
 const LazyUserWallet = React.lazy(async () => {
   const UserWalletProm = import(

--- a/src/components/WrapEtherBtn.tsx
+++ b/src/components/WrapEtherBtn.tsx
@@ -1,13 +1,19 @@
 import React, { useMemo } from 'react'
-import styled from 'styled-components'
-import { DEFAULT_MODAL_OPTIONS, ModalBodyWrapper } from 'components/Modal'
-import Modali, { useModali } from 'modali'
-import { InputBox } from 'components/InputBox'
 import { useForm } from 'react-hook-form'
-import { DEFAULT_PRECISION, formatAmountFull, toWei, parseAmount, ZERO } from '@gnosis.pm/dex-js'
+import styled from 'styled-components'
+import Modali, { useModali } from 'modali'
 import BN from 'bn.js'
+
+// utils
 import { validatePositiveConstructor, validInputPattern, logDebug } from 'utils'
+import { DEFAULT_PRECISION, formatAmountFull, toWei, parseAmount, ZERO } from '@gnosis.pm/dex-js'
+
+// components
+import { DEFAULT_MODAL_OPTIONS, ModalBodyWrapper } from 'components/Modal'
 import { TooltipWrapper } from 'components/Tooltip'
+import { InputBox } from 'components/InputBox'
+
+// hooks
 import useSafeState from 'hooks/useSafeState'
 import { useWrapUnwrapEth } from 'hooks/useWrapUnwrapEth'
 import { useTokenBalances } from 'hooks/useTokenBalances'


### PR DESCRIPTION
In order to facilitate overriding ANY component, this PR replaces all the relative imports for absolute imports

Also, for the files with a lot of imports, it reorganize them a little bit grouping by type
 