### PR TITLE
Improve order book representation

### DIFF
--- a/src/components/OrderBookBtn.tsx
+++ b/src/components/OrderBookBtn.tsx
@@ -54,7 +54,7 @@ const ModalWrapper = styled(ModalBodyWrapper)`
   }
 
   > span:first-of-type::after {
-    content: '⟶';
+    content: '/';
     margin: 0 1rem;
 
     @media ${MEDIA.mobile} {
@@ -137,7 +137,6 @@ export const OrderBookBtn: React.FC<OrderBookBtnProps> = (props: OrderBookBtnPro
     message: (
       <ModalWrapper>
         <span>
-          <p>Bid</p>{' '}
           <TokenSelector
             tokens={tokenList}
             selected={baseToken}
@@ -165,8 +164,7 @@ export const OrderBookBtn: React.FC<OrderBookBtnProps> = (props: OrderBookBtnPro
                 otherToken: baseToken,
               })
             }
-          />{' '}
-          <p>Ask</p>
+          />
         </span>
         <OrderBookWidget baseToken={baseToken} quoteToken={quoteToken} networkId={networkId} />
       </ModalWrapper>

--- a/src/components/OrderBookWidget.tsx
+++ b/src/components/OrderBookWidget.tsx
@@ -8,32 +8,15 @@ import am4themesSpiritedaway from '@amcharts/amcharts4/themes/spiritedaway'
 
 import { dexPriceEstimatorApi } from 'api'
 
-import { getNetworkFromId, safeTokenName, formatSmart, toBN } from 'utils'
+import { getNetworkFromId, safeTokenName, formatSmart, logDebug } from 'utils'
 
-import { TEN_BIG_NUMBER } from 'const'
+import { TEN_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
 
 import { TokenDetails, Network } from 'types'
+import BN from 'bn.js'
+import { DEFAULT_PRECISION } from '@gnosis.pm/dex-js'
 
-function checkPriceAndConvert(price: number): string {
-  // prices come in as type number so need to be converted
-  // some of the WEI values are so small we need to cast to Wei twice
-  const priceAsBigNumber = new BigNumber(price)
-  const calculatedPriceAsBnWei = toBN(
-    priceAsBigNumber
-      .times(TEN_BIG_NUMBER.pow(new BigNumber('18')))
-      // we don't want any decimals
-      // before passing into BN conversion
-      .decimalPlaces(0)
-      .toString(10),
-  )
-
-  return formatSmart({
-    amount: calculatedPriceAsBnWei,
-    precision: 18,
-    decimals: 6,
-    smallLimit: '0',
-  })
-}
+const SMALL_VOLUME_THRESHOLD = 0.01
 
 interface OrderBookProps {
   baseToken: TokenDetails
@@ -84,17 +67,69 @@ enum Offer {
   Ask,
 }
 
-interface RawItem {
+/**
+ * Price point as defined in the API
+ * Both price and volume are numbers (floats)
+ *
+ * The price and volume are expressed in atoms
+ */
+interface RawPricePoint {
   price: number
   volume: number
 }
 
-interface ProcessedItem {
-  volume: number
-  totalVolume: number
+/**
+ * Normalized price point
+ * Both price and volume are BigNumbers (decimal)
+ *
+ * The price and volume are expressed in atoms
+ */
+interface PricePoint {
+  price: BigNumber
+  volume: BigNumber
+}
+
+/**
+ * Price point data represented in the graph. Contains BigNumbers for operate with less errors and more precission
+ * but for representation uses number as expected by the library
+ */
+interface PricePointDetails {
+  // Basic data
+  type: Offer
+  volume: BigNumber // volume for the price point
+  totalVolume: BigNumber // cumulative volume
+  price: BigNumber
+
+  // Data for representation
+  priceNumber: number
+  priceFormatted: string
+  totalVolumeNumber: number
+  totalVolumeFormatted: string
   askValueY: number | null
   bidValueY: number | null
-  price: string | number
+}
+
+function _toPricePoint(pricePoint: RawPricePoint, quoteTokenDecimals: number, baseTokenDecimals: number): PricePoint {
+  return {
+    price: new BigNumber(pricePoint.price).dividedBy(TEN_BIG_NUMBER.pow(quoteTokenDecimals - baseTokenDecimals)),
+    volume: new BigNumber(pricePoint.volume).div(TEN_BIG_NUMBER.pow(baseTokenDecimals)),
+  }
+}
+
+function _formatSmartBigNumber(amount: BigNumber): string {
+  return formatSmart({
+    amount: new BN(
+      amount
+        .times(TEN_BIG_NUMBER.pow(new BigNumber(DEFAULT_PRECISION)))
+        // we don't want any decimals
+        // before passing into BN conversion
+        .decimalPlaces(0)
+        .toString(10),
+    ),
+    precision: DEFAULT_PRECISION,
+    decimals: 6,
+    smallLimit: '0',
+  })
 }
 
 /**
@@ -102,49 +137,91 @@ interface ProcessedItem {
  * This involves aggregating the total volume and accounting for decimals
  */
 const processData = (
-  list: RawItem[],
+  rawPricePoints: RawPricePoint[],
   baseToken: TokenDetails,
   quoteToken: TokenDetails,
   type: Offer,
-): ProcessedItem[] => {
-  let totalVolume = 0
+): PricePointDetails[] => {
   const isBid = type == Offer.Bid
-  return (
-    list
-      // Account fo decimals
-      .map(element => {
-        return {
-          price: element.price / 10 ** (quoteToken.decimals - baseToken.decimals),
-          volume: element.volume / 10 ** baseToken.decimals,
-        }
-      })
-      // Filter tiny orders
-      .filter(e => e.volume > 0.01)
-      // Accumulate totalVolume
-      .map(e => {
-        const previousTotalVolume = totalVolume
-        totalVolume += e.volume
-        return {
-          price: e.price,
-          volume: e.volume,
-          totalVolume,
-          // Amcharts draws step lines so that the x value is centered (Default). To correctly display the orderbook, we want
-          // the x value to be at the left side of the step for asks and at the right side of the step for bids.
-          //
-          //    Default            Bids          Asks
-          //            |      |                        |
-          //   ---------       ---------       ---------
-          //  |                         |      |
-          //       x                    x      x
-          //
-          // For asks, we can offset the "startLocation" by 0.5. However, Amcharts does not support a "startLocation" of -0.5.
-          // For bids, we therefore offset the curve by -1 (expose the previous total volume) and use an offset of 0.5.
-          // Otherwise our steps would be off by one.
-          askValueY: isBid ? null : totalVolume,
-          bidValueY: isBid ? previousTotalVolume : null,
-        }
-      })
+  const quoteTokenDecimals = quoteToken.decimals
+  const baseTokenDecimals = baseToken.decimals
+
+  // Convert RawPricePoint into PricePoint:
+  //  Raw items use number (floats) and are given in "atoms"
+  //  Normalized items use decimals (BigNumber) and are given in natural units
+  let pricePoints: PricePoint[] = rawPricePoints.map(pricePoint =>
+    _toPricePoint(pricePoint, quoteTokenDecimals, baseTokenDecimals),
   )
+
+  // Filter tiny orders
+  pricePoints = pricePoints.filter(pricePoint => pricePoint.volume.gt(SMALL_VOLUME_THRESHOLD))
+
+  // Convert the price points that can be represented in the graph (PricePointDetails)
+  const { points } = pricePoints.reduce(
+    (acc, pricePoint, index) => {
+      const { price, volume } = pricePoint
+      const totalVolume = acc.totalVolume.plus(volume)
+
+      // Amcharts draws step lines so that the x value is centered (Default). To correctly display the order book, we want
+      // the x value to be at the left side of the step for asks and at the right side of the step for bids.
+      //
+      //    Default            Bids          Asks
+      //            |      |                        |
+      //   ---------       ---------       ---------
+      //  |                         |      |
+      //       x                    x      x
+      //
+      // For asks, we can offset the "startLocation" by 0.5. However, Amcharts does not support a "startLocation" of -0.5.
+      // For bids, we therefore offset the curve by -1 (expose the previous total volume) and use an offset of 0.5.
+      // Otherwise our steps would be off by one.
+      let askValueY, bidValueY
+      if (isBid) {
+        const previousPricePoint = acc.points[index - 1]
+        askValueY = null
+        bidValueY = previousPricePoint?.totalVolume.toNumber() || 0
+      } else {
+        askValueY = totalVolume.toNumber()
+        bidValueY = null
+      }
+
+      // Add the new point
+      const pricePointDetails: PricePointDetails = {
+        type,
+        volume,
+        totalVolume,
+        price,
+
+        // Data for representation
+        priceNumber: price.toNumber(),
+        totalVolumeNumber: totalVolume.toNumber(),
+        priceFormatted: _formatSmartBigNumber(price),
+        totalVolumeFormatted: _formatSmartBigNumber(totalVolume),
+        askValueY,
+        bidValueY,
+      }
+      acc.points.push(pricePointDetails)
+
+      return { totalVolume, points: acc.points }
+    },
+    {
+      totalVolume: ZERO_BIG_NUMBER,
+      points: [] as PricePointDetails[],
+    },
+  )
+
+  return points
+}
+
+function _printOrderBook(pricePoints: PricePointDetails[], baseToken: TokenDetails, quoteToken: TokenDetails): void {
+  logDebug('Order Book: ' + baseToken.symbol + '-' + quoteToken.symbol)
+  pricePoints.forEach(pricePoint => {
+    const isBid = pricePoint.type === Offer.Bid
+    logDebug(
+      `\t${isBid ? 'Bid' : 'Ask'} ${pricePoint.totalVolumeFormatted} ${baseToken.symbol} at ${
+        pricePoint.priceFormatted
+      } ${quoteToken.symbol}`,
+    )
+  })
 }
 
 const draw = (
@@ -155,6 +232,8 @@ const draw = (
   hops?: number,
 ): am4charts.XYChart => {
   const baseTokenLabel = safeTokenName(baseToken)
+  const quoteTokenLabel = safeTokenName(quoteToken)
+  const market = baseTokenLabel + '-' + quoteTokenLabel
   am4core.useTheme(am4themesSpiritedaway)
   am4core.options.autoSetClassName = true
   const chart = am4core.create(chartElement, am4charts.XYChart)
@@ -168,15 +247,21 @@ const draw = (
     networkId,
   })
   chart.dataSource.adapter.add('parsedData', data => {
-    const processed = processData(data.bids, baseToken, quoteToken, Offer.Bid).concat(
-      processData(data.asks, baseToken, quoteToken, Offer.Ask),
-    )
-    processed
-      // cast as number to sort...
-      .sort((lhs, rhs) => +lhs.price - +rhs.price)
-      // show as string
-      .map(processedItem => ({ ...processedItem, price: checkPriceAndConvert(processedItem.price as number) }))
-    return processed
+    try {
+      const bids = processData(data.bids, baseToken, quoteToken, Offer.Bid)
+      const asks = processData(data.asks, baseToken, quoteToken, Offer.Ask)
+      const pricePoints = bids.concat(asks)
+
+      // Sort points by price
+      pricePoints.sort((lhs, rhs) => lhs.price.comparedTo(rhs.price))
+
+      _printOrderBook(pricePoints, baseToken, quoteToken)
+
+      return pricePoints
+    } catch (error) {
+      console.error('Error processing data', error)
+      return []
+    }
   })
 
   // Colors
@@ -187,32 +272,32 @@ const draw = (
 
   // Create axes
   const xAxis = chart.xAxes.push(new am4charts.CategoryAxis())
-  xAxis.dataFields.category = 'price'
-  xAxis.title.text = `${networkDescription} Price (${baseToken.symbol}/${quoteToken.symbol})`
+  xAxis.dataFields.category = 'priceNumber'
+  xAxis.title.text = `${networkDescription} Price (${quoteTokenLabel})`
 
   const yAxis = chart.yAxes.push(new am4charts.ValueAxis())
-  yAxis.title.text = 'Volume'
+  yAxis.title.text = baseTokenLabel
 
   // Create series
-  const bidCurve = chart.series.push(new am4charts.StepLineSeries())
-  bidCurve.dataFields.categoryX = 'price'
-  bidCurve.dataFields.valueY = 'bidValueY'
-  bidCurve.strokeWidth = 1
-  bidCurve.stroke = am4core.color(colors.green)
-  bidCurve.fill = bidCurve.stroke
-  bidCurve.startLocation = 0.5
-  bidCurve.fillOpacity = 0.1
-  bidCurve.tooltipText = `Bid: [bold]{categoryX}[/]\nVolume: [bold]{totalVolume} ${baseTokenLabel}[/]`
+  const bidSeries = chart.series.push(new am4charts.StepLineSeries())
+  bidSeries.dataFields.categoryX = 'priceNumber'
+  bidSeries.dataFields.valueY = 'bidValueY'
+  bidSeries.strokeWidth = 1
+  bidSeries.stroke = am4core.color(colors.green)
+  bidSeries.fill = bidSeries.stroke
+  bidSeries.startLocation = 0.5
+  bidSeries.fillOpacity = 0.1
+  bidSeries.tooltipText = `[bold]${market}[/]\nBid Price: [bold]{priceFormatted}[/] ${quoteTokenLabel}\nVolume: [bold]{totalVolumeFormatted}[/] ${baseTokenLabel}`
 
-  const askCurve = chart.series.push(new am4charts.StepLineSeries())
-  askCurve.dataFields.categoryX = 'price'
-  askCurve.dataFields.valueY = 'askValueY'
-  askCurve.strokeWidth = 1
-  askCurve.stroke = am4core.color(colors.red)
-  askCurve.fill = askCurve.stroke
-  askCurve.fillOpacity = 0.1
-  askCurve.startLocation = 0.5
-  askCurve.tooltipText = `Ask: [bold]{categoryX}[/]\nVolume: [bold]{totalVolume} ${baseTokenLabel}[/]`
+  const askSeries = chart.series.push(new am4charts.StepLineSeries())
+  askSeries.dataFields.categoryX = 'priceNumber'
+  askSeries.dataFields.valueY = 'askValueY'
+  askSeries.strokeWidth = 1
+  askSeries.stroke = am4core.color(colors.red)
+  askSeries.fill = askSeries.stroke
+  askSeries.fillOpacity = 0.1
+  askSeries.startLocation = 0.5
+  askSeries.tooltipText = `[bold]${market}[/]\nAsk Price: [bold]{priceFormatted}[/] ${quoteTokenLabel}\nVolume: [bold]{totalVolumeFormatted}[/] ${baseTokenLabel}`
 
   // Add cursor
   chart.cursor = new am4charts.XYCursor()

--- a/src/components/OrderBookWidget.tsx
+++ b/src/components/OrderBookWidget.tsx
@@ -111,7 +111,7 @@ interface PricePointDetails {
 
 function _toPricePoint(pricePoint: RawPricePoint, quoteTokenDecimals: number, baseTokenDecimals: number): PricePoint {
   return {
-    price: new BigNumber(pricePoint.price).dividedBy(TEN_BIG_NUMBER.pow(quoteTokenDecimals - baseTokenDecimals)),
+    price: new BigNumber(pricePoint.price).div(TEN_BIG_NUMBER.pow(quoteTokenDecimals - baseTokenDecimals)),
     volume: new BigNumber(pricePoint.volume).div(TEN_BIG_NUMBER.pow(baseTokenDecimals)),
   }
 }

--- a/src/components/TradeWidget/Price.tsx
+++ b/src/components/TradeWidget/Price.tsx
@@ -220,7 +220,7 @@ const Price: React.FC<Props> = ({ sellToken, receiveToken, priceInputId, priceIn
   return (
     <Wrapper>
       <strong>
-        Limit Price <OrderBookBtn baseToken={sellToken} quoteToken={receiveToken} />
+        Limit Price <OrderBookBtn baseToken={receiveToken} quoteToken={sellToken} />
       </strong>
       <PriceInputBox>
         <label>


### PR DESCRIPTION
Fixes #1056

This PR does a refactor in the Order Book to tackle with the following issues:
- All operations are done using floats, so there's some precision errors and possible overflows
- The order book continues to be a source of confusion
- A refactor will come handy to prepare for https://github.com/gnosis/dex-react/issues/1049
- It prepares for receiving `string` from the API instead of numbers --> I guess that's coming, since Nick is working in the event-base order book. Now if they send strings instead of numbers, it should work too

## Inverts the order book
Apparently we were showing the order book the other way around

If we sell `USDC` for buying `WETH`, then we are in  `WETH-USDC` market
* `WETH`: Base token
* `USDC`: Quote token

This PR corrects this issue in the trading page

## Change the header
![image](https://user-images.githubusercontent.com/2352112/83057829-bc4d4180-a057-11ea-8d8c-c6209a04bb93.png)

It was source of confusion. Sho now, it shows the Market (`BUY-SELL`) instead of `SELL --> BUY`

## Some changes regarding the representation.

In the previous version, we show the order book like this:

![image](https://user-images.githubusercontent.com/2352112/83056371-91fa8480-a055-11ea-88b5-dc3548bb1cb6.png)

The proposal is to show it like this:
![image](https://user-images.githubusercontent.com/2352112/83056438-b3f40700-a055-11ea-89bb-7661b4ea2a90.png)

Note that:
* Y-axis shows is named after his units --> `WETH` in this case
* X-axis shows the units instead of the market --> `USDC` in this case
* The tooltip shows the Market where you are selling
* The tooltip price has been renamed and shows the units  --> `USDC`
* The tooltip volume shows the units --> `WETH` in this case
* Now volumes and prices are formatted using the `formatSmart` function, so they are more readable

## Other changes
**New types**
* `RawPricePoint`: Models the data returned by the endpoint
* `PricePoint` is a price point normalized (units instead of atoms, and uses BigNumber)
* `PricePointDetails` Models the details of the price point used for representation. It has some data replication needed to represent and format the price point (i.e. the formatted version of the volume and price)

**Debug**
Now the console shows the order book in the console. It's handy for debugging. Although in production is hidden

