### PR TITLE
Proxy composed provider

### DIFF
--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -8,7 +8,6 @@ import RpcEngine, {
 import providerFromEngine from 'eth-json-rpc-middleware/providerFromEngine'
 import { Provider } from '@gnosis.pm/dapp-ui'
 import { WebsocketProvider, TransactionConfig } from 'web3-core'
-// import { EventEmitter } from 'events'
 import { numberToHex } from 'web3-utils'
 
 // custom providerAsMiddleware
@@ -29,33 +28,6 @@ function providerAsMiddleware(provider: Provider | WebsocketProvider): JsonRpcMi
     })
   }
 }
-
-//  EIP 1193 events (including deprecated) + 'data' + WS events + WC events
-// a good idea is to include all known events
-// const EVENTS_TO_REEMIT = [
-//   'connect',
-//   'disconnect',
-//   'close',
-//   'chainChanged',
-//   'networkChanged',
-//   'accountsChanged',
-//   'message',
-//   'notification',
-//   'data',
-//   'open',
-//   'reconnect',
-//   'error',
-// ]
-
-// interface ConnectToReemitParams {
-//   from: EventEmitter
-//   to: EventEmitter
-//   events: string[]
-// }
-
-// const connectToReemit = ({ from, to, events }: ConnectToReemitParams): void => {
-//   events.forEach(event => from.on(event, to.emit.bind(to, event)))
-// }
 
 const createConditionalMiddleware = <T extends unknown>(
   condition: (req: JsonRpcRequest<T>) => boolean,
@@ -127,18 +99,8 @@ export const composeProvider = (
 
   const composedProvider: Provider = providerFromEngine(engine)
 
-  // reemit all(likely) events from provider on composedProvider
-  // connectToReemit({
-  //   from: provider,
-  //   to: composedProvider,
-  //   events: EVENTS_TO_REEMIT,
-  // })
-
-  // return composedProvider
-
   const providerProxy = new Proxy(composedProvider, {
     get: function(target, prop, receiver): unknown {
-      console.log('Proxy::prop access', prop)
       if (prop === 'sendAsync' || prop === 'send') {
         // composedProvider handles it
         return Reflect.get(target, prop, receiver)


### PR DESCRIPTION
I couldn't connect some mobile providers(including TrustWallet)

My guess is that the minimal Provider interface that `eth-json-rpc-middleware/providerFromEngine` implements, which is only `send` and `sendAsync` functions, is not enough. Even if we reemit events

Maybe adding `enable` function would suffice. Maybe some more. I just wrapped `composedProvider` in a `Proxy`