### PR TITLE
Save trades as csv

### DIFF
--- a/src/components/FileDownloaderLink.tsx
+++ b/src/components/FileDownloaderLink.tsx
@@ -1,14 +1,17 @@
-import React, { useRef, useEffect } from 'react'
-
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faFileCsv } from '@fortawesome/free-solid-svg-icons'
+import React, { useRef, useEffect, AnchorHTMLAttributes } from 'react'
 
 interface FileSaverLinkProps {
   data?: string
   options?: BlobPropertyBag
+  filename: string
 }
 
-export const FileDownloaderLink: React.FC<FileSaverLinkProps> = ({ data, options }) => {
+export const FileDownloaderLink: React.FC<FileSaverLinkProps & AnchorHTMLAttributes<HTMLAnchorElement>> = ({
+  data,
+  options,
+  filename,
+  ...anchorProps
+}) => {
   const lastObjectURL = useRef('')
   const lastDataUsed = useRef('')
 
@@ -41,9 +44,5 @@ export const FileDownloaderLink: React.FC<FileSaverLinkProps> = ({ data, options
     e.currentTarget.href = lastObjectURL.current = URL.createObjectURL(blob)
   }
 
-  return (
-    <a href={lastObjectURL.current} download="trades.csv" onClick={handleClick}>
-      <FontAwesomeIcon icon={faFileCsv} size="2x" />
-    </a>
-  )
+  return <a href={lastObjectURL.current} download={filename} onClick={handleClick} {...anchorProps} />
 }

--- a/src/components/FileDownloaderLink.tsx
+++ b/src/components/FileDownloaderLink.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, AnchorHTMLAttributes } from 'react'
 
 interface FileSaverLinkProps {
-  data?: string
+  data?: string | (() => string)
   options?: BlobPropertyBag
   filename: string
 }
@@ -32,15 +32,16 @@ export const FileDownloaderLink: React.FC<FileSaverLinkProps & AnchorHTMLAttribu
       e.preventDefault()
       return
     }
+    const csvData = typeof data === 'string' ? data : data()
     // data didn't change, reusing already set ObjectURL
-    if (lastDataUsed.current === data) return
-    lastDataUsed.current = data
+    if (lastDataUsed.current === csvData) return
+    lastDataUsed.current = csvData
 
     // new data, need new ObjectURL
     // release old if was set previously
     if (lastObjectURL.current) URL.revokeObjectURL(lastObjectURL.current)
 
-    const blob = new Blob([data], options)
+    const blob = new Blob([csvData], options)
     e.currentTarget.href = lastObjectURL.current = URL.createObjectURL(blob)
   }
 

--- a/src/components/FileDownloaderLink.tsx
+++ b/src/components/FileDownloaderLink.tsx
@@ -1,0 +1,49 @@
+import React, { useRef, useEffect } from 'react'
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faFileCsv } from '@fortawesome/free-solid-svg-icons'
+
+interface FileSaverLinkProps {
+  data?: string
+  options?: BlobPropertyBag
+}
+
+export const FileDownloaderLink: React.FC<FileSaverLinkProps> = ({ data, options }) => {
+  const lastObjectURL = useRef('')
+  const lastDataUsed = useRef('')
+
+  useEffect(
+    () => (): void => {
+      // on unmount release ObjectURL if any
+      if (lastObjectURL.current) URL.revokeObjectURL(lastObjectURL.current)
+    },
+    [],
+  )
+
+  // only create download onClick because
+  // creating and retaining BLob and ObjectURL can be expensive on each render
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>): void => {
+    // no data
+    if (!data) {
+      // prevent invalid file download
+      e.preventDefault()
+      return
+    }
+    // data didn't change, reusing already set ObjectURL
+    if (lastDataUsed.current === data) return
+    lastDataUsed.current = data
+
+    // new data, need new ObjectURL
+    // release old if was set previously
+    if (lastObjectURL.current) URL.revokeObjectURL(lastObjectURL.current)
+
+    const blob = new Blob([data], options)
+    e.currentTarget.href = lastObjectURL.current = URL.createObjectURL(blob)
+  }
+
+  return (
+    <a href={lastObjectURL.current} download="trades.csv" onClick={handleClick}>
+      <FontAwesomeIcon icon={faFileCsv} size="2x" />
+    </a>
+  )
+}

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -15,7 +15,7 @@ import { displayTokenSymbolOrLink } from 'utils/display'
 
 import useSafeState from 'hooks/useSafeState'
 
-function classifyTrade(trade: Trade): string {
+export function classifyTrade(trade: Trade): string {
   return isTradeFilled(trade) ? 'Full' : 'Partial'
 }
 

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import { ContentPage } from 'components/Layout/PageWrapper'
 import { CardTable } from 'components/Layout/Card'
@@ -6,26 +6,66 @@ import { CardTable } from 'components/Layout/Card'
 import { useWalletConnection } from 'hooks/useWalletConnection'
 import { useTrades } from 'hooks/useTrades'
 
-import { TradeRow } from 'components/TradesWidget/TradeRow'
+import { TradeRow, classifyTrade } from 'components/TradesWidget/TradeRow'
+
+import { formatPrice, formatSmart } from '@gnosis.pm/dex-js'
+
+import { Trade } from 'api/exchange/ExchangeApi'
+
+import { displayTokenSymbolOrLink } from 'utils/display'
+import { FileDownloaderLink } from 'components/FileDownloaderLink'
+
+const formatTradeAsCSV = (trade: Trade, now: Date): string => {
+  return [
+    displayTokenSymbolOrLink(trade.sellToken) + '/' + displayTokenSymbolOrLink(trade.buyToken),
+    formatSmart({ amount: trade.sellAmount, precision: trade.sellToken.decimals as number }) +
+      ' ' +
+      displayTokenSymbolOrLink(trade.sellToken),
+    formatPrice(trade.limitPrice),
+    formatPrice(trade.fillPrice),
+    formatSmart({ amount: trade.buyAmount, precision: trade.buyToken.decimals as number }) +
+      ' ' +
+      displayTokenSymbolOrLink(trade.buyToken),
+    classifyTrade(trade),
+    new Date(trade.timestamp).toLocaleString(),
+    trade.txHash,
+    trade.settlingDate > now ? 'NOT SETTLED' : 'SETTLED',
+  ]
+    .map(value => {
+      // " is a string delimeter
+      // if already included in e.g. symbol
+      // must be replaced by double ""
+      value = value.replace(/"/g, '""')
+
+      // if there's a field delimeter comma in e.g. symbol or date
+      // need to enclose whole string in quotes
+      if (value.includes(',')) value = `"${value}"`
+      return value
+    })
+    .join(',')
+}
+
+const tableHeads = ['Market', 'Amount', 'Limit Price', 'Fill Price', 'Received', 'Type', 'Time', 'Tx', 'Settled']
+const tableHeader = tableHeads.join(',') + '\n'
 
 const Trades: React.FC = () => {
   const { networkId } = useWalletConnection()
   const trades = useTrades()
 
+  const csvString = useMemo(() => {
+    const now = new Date()
+    return tableHeader + trades.map(trade => formatTradeAsCSV(trade, now)).join('\n')
+  }, [trades])
+
   return (
     <ContentPage>
+      {trades.length > 0 && <FileDownloaderLink data={csvString} options={{ type: 'text/csv;charset=utf-8;' }} />}
       <CardTable $columns="1fr 1.2fr repeat(2, 0.8fr) 1.2fr 0.7fr 0.8fr 1fr 0.5fr" $rowSeparation="0">
         <thead>
           <tr>
-            <th>Market</th>
-            <th>Amount</th>
-            <th>Limit Price</th>
-            <th>Fill Price</th>
-            <th>Received</th>
-            <th>Type</th>
-            <th>Time</th>
-            <th>Tx</th>
-            <th>Settled</th>
+            {tableHeads.map(head => (
+              <th key={head}>{head}</th>
+            ))}
           </tr>
         </thead>
         <tbody>

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -1,5 +1,8 @@
 import React, { useMemo } from 'react'
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faFileCsv } from '@fortawesome/free-solid-svg-icons'
+
 import { ContentPage } from 'components/Layout/PageWrapper'
 import { CardTable } from 'components/Layout/Card'
 
@@ -59,7 +62,11 @@ const Trades: React.FC = () => {
 
   return (
     <ContentPage>
-      {trades.length > 0 && <FileDownloaderLink data={csvString} options={{ type: 'text/csv;charset=utf-8;' }} />}
+      {trades.length > 0 && (
+        <FileDownloaderLink data={csvString} options={{ type: 'text/csv;charset=utf-8;' }} filename="trades.csv">
+          <FontAwesomeIcon icon={faFileCsv} size="2x" />
+        </FileDownloaderLink>
+      )}
       <CardTable $columns="1fr 1.2fr repeat(2, 0.8fr) 1.2fr 0.7fr 0.8fr 1fr 0.5fr" $rowSeparation="0">
         <thead>
           <tr>

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,57 @@
+import { logDebug } from 'utils/miscellaneous'
+
+// TODO: can I make sure - using types - that headers length matches transformer return type length?
+// Alternatively, I could make headers be the keys of a second type parameter
+// which is the result of transformer, such as transformer<T, R>(item: T) => R[]
+interface ToCsvParams<T> {
+  headers?: string[]
+  data: T[]
+  transformer: (item: T) => string[]
+}
+
+/**
+ * Util function that transforms given data and transformer function into a csv string,
+ * taking care of escaping and error handling
+ *
+ * `headers` (optional). If present, length must match transformer return type length
+ * `data` is a list of items to be converted to CSV by `transformer`
+ * `transformer` is a function that receives the item and returns a list of strings
+ */
+export function toCsv<T>({ headers = [], data, transformer }: ToCsvParams<T>): string {
+  return data
+    .reduce(
+      (acc, item) => {
+        let values
+        try {
+          values = transformer(item)
+
+          // Make sure the returned values match.
+          if (headers && values.length !== headers.length) {
+            throw new Error(`Values length (${values.length}) doesn't match headers length ${headers.length}`)
+          }
+        } catch (e) {
+          logDebug(`[utils:toCsv] Not able to transform into csv: ${item}`, e)
+          return acc
+        }
+        const csvRow = values
+          .map(value => {
+            // " is a string delimeter
+            // if already included in e.g. symbol
+            // must be replaced by double ""
+            value = value.replace(/"/g, '""')
+
+            // if there's a field delimeter comma in e.g. symbol or date
+            // need to enclose whole string in quotes
+            if (value.includes(',')) value = `"${value}"`
+            return value
+          })
+          .join(',')
+
+        acc.push(csvRow)
+
+        return acc
+      },
+      [headers.join(',')],
+    )
+    .join('\n')
+}


### PR DESCRIPTION
Adds CSV saving functionality

Feel free to style/position as you see fit

Also I'm not a fan of how `formatTradeAsCSV` has to duplicate a lot of `TradeRow` functionality and make an extra loop over `trades`.
Maybe perform formatting only once and make `TradeRow` accept
```js
[
    displayTokenSymbolOrLink(trade.sellToken) + '/' + displayTokenSymbolOrLink(trade.buyToken),
    formatSmart({ amount: trade.sellAmount, precision: trade.sellToken.decimals as number }) +
      ' ' +
      displayTokenSymbolOrLink(trade.sellToken),
    formatPrice(trade.limitPrice),
    formatPrice(trade.fillPrice),
    formatSmart({ amount: trade.buyAmount, precision: trade.buyToken.decimals as number }) +
      ' ' +
      displayTokenSymbolOrLink(trade.buyToken),
    classifyTrade(trade),
    new Date(trade.timestamp).toLocaleString(),
    trade.txHash,
    trade.settlingDate > now ? 'NOT SETTLED' : 'SETTLED',
  ]
```
Up to you, @alfetopito 
