### PR TITLE
1029/styling trades

### DIFF
--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -151,6 +151,8 @@ export interface Trade extends BaseTradeEvent {
   limitPrice?: BigNumber
   fillPrice: BigNumber
   remainingAmount?: BN
+  orderBuyAmount?: BN
+  orderSellAmount?: BN
 }
 
 export interface GetOrdersPaginatedResult {

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -78,7 +78,7 @@ export const TradeRow: React.FC<TradeRowProps> = params => {
   return !isTradeSettled(trade) ? null : (
     <tr data-order-id={orderId} data-batch-id={batchId}>
       <td data-label="Date" title={new Date(timestamp).toLocaleString()}>
-        {formatDateFromBatchId(batchId)}
+        {formatDateFromBatchId(batchId, { strict: true })}
       </td>
       <td>
         {displayTokenSymbolOrLink(buyToken)}/{displayTokenSymbolOrLink(sellToken)}

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -23,12 +23,15 @@ const TypePill = styled.span<{
   $bgColor?: string
 }>`
   background-color: ${({ $bgColor = 'green' }): string => $bgColor};
+  display: inline-block;
+  font-size: 0.9rem;
+  padding: 0.2rem 0.8rem;
+  min-width: 5.3em;
   color: white;
   font-weight: bold;
   border-radius: 1em;
   text-align: center;
   text-transform: uppercase;
-  padding: 0.5em;
 `
 
 export const TradeRow: React.FC<TradeRowProps> = params => {

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -30,9 +30,21 @@ interface TradeRowProps {
 }
 
 const TypePill = styled.span<{
-  $bgColor?: string
+  tradeType: TradeType
 }>`
-  background-color: ${({ $bgColor = 'green' }): string => $bgColor};
+  background-color: ${({ tradeType }): string => {
+    switch (tradeType) {
+      case 'full':
+        return 'darkgreen'
+      case 'partial':
+        return 'darkorange'
+      case 'liquidity':
+        return 'blueviolet'
+      case 'unknown':
+      default:
+        return 'grey'
+    }
+  }};
   display: inline-block;
   font-size: 0.9rem;
   padding: 0.2rem 0.8rem;
@@ -64,42 +76,27 @@ export const TradeRow: React.FC<TradeRowProps> = params => {
 
   const tradeType = useMemo(() => classifyTrade(trade), [trade])
 
-  const [typeColumnTitle, tradeTypePillColor] = useMemo(() => {
-    let title = ''
-    let color = 'grey'
-
-    let tradeAmount, orderAmount
-    if (orderSellAmount) {
-      tradeAmount = formatAmountFull({
-        amount: sellAmount,
-        precision: sellTokenDecimals,
-      })
-      orderAmount = formatAmountFull({
-        amount: orderSellAmount,
-        precision: sellTokenDecimals,
-      })
-    }
-
+  const typeColumnTitle = useMemo(() => {
     switch (tradeType) {
       case 'full':
-        title = `${tradeAmount} matched out of ${orderAmount}`
-        color = 'darkgreen'
-        break
       case 'partial': {
-        title = `${tradeAmount} matched out of ${orderAmount}`
-        color = 'darkorange'
-        break
+        if (orderSellAmount) {
+          const tradeAmount = formatAmountFull({
+            amount: sellAmount,
+            precision: sellTokenDecimals,
+          })
+          const orderAmount = formatAmountFull({
+            amount: orderSellAmount,
+            precision: sellTokenDecimals,
+          })
+          return `${tradeAmount} matched out of ${orderAmount}`
+        }
       }
       case 'liquidity':
-        color = 'blueviolet'
-        break
       case 'unknown':
-        color = 'grey'
-        break
       default:
-        title = ''
+        return ''
     }
-    return [title, color]
   }, [orderSellAmount, sellAmount, sellTokenDecimals, tradeType])
 
   // Do not display trades that are not settled
@@ -124,7 +121,7 @@ export const TradeRow: React.FC<TradeRowProps> = params => {
         {formatSmart({ amount: buyAmount, precision: buyTokenDecimals })} {displayTokenSymbolOrLink(buyToken)}
       </td>
       <td data-label="Type" title={typeColumnTitle}>
-        <TypePill $bgColor={tradeTypePillColor}>{tradeType}</TypePill>
+        <TypePill tradeType={tradeType}>{tradeType}</TypePill>
       </td>
       <td>
         <EtherscanLink type={'event'} identifier={txHash} networkId={networkId} />

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -83,14 +83,14 @@ export const TradeRow: React.FC<TradeRowProps> = params => {
       <td>
         {displayTokenSymbolOrLink(buyToken)}/{displayTokenSymbolOrLink(sellToken)}
       </td>
-      <td data-label="Amount" title={formatAmountFull({ amount: sellAmount, precision: sellTokenDecimals })}>
-        {formatSmart({ amount: sellAmount, precision: sellTokenDecimals })} {displayTokenSymbolOrLink(sellToken)}
-      </td>
       <td data-label="Limit Price" title={limitPrice && formatPrice({ price: limitPrice, decimals: 8 })}>
         {limitPrice ? formatPrice(limitPrice) : 'N/A'}
       </td>
       <td data-label="Fill Price" title={formatPrice({ price: fillPrice, decimals: 8 })}>
         {formatPrice(fillPrice)}
+      </td>
+      <td data-label="Amount" title={formatAmountFull({ amount: sellAmount, precision: sellTokenDecimals })}>
+        {formatSmart({ amount: sellAmount, precision: sellTokenDecimals })} {displayTokenSymbolOrLink(sellToken)}
       </td>
       <td data-label="Received" title={formatAmountFull({ amount: buyAmount, precision: buyTokenDecimals })}>
         {formatSmart({ amount: buyAmount, precision: buyTokenDecimals })} {displayTokenSymbolOrLink(buyToken)}

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -112,8 +112,14 @@ const Trades: React.FC = () => {
             <th>Date</th>
             <th>Market</th>
             <th>Amount</th>
-            <th>Limit Price</th>
-            <th>Fill Price</th>
+            <th>
+              Limit <br />
+              Price
+            </th>
+            <th>
+              Fill <br />
+              Price
+            </th>
             <th>Received</th>
             <th>Type</th>
             <th>

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -106,7 +106,7 @@ const Trades: React.FC = () => {
     <ConnectWalletBanner />
   ) : (
     <ContentPage>
-      <CardTable $columns="1.2fr 1fr repeat(2, 0.7fr) repeat(2, 1.2fr) 0.7fr 1fr" $rowSeparation="0">
+      <CardTable $columns="1.2fr 1fr repeat(2, 0.7fr) repeat(2, 1.2fr) 0.9fr 1fr" $rowSeparation="0">
         <thead>
           <tr>
             <th>Date</th>

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -106,12 +106,11 @@ const Trades: React.FC = () => {
     <ConnectWalletBanner />
   ) : (
     <ContentPage>
-      <CardTable $columns="1.2fr 1fr 1.2fr repeat(2, 0.7fr) 1.2fr 0.7fr 1fr" $rowSeparation="0">
+      <CardTable $columns="1.2fr 1fr repeat(2, 0.7fr) repeat(2, 1.2fr) 0.7fr 1fr" $rowSeparation="0">
         <thead>
           <tr>
             <th>Date</th>
             <th>Market</th>
-            <th>Amount</th>
             <th>
               Limit <br />
               Price
@@ -120,6 +119,7 @@ const Trades: React.FC = () => {
               Fill <br />
               Price
             </th>
+            <th>Amount</th>
             <th>Received</th>
             <th>Type</th>
             <th>

--- a/src/services/factories/getTrades.ts
+++ b/src/services/factories/getTrades.ts
@@ -153,6 +153,8 @@ export function getTradesFactory(factoryParams: {
           denominator: { amount: event.sellAmount, decimals: sellToken.decimals },
         }),
         remainingAmount: order && order.priceDenominator.sub(event.sellAmount),
+        orderBuyAmount: order && order.priceNumerator,
+        orderSellAmount: order && order.priceDenominator,
       }
       acc.push(trade)
 

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,4 +1,4 @@
-import { formatDistanceToNow, addMinutes } from 'date-fns'
+import { formatDistanceToNow, addMinutes, formatDistanceStrict } from 'date-fns'
 
 import { BATCH_TIME, BATCH_TIME_IN_MS, BATCH_SUBMISSION_CLOSE_TIME } from 'const'
 
@@ -30,9 +30,10 @@ export function batchIdToDate(batchId: number): Date {
   return new Date(timestamp)
 }
 
-export function formatDateFromBatchId(batchId: number): string {
+export function formatDateFromBatchId(batchId: number, options?: { strict?: boolean; addSuffix?: boolean }): string {
+  const { strict = false, addSuffix = true } = options || {}
   const date = batchIdToDate(batchId)
-  return formatDistanceToNow(date, { addSuffix: true })
+  return strict ? formatDistanceStrict(date, new Date(), { addSuffix }) : formatDistanceToNow(date, { addSuffix })
 }
 
 /**


### PR DESCRIPTION
## Update Jun 04

- Switched position of `Amount` column before `Received` column.
- Added `liquidity` type (with a nice color :paintbrush: )
- Type column title displayed only for `partial` and `full` types of trades. No point for `liquidity`.

![screenshot_2020-06-04_09-29-47](https://user-images.githubusercontent.com/43217/83785400-19dc2200-a646-11ea-9a34-0f71e481af36.png)

---

Part of #1029 

Addressing parts of https://github.com/gnosis/dex-react/pull/1012#issuecomment-638092146

- Updating the Pill css as suggested 
- Adding a title to Pills
- Shortening the date string


![screenshot_2020-06-03_14-05-24](https://user-images.githubusercontent.com/43217/83689246-8e11b980-a5a3-11ea-9500-f79bd45e56fa.png)


Do not intend to deal with mobile in this PR
