### PR TITLE
1030/reverted trades

### DIFF
--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -148,6 +148,8 @@ export interface EventWithBlockInfo extends BaseTradeEvent {
  * Trade enriches BaseTradeEvent with block, order and token data
  */
 export interface Trade extends EventWithBlockInfo {
+  revertTimestamp?: number
+  revertId?: string
   settlingTimestamp: number
   buyToken: TokenDetails
   sellToken: TokenDetails

--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -138,9 +138,8 @@ export interface BaseTradeEvent {
   id: string // txHash | eventIndex
 }
 
-interface AdditionalEventDetails extends BaseTradeEvent {
+export interface EventWithBlockInfo extends BaseTradeEvent {
   revertKey: string // batchId | orderId, to find reverts
-  // indexOnBatch: number // tracks trade position on batch, in case of reverts
   batchId: number
   timestamp: number
 }
@@ -148,7 +147,7 @@ interface AdditionalEventDetails extends BaseTradeEvent {
 /**
  * Trade enriches BaseTradeEvent with block, order and token data
  */
-export interface Trade extends AdditionalEventDetails {
+export interface Trade extends EventWithBlockInfo {
   settlingTimestamp: number
   buyToken: TokenDetails
   sellToken: TokenDetails
@@ -159,7 +158,7 @@ export interface Trade extends AdditionalEventDetails {
   orderSellAmount?: BN
 }
 
-export type TradeReversion = AdditionalEventDetails
+export type TradeReversion = EventWithBlockInfo
 
 export interface GetOrdersPaginatedResult {
   orders: AuctionElement[]

--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -138,14 +138,17 @@ export interface BaseTradeEvent {
   id: string // txHash | eventIndex
 }
 
+interface AdditionalEventDetails extends BaseTradeEvent {
+  revertKey: string // batchId | orderId, to find reverts
+  // indexOnBatch: number // tracks trade position on batch, in case of reverts
+  batchId: number
+  timestamp: number
+}
+
 /**
  * Trade enriches BaseTradeEvent with block, order and token data
  */
-export interface Trade extends BaseTradeEvent {
-  batchId: number
-  revertKey: string // batchId | orderId, to find reverts
-  // indexOnBatch: number // tracks trade position on batch, in case of reverts
-  timestamp: number
+export interface Trade extends AdditionalEventDetails {
   settlingTimestamp: number
   buyToken: TokenDetails
   sellToken: TokenDetails
@@ -155,6 +158,8 @@ export interface Trade extends BaseTradeEvent {
   orderBuyAmount?: BN
   orderSellAmount?: BN
 }
+
+export type TradeReversion = AdditionalEventDetails
 
 export interface GetOrdersPaginatedResult {
   orders: AuctionElement[]

--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -139,7 +139,6 @@ export interface BaseTradeEvent {
 }
 
 export interface EventWithBlockInfo extends BaseTradeEvent {
-  revertKey: string // batchId | orderId, to find reverts
   batchId: number
   timestamp: number
 }
@@ -196,14 +195,6 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
       },
       {},
     )
-  }
-
-  /** STATIC methods **/
-
-  // TODO: Not very happy with this method. Can't be used inside the class because batchId is only known with block data
-  // TODO: Don't really know where to put it
-  public static buildTradeRevertKey(batchId: number, orderId: string): string {
-    return batchId + '|' + orderId
   }
 
   /** PUBLIC methods **/

--- a/src/api/exchange/ExchangeApiMock.ts
+++ b/src/api/exchange/ExchangeApiMock.ts
@@ -67,6 +67,10 @@ export class ExchangeApiMock extends DepositApiMock implements ExchangeApi {
     return []
   }
 
+  public async getPastTradeReversions(): Promise<BaseTradeEvent[]> {
+    return []
+  }
+
   public async getOrder({ userAddress, orderId }: GetOrderParams): Promise<Order> {
     this._initOrders(userAddress)
 

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo } from 'react'
 import styled from 'styled-components'
 import BigNumber from 'bignumber.js'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faUndo } from '@fortawesome/free-solid-svg-icons'
 
 import { formatPrice, formatSmart, formatAmountFull, DEFAULT_PRECISION, isOrderUnlimited } from '@gnosis.pm/dex-js'
 
@@ -147,7 +149,19 @@ export const TradeRow: React.FC<TradeRowProps> = params => {
         <TypePill tradeType={tradeType}>{tradeType}</TypePill>
       </td>
       <td>
-        <EtherscanLink type={'event'} identifier={txHash} networkId={networkId} />
+        {/* TODO: remove icon and filter out reverted trades */}
+        <EtherscanLink type={'event'} identifier={txHash} networkId={networkId} />{' '}
+        {trade.revertId && (
+          <FontAwesomeIcon
+            icon={faUndo}
+            data-trade-id={trade.id}
+            data-revert-id={trade.revertId}
+            data-revert-timestamp={trade.revertTimestamp}
+            data-sell-token-id={trade.sellTokenId}
+            data-buy-token-id={trade.buyTokenId}
+            data-order-id={trade.orderId}
+          />
+        )}
       </td>
     </tr>
   )

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -19,7 +19,7 @@ import { Trade } from 'api/exchange/ExchangeApi'
 import { toCsv, CsvColumns } from 'utils/csv'
 
 import { TradeRow, classifyTrade } from 'components/TradesWidget/TradeRow'
-import { getNetworkFromId, isTradeSettled } from 'utils'
+import { getNetworkFromId, isTradeSettled, isTradeReverted } from 'utils'
 
 const CsvButtonContainer = styled.div`
   display: flex;
@@ -88,13 +88,17 @@ const Trades: React.FC = () => {
   const { networkId, userAddress, isConnected } = useWalletConnection()
   const trades = useTrades()
 
+  const filteredTrades = useMemo(() => trades.filter(trade => isTradeSettled(trade) && !isTradeReverted(trade)), [
+    trades,
+  ])
+
   const generateCsv = useCallback(
     () =>
       toCsv({
-        data: trades.filter(isTradeSettled),
+        data: filteredTrades,
         transformer: csvTransformer,
       }),
-    [trades],
+    [filteredTrades],
   )
 
   const filename = useMemo(
@@ -136,7 +140,7 @@ const Trades: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {trades.map(trade => (
+          {filteredTrades.map(trade => (
             <TradeRow key={trade.id} trade={trade} networkId={networkId} />
           ))}
         </tbody>

--- a/src/hooks/useTrades.ts
+++ b/src/hooks/useTrades.ts
@@ -5,7 +5,7 @@ import { BATCH_TIME } from '@gnosis.pm/dex-js'
 import { Trade } from 'api/exchange/ExchangeApi'
 import { web3 } from 'api'
 
-import { getTrades } from 'services'
+import { getTradesAndTradeReversions } from 'services'
 
 import { appendTrades, updateLastCheckedBlock, overwriteTrades } from 'reducers-actions/trades'
 
@@ -47,7 +47,7 @@ export function useTrades(): Trade[] {
           toBlock,
           orders,
         }
-        const { trades: newTrades, reverts } = await getTrades(params)
+        const { trades: newTrades, reverts } = await getTradesAndTradeReversions(params)
         dispatch(
           newTrades.length > 0 || reverts.length > 0
             ? appendTrades(newTrades, reverts, toBlock)

--- a/src/hooks/useTrades.ts
+++ b/src/hooks/useTrades.ts
@@ -47,7 +47,7 @@ export function useTrades(): Trade[] {
           toBlock,
           orders,
         }
-        const newTrades = await getTrades(params)
+        const [newTrades, reverts] = await getTrades(params)
         dispatch(newTrades.length > 0 ? appendTrades(newTrades, toBlock) : updateLastCheckedBlock(toBlock))
       }
     }

--- a/src/hooks/useTrades.ts
+++ b/src/hooks/useTrades.ts
@@ -30,7 +30,7 @@ export function useTrades(): Trade[] {
 
   useEffect(() => {
     // Resetting trades on network change
-    dispatch(overwriteTrades([], undefined))
+    dispatch(overwriteTrades([], [], undefined))
   }, [dispatch, networkId, userAddress])
 
   useEffect(() => {
@@ -47,8 +47,12 @@ export function useTrades(): Trade[] {
           toBlock,
           orders,
         }
-        const [newTrades, reverts] = await getTrades(params)
-        dispatch(newTrades.length > 0 ? appendTrades(newTrades, toBlock) : updateLastCheckedBlock(toBlock))
+        const { trades: newTrades, reverts } = await getTrades(params)
+        dispatch(
+          newTrades.length > 0 || reverts.length > 0
+            ? appendTrades(newTrades, reverts, toBlock)
+            : updateLastCheckedBlock(toBlock),
+        )
       }
     }
 

--- a/src/hooks/useTrades.ts
+++ b/src/hooks/useTrades.ts
@@ -34,22 +34,21 @@ export function useTrades(): Trade[] {
   }, [dispatch, networkId, userAddress])
 
   useEffect(() => {
-    function updateTrades(): void {
+    async function updateTrades(): Promise<void> {
       if (userAddress && networkId) {
         // Don't want to update on every block
         // So instead, we get the latest block when the time comes
-        web3.eth.getBlockNumber().then(toBlock => {
-          getTrades({
-            userAddress,
-            networkId,
-            // fromBlock is inclusive. If set, add 1 to avoid duplicates, otherwise return undefined
-            fromBlock: !lastCheckedBlock ? lastCheckedBlock : lastCheckedBlock + 1,
-            toBlock,
-            orders,
-          }).then(newTrades =>
-            dispatch(newTrades.length > 0 ? appendTrades(newTrades, toBlock) : updateLastCheckedBlock(toBlock)),
-          )
-        })
+        const toBlock = await web3.eth.getBlockNumber()
+        const params = {
+          userAddress,
+          networkId,
+          // fromBlock is inclusive. If set, add 1 to avoid duplicates, otherwise return undefined
+          fromBlock: !lastCheckedBlock ? lastCheckedBlock : lastCheckedBlock + 1,
+          toBlock,
+          orders,
+        }
+        const newTrades = await getTrades(params)
+        dispatch(newTrades.length > 0 ? appendTrades(newTrades, toBlock) : updateLastCheckedBlock(toBlock))
       }
     }
 

--- a/src/hooks/useTrades.ts
+++ b/src/hooks/useTrades.ts
@@ -29,7 +29,7 @@ export function useTrades(): Trade[] {
 
   useEffect(() => {
     // Resetting trades on network change
-    dispatch(overwriteTrades([], [], undefined))
+    dispatch(overwriteTrades({ trades: [], reverts: [], lastCheckedBlock: undefined }))
   }, [dispatch, networkId, userAddress])
 
   useEffect(() => {
@@ -64,7 +64,7 @@ export function useTrades(): Trade[] {
 
         dispatch(
           newTrades.length > 0 || reverts.length > 0
-            ? appendTrades(newTrades, reverts, toBlock)
+            ? appendTrades({ trades: newTrades, reverts, lastCheckedBlock: toBlock })
             : updateLastCheckedBlock(toBlock),
         )
       }

--- a/src/hooks/useTrades.ts
+++ b/src/hooks/useTrades.ts
@@ -85,8 +85,8 @@ export function useTrades(): Trade[] {
       // Thus, we check for new trades a few seconds after the 4min mark
       const delay = getTimeRemainingInBatch() - 30
 
-      // Update now to not leave the interface empty
-      if (trades.length === 0 || (delay >= 0 && delay < 10)) {
+      // Update now if this is the first time for this address/network OR within the range to start now
+      if (!lastCheckedBlock || (delay >= 0 && delay < 10)) {
         updateTrades()
       }
 
@@ -106,7 +106,7 @@ export function useTrades(): Trade[] {
       cancelled = true
       if (intervalId) clearInterval(intervalId)
     }
-  }, [userAddress, networkId, lastCheckedBlock, dispatch, trades, orders])
+  }, [userAddress, networkId, lastCheckedBlock, dispatch, orders])
 
   // latest first
   return trades.slice(0).reverse()

--- a/src/reducers-actions/trades.ts
+++ b/src/reducers-actions/trades.ts
@@ -46,14 +46,11 @@ function groupByRevertKey<T extends EventWithBlockInfo>(list: T[]): Map<string, 
 
   list.forEach(item => {
     if (map.has(item.revertKey)) {
-      // Do I have to pop it out?
       const subList = map.get(item.revertKey) as T[]
 
       // Do not insert duplicates
       if (!subList.find(({ id }) => item.id === id)) {
         subList.push(item)
-        // Do I have to put it back in?
-        map.set(item.revertKey, subList)
       }
     } else {
       map.set(item.revertKey, [item])

--- a/src/reducers-actions/trades.ts
+++ b/src/reducers-actions/trades.ts
@@ -41,7 +41,9 @@ export const updateLastCheckedBlock = (lastCheckedBlock: number): UpdateBlockAct
 // TODO: store to/load from localStorage
 export const INITIAL_TRADES_STATE = { trades: [], reverts: [] }
 
-function groupByRevertKey<T extends EventWithBlockInfo>(list: T[], map: Map<string, T[]>): void {
+function groupByRevertKey<T extends EventWithBlockInfo>(list: T[]): Map<string, T[]> {
+  const map = new Map<string, T[]>()
+
   list.forEach(item => {
     if (map.has(item.revertKey)) {
       // Do I have to pop it out?
@@ -57,6 +59,8 @@ function groupByRevertKey<T extends EventWithBlockInfo>(list: T[], map: Map<stri
       map.set(item.revertKey, [item])
     }
   })
+
+  return map
 }
 
 function flattenGroup<T extends EventWithBlockInfo>(map: Map<string, T[]>): T[] {
@@ -75,12 +79,9 @@ function sortByTimeAndPosition(a: EventWithBlockInfo, b: EventWithBlockInfo): nu
 }
 
 function applyRevertsToTrades(trades: Trade[], reverts: TradeReversion[]): [Trade[], TradeReversion[]] {
-  const tradesByRevertKey = new Map<string, Trade[]>()
-  const revertsByRevertKey = new Map<string, TradeReversion[]>()
-
   // Group trades by revertKey
-  groupByRevertKey(trades, tradesByRevertKey)
-  groupByRevertKey(reverts, revertsByRevertKey)
+  const tradesByRevertKey = groupByRevertKey(trades)
+  const revertsByRevertKey = groupByRevertKey(reverts)
 
   // Assumptions:
   // 1. There can be more than one trade per batch for a given order (even if there are no reverts)

--- a/src/reducers-actions/trades.ts
+++ b/src/reducers-actions/trades.ts
@@ -99,14 +99,16 @@ function applyRevertsToTrades(trades: Trade[], reverts: TradeReversion[]): [Trad
       if (remainingTrades < 1) {
         // Case 2 and 3, all trades reverted
         tradesByRevertKey.delete(revertKey)
-        logDebug(`All ${trades.length} trade(s) reverted by ${reverts.length} revert(s). Key:${revertKey}`)
+        logDebug(`[reducers:trade][${revertKey}] All ${trades.length} trade(s) reverted by ${reverts.length} revert(s)`)
       } else {
         // Case 1. One or more trades left, pick from the end
         const filteredTrades = trades.slice(trades.length - remainingTrades)
         tradesByRevertKey.set(revertKey, filteredTrades)
-        logDebug(`Reverted ${reverts.length} trade(s), ${filteredTrades.length} left. Key:${revertKey}`)
+        logDebug(`[reducers:trade][${revertKey}] Reverted ${reverts.length} trade(s), ${filteredTrades.length} left`)
       }
     }
+    // TODO: this effectively makes the reverts global state to always be empty.
+    //    Should we care? Is there a use case where a revert will happen before a trade?
     // Reverts have been "used", remove them
     revertsByRevertKey.delete(revertKey)
   })
@@ -126,6 +128,7 @@ export const reducer = (state: TradesState, action: ReducerActionType): TradesSt
     }
     case 'OVERWRITE_TRADES': {
       const { trades: newTrades, reverts: newReverts, lastCheckedBlock } = action.payload
+
       const [trades, reverts] = applyRevertsToTrades(newTrades, newReverts)
 
       return { trades, reverts, lastCheckedBlock }

--- a/src/reducers-actions/trades.ts
+++ b/src/reducers-actions/trades.ts
@@ -125,7 +125,10 @@ export const reducer = (state: TradesState, action: ReducerActionType): TradesSt
       return { trades, reverts, lastCheckedBlock }
     }
     case 'OVERWRITE_TRADES': {
-      return { ...action.payload }
+      const { trades: newTrades, reverts: newReverts, lastCheckedBlock } = action.payload
+      const [trades, reverts] = applyRevertsToTrades(newTrades, newReverts)
+
+      return { trades, reverts, lastCheckedBlock }
     }
     case 'UPDATE_BLOCK': {
       return { ...state, ...action.payload }

--- a/src/reducers-actions/trades.ts
+++ b/src/reducers-actions/trades.ts
@@ -1,6 +1,6 @@
 import { Actions } from 'reducers-actions'
 import { Trade, TradeReversion, EventWithBlockInfo } from 'api/exchange/ExchangeApi'
-import { logDebug } from 'utils'
+import { logDebug, flattenMapOfLists } from 'utils'
 
 export type ActionTypes = 'OVERWRITE_TRADES' | 'APPEND_TRADES' | 'UPDATE_BLOCK'
 
@@ -58,13 +58,6 @@ function groupByRevertKey<T extends EventWithBlockInfo>(list: T[]): Map<string, 
   })
 
   return map
-}
-
-function flattenGroup<T extends EventWithBlockInfo>(map: Map<string, T[]>): T[] {
-  return Array.from(map.keys()).reduce<T[]>((acc, key) => {
-    const list = map.get(key) as T[]
-    return acc.concat(list)
-  }, [])
 }
 
 function sortByTimeAndPosition(a: EventWithBlockInfo, b: EventWithBlockInfo): number {
@@ -131,7 +124,7 @@ function applyRevertsToTrades(trades: Trade[], reverts: TradeReversion[]): [Trad
     revertsByRevertKey.delete(revertKey)
   })
 
-  return [flattenGroup(tradesByRevertKey), flattenGroup(revertsByRevertKey)]
+  return [flattenMapOfLists(tradesByRevertKey), flattenMapOfLists(revertsByRevertKey)]
 }
 
 export const reducer = (state: TradesState, action: ReducerActionType): TradesState => {

--- a/src/reducers-actions/trades.ts
+++ b/src/reducers-actions/trades.ts
@@ -1,5 +1,6 @@
 import { Actions } from 'reducers-actions'
 import { Trade, TradeReversion, EventWithBlockInfo } from 'api/exchange/ExchangeApi'
+import { logDebug } from 'utils'
 
 export type ActionTypes = 'OVERWRITE_TRADES' | 'APPEND_TRADES' | 'UPDATE_BLOCK'
 
@@ -40,25 +41,85 @@ export const updateLastCheckedBlock = (lastCheckedBlock: number): UpdateBlockAct
 // TODO: store to/load from localStorage
 export const INITIAL_TRADES_STATE = { trades: [], reverts: [] }
 
+function groupByRevertKey<T extends EventWithBlockInfo>(list: T[], map: Map<string, T[]>): void {
+  list.forEach(item => {
+    if (map.has(item.revertKey)) {
+      // Do I have to pop it out?
+      const subList = map.get(item.revertKey) as T[]
+
+      // Do not insert duplicates
+      if (!subList.find(({ id }) => item.id === id)) {
+        subList.push(item)
+        // Should I sort on insert?
+        subList.sort((a, b) => a.timestamp - b.timestamp)
+        // Do I have to put it back in?
+        map.set(item.revertKey, subList)
+      }
+    } else {
+      map.set(item.revertKey, [item])
+    }
+  })
+}
+
+function flattenGroup<T extends EventWithBlockInfo>(map: Map<string, T[]>): T[] {
+  return Array.from(map.keys()).reduce<T[]>((acc, key) => {
+    const list = map.get(key) as T[]
+    return acc.concat(list)
+  }, [])
+}
+
 export const reducer = (state: TradesState, action: ReducerActionType): TradesState => {
   switch (action.type) {
     case 'APPEND_TRADES': {
-      const { trades: currTrades } = state
-      const { trades: newTrades, lastCheckedBlock } = action.payload
+      const { trades: currTrades, reverts: currReverts } = state
+      const { trades: newTrades, reverts: newReverts, lastCheckedBlock } = action.payload
 
-      const seenTradeIdsSet = new Set<string>()
+      const tradesByRevertKey = new Map<string, Trade[]>()
+      const revertsByRevertKey = new Map<string, TradeReversion[]>()
 
-      // Append new list to existing list of trades
-      const trades = currTrades.concat(newTrades).reduce<Trade[]>((acc, trade) => {
-        // Removes possible duplicates
-        if (!seenTradeIdsSet.has(trade.id)) {
-          acc.push(trade)
-          seenTradeIdsSet.add(trade.id)
+      // Group trades by revertKey
+      groupByRevertKey(currTrades.concat(newTrades), tradesByRevertKey)
+      groupByRevertKey(currReverts.concat(newReverts), revertsByRevertKey)
+
+      // Assumptions:
+      // 1. There can be more than one trade per batch for a given order (even if there are no reverts)
+      //    This case is not likely given our current solvers, but it's not forbidden by the contract
+      // 2. There will never be more reverts than trades for a given batch/order pair
+      // 3. Every revert matches 1 trade
+      // 4. Reverts match Trades by order or appearance (first Revert matches first Trade and so on)
+
+      Array.from(revertsByRevertKey.keys()).forEach(revertKey => {
+        const reverts = revertsByRevertKey.get(revertKey) as TradeReversion[]
+        const trades = tradesByRevertKey.get(revertKey)
+
+        // Given the assumptions above, the possibilities are:
+        // 1. # trades > # reverts
+        // 2. # trades == # reverts
+        // Not possible:
+        // 3. # trades < # reverts
+        // 4. There are reverts but there are no trades for given revertKey <- should NOT ever happen
+        // 5. There are trades but no reverts <- wouldn't be in this loop in that case
+        if (trades) {
+          const remainingTrades = trades.length - reverts.length
+          if (remainingTrades < 1) {
+            // Case 2 and 3, all trades reverted
+            tradesByRevertKey.delete(revertKey)
+            logDebug(`All ${trades.length} trade(s) reverted by ${reverts.length} revert(s). Key:${revertKey}`)
+          } else {
+            // Case 1. One or more trades left, pick from the end
+            const filteredTrades = trades.slice(trades.length - remainingTrades)
+            tradesByRevertKey.set(revertKey, filteredTrades)
+            logDebug(`Reverted ${reverts.length} trade(s), ${filteredTrades.length} left. Key:${revertKey}`)
+          }
         }
-        return acc
-      }, [])
+        // Reverts have been "used", remove them
+        revertsByRevertKey.delete(revertKey)
+      })
 
-      return { trades, lastCheckedBlock }
+      const trades = flattenGroup(tradesByRevertKey)
+      const reverts = flattenGroup(revertsByRevertKey)
+
+      return { trades, reverts, lastCheckedBlock }
     }
     case 'OVERWRITE_TRADES': {
       return { ...action.payload }

--- a/src/reducers-actions/trades.ts
+++ b/src/reducers-actions/trades.ts
@@ -1,10 +1,11 @@
 import { Actions } from 'reducers-actions'
-import { Trade } from 'api/exchange/ExchangeApi'
+import { Trade, TradeReversion, EventWithBlockInfo } from 'api/exchange/ExchangeApi'
 
 export type ActionTypes = 'OVERWRITE_TRADES' | 'APPEND_TRADES' | 'UPDATE_BLOCK'
 
 export interface TradesState {
   trades: Trade[]
+  reverts: TradeReversion[]
   lastCheckedBlock?: number
 }
 
@@ -13,14 +14,22 @@ type AppendTradesActionType = Actions<'APPEND_TRADES', Required<TradesState>>
 type UpdateBlockActionType = Actions<'UPDATE_BLOCK', Required<Pick<TradesState, 'lastCheckedBlock'>>>
 type ReducerActionType = Actions<ActionTypes, TradesState>
 
-export const overwriteTrades = (trades: Trade[], lastCheckedBlock?: number): OverwriteTradesActionType => ({
+export const overwriteTrades = (
+  trades: Trade[],
+  reverts: TradeReversion[],
+  lastCheckedBlock?: number,
+): OverwriteTradesActionType => ({
   type: 'OVERWRITE_TRADES',
-  payload: { trades, lastCheckedBlock },
+  payload: { trades, reverts, lastCheckedBlock },
 })
 
-export const appendTrades = (trades: Trade[], lastCheckedBlock: number): AppendTradesActionType => ({
+export const appendTrades = (
+  trades: Trade[],
+  reverts: TradeReversion[],
+  lastCheckedBlock: number,
+): AppendTradesActionType => ({
   type: 'APPEND_TRADES',
-  payload: { trades, lastCheckedBlock },
+  payload: { trades, reverts, lastCheckedBlock },
 })
 
 export const updateLastCheckedBlock = (lastCheckedBlock: number): UpdateBlockActionType => ({
@@ -29,7 +38,7 @@ export const updateLastCheckedBlock = (lastCheckedBlock: number): UpdateBlockAct
 })
 
 // TODO: store to/load from localStorage
-export const INITIAL_TRADES_STATE = { trades: [] }
+export const INITIAL_TRADES_STATE = { trades: [], reverts: [] }
 
 export const reducer = (state: TradesState, action: ReducerActionType): TradesState => {
   switch (action.type) {

--- a/src/reducers-actions/trades.ts
+++ b/src/reducers-actions/trades.ts
@@ -49,17 +49,21 @@ function buildTradeRevertKey(batchId: number, orderId: string): string {
 
 function groupByRevertKey<T extends EventWithBlockInfo>(list: T[], initial?: Map<string, T[]>): Map<string, T[]> {
   const map = initial || new Map<string, T[]>()
+  const seenIds = new Set<string>()
 
   list.forEach(item => {
+    // Avoid duplicate entries
+    if (seenIds.has(item.id)) {
+      return
+    }
+    seenIds.add(item.id)
+
     const revertKey = buildTradeRevertKey(item.batchId, item.orderId)
 
     if (map.has(revertKey)) {
       const subList = map.get(revertKey) as T[]
 
-      // Do not insert duplicates
-      if (!subList.find(({ id }) => item.id === id)) {
-        subList.push(item)
-      }
+      subList.push(item)
     } else {
       map.set(revertKey, [item])
     }

--- a/src/reducers-actions/trades.ts
+++ b/src/reducers-actions/trades.ts
@@ -151,9 +151,9 @@ function applyRevertsToTrades(
           tradesIndex++
         }
       }
-      // Shouldn't happen, here for debugging
+      // Shouldn't happen, but...
       if (tradesIndex === trades.length && revertsIndex < reverts.length) {
-        console.error(`There are reverts not matched to trades`)
+        throw new Error(`There are ${reverts.length - revertsIndex} reverts not matched to trades`)
       }
     }
   })

--- a/src/reducers-actions/trades.ts
+++ b/src/reducers-actions/trades.ts
@@ -19,20 +19,18 @@ type AppendTradesActionType = Actions<'APPEND_TRADES', Required<Omit<TradesState
 type UpdateBlockActionType = Actions<'UPDATE_BLOCK', Required<Pick<TradesState, 'lastCheckedBlock'>>>
 type ReducerActionType = Actions<ActionTypes, TradesState & WithReverts>
 
-export const overwriteTrades = (
-  trades: Trade[],
-  reverts: TradeReversion[],
-  lastCheckedBlock?: number,
-): OverwriteTradesActionType => ({
+interface Params {
+  trades: Trade[]
+  reverts: TradeReversion[]
+  lastCheckedBlock?: number
+}
+
+export const overwriteTrades = ({ trades, reverts, lastCheckedBlock }: Params): OverwriteTradesActionType => ({
   type: 'OVERWRITE_TRADES',
   payload: { trades, reverts, lastCheckedBlock },
 })
 
-export const appendTrades = (
-  trades: Trade[],
-  reverts: TradeReversion[],
-  lastCheckedBlock: number,
-): AppendTradesActionType => ({
+export const appendTrades = ({ trades, reverts, lastCheckedBlock }: Required<Params>): AppendTradesActionType => ({
   type: 'APPEND_TRADES',
   payload: { trades, reverts, lastCheckedBlock },
 })

--- a/src/reducers-actions/trades.ts
+++ b/src/reducers-actions/trades.ts
@@ -45,19 +45,25 @@ export const updateLastCheckedBlock = (lastCheckedBlock: number): UpdateBlockAct
 // TODO: store to/load from localStorage
 export const INITIAL_TRADES_STATE = { trades: [], pendingTrades: new Map<string, Trade[]>() }
 
+function buildTradeRevertKey(batchId: number, orderId: string): string {
+  return batchId + '|' + orderId
+}
+
 function groupByRevertKey<T extends EventWithBlockInfo>(list: T[], initial?: Map<string, T[]>): Map<string, T[]> {
   const map = initial || new Map<string, T[]>()
 
   list.forEach(item => {
-    if (map.has(item.revertKey)) {
-      const subList = map.get(item.revertKey) as T[]
+    const revertKey = buildTradeRevertKey(item.batchId, item.orderId)
+
+    if (map.has(revertKey)) {
+      const subList = map.get(revertKey) as T[]
 
       // Do not insert duplicates
       if (!subList.find(({ id }) => item.id === id)) {
         subList.push(item)
       }
     } else {
-      map.set(item.revertKey, [item])
+      map.set(revertKey, [item])
     }
   })
 

--- a/src/reducers-actions/trades.ts
+++ b/src/reducers-actions/trades.ts
@@ -87,15 +87,15 @@ function getPendingTrades(tradesByRevertKey: Map<string, Trade[]>): Map<string, 
   // The `revertKey` is composed by batchId|orderId, so this regex looks for the batchIds in the keys
   const batchesRegex = new RegExp(`^(${currentBatchId}|${currentBatchId - 1}|${currentBatchId - 2})\|`)
 
-  return new Map<string, Trade[]>(
-    // Iterate over trade groups by key. Reduces it to a list of tuples.
-    Array.from(tradesByRevertKey.keys()).reduce<[string, Trade[]][]>((acc, key) => {
-      if (batchesRegex.test(key)) {
-        acc.push([key, tradesByRevertKey.get(key) as Trade[]])
-      }
-      return acc
-    }, []),
-  )
+  const pending = new Map<string, Trade[]>()
+
+  tradesByRevertKey.forEach((trades, key) => {
+    if (batchesRegex.test(key)) {
+      pending.set(key, trades)
+    }
+  })
+
+  return pending
 }
 
 function applyRevertsToTrades(
@@ -114,8 +114,8 @@ function applyRevertsToTrades(
   // 3. Every revert matches 1 trade
   // 4. Reverts match Trades by order or appearance (first Revert matches first Trade and so on)
 
-  Array.from(revertsByRevertKey.keys()).forEach(revertKey => {
-    const reverts = (revertsByRevertKey.get(revertKey) as TradeReversion[]).sort(sortByTimeAndPosition)
+  revertsByRevertKey.forEach((reverts, revertKey) => {
+    reverts.sort(sortByTimeAndPosition)
     const trades = tradesByRevertKey.get(revertKey)?.sort(sortByTimeAndPosition)
 
     if (trades) {

--- a/src/services/factories/getTrades.ts
+++ b/src/services/factories/getTrades.ts
@@ -29,7 +29,7 @@ interface GetTradesAndTradeReversionReturn {
   reverts: TradeReversion[]
 }
 
-export function getTradesFactory(factoryParams: {
+export function getTradesAndTradeReversionsFactory(factoryParams: {
   web3: Web3
   exchangeApi: ExchangeApi
   getTokens: ReturnType<typeof getTokensFactory>

--- a/src/services/factories/getTrades.ts
+++ b/src/services/factories/getTrades.ts
@@ -2,14 +2,7 @@ import Web3 from 'web3'
 
 import { TokenDetails, calculatePrice } from '@gnosis.pm/dex-js'
 
-import ExchangeApiImpl, {
-  ExchangeApi,
-  Trade,
-  TradeReversion,
-  Order,
-  AuctionElement,
-  BaseTradeEvent,
-} from 'api/exchange/ExchangeApi'
+import { ExchangeApi, Trade, TradeReversion, Order, AuctionElement, BaseTradeEvent } from 'api/exchange/ExchangeApi'
 
 import { getTokensFactory } from 'services/factories/tokenList'
 import { addUnlistedTokensToUserTokenListByIdFactory } from 'services/factories/addUnlistedTokensToUserTokenListById'
@@ -49,9 +42,8 @@ export function getTradesAndTradeReversionsFactory(factoryParams: {
     return events.map<TradeReversion>(event => {
       const timestamp = blockTimes.get(event.blockNumber) as number
       const batchId = dateToBatchId(timestamp)
-      const revertKey = ExchangeApiImpl.buildTradeRevertKey(batchId, event.orderId)
 
-      return { ...event, timestamp, batchId, revertKey }
+      return { ...event, timestamp, batchId }
     })
   }
 
@@ -64,7 +56,6 @@ export function getTradesAndTradeReversionsFactory(factoryParams: {
     return events.map<Trade>(event => {
       const timestamp = blockTimes.get(event.blockNumber) as number
       const batchId = dateToBatchId(timestamp)
-      const revertKey = ExchangeApiImpl.buildTradeRevertKey(batchId, event.orderId)
 
       const buyToken = tokens.get(event.buyTokenId) as TokenDetails
       const sellToken = tokens.get(event.sellTokenId) as TokenDetails
@@ -76,7 +67,6 @@ export function getTradesAndTradeReversionsFactory(factoryParams: {
         ...event,
         batchId,
         timestamp,
-        revertKey,
         settlingTimestamp: calculateSettlingTimestamp(batchId),
         buyToken,
         sellToken,

--- a/src/services/factories/getTrades.ts
+++ b/src/services/factories/getTrades.ts
@@ -195,13 +195,12 @@ export function getTradesAndTradeReversionsFactory(factoryParams: {
 
     // ### TRADES and TRADE REVERSIONS ###
     // Final step, put all together
-    const [trades, reverts] = await Promise.all([
+    const [trades, reverts] = await Promise.all<Trade[], TradeReversion[]>([
       assembleTrades(tradeEvents, blockTimes, orders, tokens),
       assembleTradeReversions(tradeReversionEvents, blockTimes),
     ])
 
-    //TODO: Can't figure out why, but TS doesn't accept `trades` is of type `Trade[]`
-    return { trades: trades as Trade[], reverts }
+    return { trades, reverts }
   }
 
   return getTradesAndTradeReversions

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -10,7 +10,7 @@ import {
   getTokenFromErc20Factory,
   TokenFromExchange,
   TokenFromErc20,
-  getTradesFactory,
+  getTradesAndTradeReversionsFactory,
   addUnlistedTokensToUserTokenListByIdFactory,
 } from './factories'
 
@@ -47,7 +47,11 @@ export const addUnlistedTokensToUserTokenListById = addUnlistedTokensToUserToken
   getTokenFromExchangeById,
 })
 
-export const getTrades = getTradesFactory({ ...apis, getTokens, addUnlistedTokensToUserTokenListById })
+export const getTradesAndTradeReversions = getTradesAndTradeReversionsFactory({
+  ...apis,
+  getTokens,
+  addUnlistedTokensToUserTokenListById,
+})
 
 export interface TokenAndNetwork {
   networkId: number

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -164,3 +164,7 @@ export async function retry<T extends () => any>(fn: T, options?: RetryOptions):
     }
   }
 }
+
+export function flattenMapOfLists<K, T>(map: Map<K, T[]>): T[] {
+  return Array.from(map.values()).reduce<T[]>((acc, list) => acc.concat(list), [])
+}

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -113,6 +113,10 @@ export function isTradeSettled(trade: Trade): boolean {
   return trade.settlingTimestamp <= Date.now()
 }
 
+export function isTradeReverted(trade: Trade): boolean {
+  return !!trade.revertId
+}
+
 export const isOrderActive = (order: AuctionElement, now: Date): boolean =>
   batchIdToDate(order.validUntil) >= now && !isOrderFilled(order)
 


### PR DESCRIPTION
Closes #1030

## Update Jun 08

- No longer removing reverted trades
- No longer storing reverts on global state
- Only for testing/debugging, added an icon next to reverted trades. Will filter reverted trades out before merging and remove this entirely.

![screenshot_2020-06-08_14-09-35](https://user-images.githubusercontent.com/43217/84084058-9bf67e80-a997-11ea-9cc6-06b7247cb9a6.png)

- Addressed minor PR comments

![screenshot_2020-06-08_15-03-58](https://user-images.githubusercontent.com/43217/84084892-3acfaa80-a999-11ea-965a-08713be4e13b.png)


---

Removing reverted trades.

![screenshot_2020-06-05_13-56-29](https://user-images.githubusercontent.com/43217/83921951-54bc8380-a734-11ea-8537-913335d4b59f.png)


Todo:
- [x] Use trade reverts on global state to filter out reverted trades
- [x] Fix type issue on `getTrades` service return
![screenshot_2020-06-04_15-12-31](https://user-images.githubusercontent.com/43217/83815767-cbdf1280-a675-11ea-92f6-67ed9d315de3.png)
