### PR TITLE
Fixing token images on dark mode

### DIFF
--- a/src/components/TokenImg.tsx
+++ b/src/components/TokenImg.tsx
@@ -13,6 +13,8 @@ const TokenImg = styled.img.attrs(() => ({ onError: _loadFallbackTokenImage }))`
   border-radius: 3.6rem;
   object-fit: contain;
   margin: 0 1rem 0 0;
+  background-color: white;
+  padding: 2px;
 `
 
 export default TokenImg


### PR DESCRIPTION
Before:

![screenshot_2020-05-27_08-04-01](https://user-images.githubusercontent.com/43217/83037388-95a7f000-9ff0-11ea-95db-b8bcb6e7de59.png)
![screenshot_2020-05-27_08-03-52](https://user-images.githubusercontent.com/43217/83037391-95a7f000-9ff0-11ea-8f37-0487520670f9.png)


Now:

![screenshot_2020-05-27_07-52-04](https://user-images.githubusercontent.com/43217/83037244-6b563280-9ff0-11ea-9523-c868bab7a356.png)
![screenshot_2020-05-27_07-51-55](https://user-images.githubusercontent.com/43217/83037246-6beec900-9ff0-11ea-8cdb-a40b7e6cf203.png)
