### PR TITLE
1032/filter tokens orders widget

### DIFF
--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -1,10 +1,10 @@
 import BN from 'bn.js'
 import { PastEventOptions } from 'web3-eth-contract'
 
-import { assert, BatchExchangeEvents, TokenDetails } from '@gnosis.pm/dex-js'
+import { assert, BatchExchangeEvents } from '@gnosis.pm/dex-js'
 
 import { DepositApiImpl, DepositApi, DepositApiDependencies } from 'api/deposit/DepositApi'
-import { Receipt, WithTxOptionalParams } from 'types'
+import { Receipt, TokenDetails, WithTxOptionalParams } from 'types'
 import { logDebug } from 'utils'
 import { decodeAuctionElements, decodeOrder } from './utils/decodeAuctionElements'
 import { DEFAULT_ORDERS_PAGE_SIZE, LIMIT_EXCEEDED_ERROR_CODE } from 'const'

--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -104,6 +104,11 @@ export interface ExchangeApi extends DepositApi {
   cancelOrders(params: CancelOrdersParams): Promise<Receipt>
 }
 
+export interface DetailedAuctionElement extends AuctionElement {
+  buyToken: TokenDetails | null
+  sellToken: TokenDetails | null
+}
+
 export interface AuctionElement extends Order {
   user: string
   sellTokenBalance: BN

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -3,21 +3,18 @@ import Modali from 'modali'
 import styled from 'styled-components'
 import BN from 'bn.js'
 
-// Assets
-import searchIcon from 'assets/img/search.svg'
-
 // Utils, const, types
 import { logDebug, getToken } from 'utils'
 import { ZERO, MEDIA } from 'const'
 import { TokenBalanceDetails } from 'types'
-import { TokenLocalState } from 'reducers-actions'
 import { LocalTokensState } from 'reducers-actions/localTokens'
+import { TokenLocalState } from 'reducers-actions'
 
 // Components
 import { CardTable } from 'components/Layout/Card'
 import ErrorMsg from 'components/ErrorMsg'
 import Widget from 'components/Layout/Widget'
-import FormMessage from 'components/TradeWidget/FormMessage'
+import FilterTools from 'components/FilterTools'
 
 // DepositWidget: subcomponents
 import { Row } from 'components/DepositWidget/Row'
@@ -184,19 +181,8 @@ const BalancesWidget = styled(Widget)`
       }
     }
   }
-`
-
-export const BalanceTools = styled.div`
-  display: flex;
-  width: 100%;
-  justify-content: space-between;
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-  align-items: center;
-  order: 0;
-
-  > .balances-manageTokens {
+  // button
+  .balances-manageTokens {
     font-size: 1.4rem;
     color: var(--color-text-active);
     letter-spacing: 0;
@@ -218,7 +204,8 @@ export const BalanceTools = styled.div`
     }
   }
 
-  > .balances-hideZero {
+  // label + radio input
+  .balances-hideZero {
     display: flex;
     flex-flow: row nowrap;
     font-size: 1.4rem;
@@ -235,83 +222,6 @@ export const BalanceTools = styled.div`
     > b {
       font-weight: inherit;
       margin: 0 0 0 0.5rem;
-    }
-  }
-
-  > .balances-searchTokens {
-    display: flex;
-    width: auto;
-    max-width: 100%;
-    position: relative;
-    height: 5.6rem;
-    margin: 1.6rem;
-
-    @media ${MEDIA.mobile} {
-      width: 100%;
-      height: 4.6rem;
-      margin: 0 0 2.4rem;
-    }
-
-    > ${FormMessage} {
-      color: var(--color-text-primary);
-      font-size: x-small;
-      margin: 0;
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      width: max-content;
-      padding: 0.1rem 1.6rem 0.1rem 0.5rem;
-      border-radius: 0 1.6rem 0rem 0rem;
-    }
-
-    > input {
-      margin: 0;
-      width: 35rem;
-      max-width: 100%;
-      background: var(--color-background-input) url(${searchIcon}) no-repeat left 1.6rem center/1.6rem;
-      border-radius: 0.6rem 0.6rem 0 0;
-      border: 0;
-      font-size: 1.4rem;
-      line-height: 1;
-      box-sizing: border-box;
-      border-bottom: 0.2rem solid transparent;
-      font-weight: var(--font-weight-normal);
-      padding: 0 1.6rem 0 4.8rem;
-      outline: 0;
-
-      @media ${MEDIA.mobile} {
-        font-size: 1.3rem;
-        width: 100%;
-      }
-
-      &::placeholder {
-        font-size: inherit;
-        color: inherit;
-      }
-
-      &:focus {
-        color: var(--color-text-active);
-      }
-
-      &:focus,
-      &:focus ~ ${FormMessage} {
-        border-bottom: 0.2rem solid var(--color-text-active);
-        border-color: var(--color-text-active);
-
-        transition: all 0.2s ease-in-out;
-      }
-
-      &.error {
-        border-color: var(--color-error);
-      }
-
-      &.warning {
-        border-color: orange;
-      }
-
-      &:disabled {
-        box-shadow: none;
-      }
     }
   }
 `
@@ -433,18 +343,12 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
 
   return (
     <BalancesWidget>
-      <BalanceTools>
-        <label className="balances-searchTokens">
-          <input
-            placeholder="Search token by Name, Symbol or Address"
-            type="text"
-            value={search}
-            onChange={handleSearch}
-          />
-          {hideZeroBalances && displayedBalances?.length > 0 && (
-            <FormMessage className="warning">Filter: Showing {displayedBalances?.length} tokens</FormMessage>
-          )}
-        </label>
+      <FilterTools
+        searchValue={search}
+        handleSearch={handleSearch}
+        showFilter={hideZeroBalances && displayedBalances?.length > 0}
+        dataLength={displayedBalances.length}
+      >
         <label className="balances-hideZero">
           <input type="checkbox" checked={hideZeroBalances} onChange={handleHideZeroBalances} />
           <b>Hide zero balances</b>
@@ -452,7 +356,7 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
         <button type="button" className="balances-manageTokens" onClick={toggleModal}>
           Manage Tokens
         </button>
-      </BalanceTools>
+      </FilterTools>
       {error ? (
         <ErrorMsg title="oops..." message="Something happened while loading the balances" />
       ) : (

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -253,7 +253,7 @@ export const BalanceTools = styled.div`
     }
 
     > ${FormMessage} {
-      color: initial;
+      color: var(--color-text-primary);
       font-size: x-small;
       margin: 0;
       position: absolute;

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -193,7 +193,7 @@ export const BalanceTools = styled.div`
   padding: 0;
   box-sizing: border-box;
   align-items: center;
-  order: 1;
+  order: 0;
 
   > .balances-manageTokens {
     font-size: 1.4rem;

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -290,9 +290,15 @@ export const BalanceTools = styled.div`
       }
 
       &:focus {
+        color: var(--color-text-active);
+      }
+
+      &:focus,
+      &:focus ~ ${FormMessage} {
         border-bottom: 0.2rem solid var(--color-text-active);
         border-color: var(--color-text-active);
-        color: var(--color-text-active);
+
+        transition: all 0.2s ease-in-out;
       }
 
       &.error {

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -185,7 +185,7 @@ const BalancesWidget = styled(Widget)`
   }
 `
 
-const BalanceTools = styled.div`
+export const BalanceTools = styled.div`
   display: flex;
   width: 100%;
   justify-content: space-between;

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -344,6 +344,7 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
   return (
     <BalancesWidget>
       <FilterTools
+        resultName="tokens"
         searchValue={search}
         handleSearch={handleSearch}
         showFilter={(!!search || hideZeroBalances) && displayedBalances?.length > 0}

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -346,7 +346,7 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
       <FilterTools
         searchValue={search}
         handleSearch={handleSearch}
-        showFilter={hideZeroBalances && displayedBalances?.length > 0}
+        showFilter={(!!search || hideZeroBalances) && displayedBalances?.length > 0}
         dataLength={displayedBalances.length}
       >
         <label className="balances-hideZero">

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -17,6 +17,7 @@ import { LocalTokensState } from 'reducers-actions/localTokens'
 import { CardTable } from 'components/Layout/Card'
 import ErrorMsg from 'components/ErrorMsg'
 import Widget from 'components/Layout/Widget'
+import FormMessage from 'components/TradeWidget/FormMessage'
 
 // DepositWidget: subcomponents
 import { Row } from 'components/DepositWidget/Row'
@@ -251,6 +252,18 @@ export const BalanceTools = styled.div`
       margin: 0 0 2.4rem;
     }
 
+    > ${FormMessage} {
+      color: initial;
+      font-size: x-small;
+      margin: 0;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: max-content;
+      padding: 0.1rem 1.6rem 0.1rem 0.5rem;
+      border-radius: 0 1.6rem 0rem 0rem;
+    }
+
     > input {
       margin: 0;
       width: 35rem;
@@ -422,6 +435,9 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
             value={search}
             onChange={handleSearch}
           />
+          {hideZeroBalances && displayedBalances?.length > 0 && (
+            <FormMessage className="warning">Filter: Showing {displayedBalances?.length} tokens</FormMessage>
+          )}
         </label>
         <label className="balances-hideZero">
           <input type="checkbox" checked={hideZeroBalances} onChange={handleHideZeroBalances} />

--- a/src/components/FilterTools.tsx
+++ b/src/components/FilterTools.tsx
@@ -1,0 +1,134 @@
+import React from 'react'
+import styled from 'styled-components'
+// Components
+import FormMessage from './TradeWidget/FormMessage'
+// Assets
+import searchIcon from 'assets/img/search.svg'
+// Misc
+import { MEDIA } from 'const'
+
+export const BalanceTools = styled.div<{ $css?: string | false }>`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  align-items: center;
+  order: 0;
+
+  ${FormMessage} {
+    color: var(--color-text-primary);
+    background: var(--color-background-validation-warning);
+    font-size: x-small;
+    margin: 0;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: max-content;
+    padding: 0.1rem 1.6rem 0.1rem 0.5rem;
+    border-radius: 0 1.6rem 0rem 0rem;
+  }
+
+  // label + search input
+  > .balances-searchTokens {
+    display: flex;
+    width: auto;
+    max-width: 100%;
+    position: relative;
+    height: 5.6rem;
+    margin: 1.6rem;
+
+    > input {
+      margin: 0;
+      width: 35rem;
+      max-width: 100%;
+      background: var(--color-background-input) url(${searchIcon}) no-repeat left 1.6rem center/1.6rem;
+      border-radius: 0.6rem 0.6rem 0 0;
+      border: 0;
+      font-size: 1.4rem;
+      line-height: 1;
+      box-sizing: border-box;
+      border-bottom: 0.2rem solid transparent;
+      font-weight: var(--font-weight-normal);
+      padding: 0 1.6rem 0 4.8rem;
+      outline: 0;
+
+      @media ${MEDIA.mobile} {
+        font-size: 1.3rem;
+        width: 100%;
+      }
+
+      &::placeholder {
+        font-size: inherit;
+        color: inherit;
+      }
+
+      &:focus {
+        color: var(--color-text-active);
+      }
+
+      &:focus {
+        border-bottom: 0.2rem solid var(--color-text-active);
+        border-color: var(--color-text-active);
+
+        transition: all 0.2s ease-in-out;
+      }
+
+      &.error {
+        border-color: var(--color-error);
+      }
+
+      &.warning {
+        border-color: orange;
+      }
+
+      &:disabled {
+        box-shadow: none;
+      }
+    }
+    @media ${MEDIA.mobile} {
+      width: 100%;
+      height: 4.6rem;
+      margin: 0 0 2.4rem;
+
+      > ${FormMessage} {
+        bottom: -1.2rem;
+        border-radius: 0 0 1.6rem 0rem;
+      }
+    }
+  }
+  ${({ $css = '' }): string | false => $css}
+`
+
+interface Props {
+  customStyles?: string | false
+  dataLength: number
+  searchValue: string
+  showFilter: boolean
+  handleSearch: (e: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+const FilterTools: React.FC<Props> = ({
+  children,
+  customStyles,
+  dataLength,
+  searchValue,
+  showFilter,
+  handleSearch,
+}) => (
+  <BalanceTools $css={customStyles}>
+    <label className="balances-searchTokens">
+      <input
+        placeholder="Search token by Name, Symbol or Address"
+        type="text"
+        value={searchValue}
+        onChange={handleSearch}
+      />
+      {showFilter && <FormMessage id="filterLabel">Filter: Showing {dataLength} tokens</FormMessage>}
+    </label>
+    <>{children}</>
+  </BalanceTools>
+)
+
+export default FilterTools

--- a/src/components/FilterTools.tsx
+++ b/src/components/FilterTools.tsx
@@ -104,6 +104,7 @@ export const BalanceTools = styled.div<{ $css?: string | false }>`
 interface Props {
   customStyles?: string | false
   dataLength: number
+  resultName?: string
   searchValue: string
   showFilter: boolean
   handleSearch: (e: React.ChangeEvent<HTMLInputElement>) => void
@@ -113,6 +114,7 @@ const FilterTools: React.FC<Props> = ({
   children,
   customStyles,
   dataLength,
+  resultName = 'results',
   searchValue,
   showFilter,
   handleSearch,
@@ -125,7 +127,11 @@ const FilterTools: React.FC<Props> = ({
         value={searchValue}
         onChange={handleSearch}
       />
-      {showFilter && <FormMessage id="filterLabel">Filter: Showing {dataLength} tokens</FormMessage>}
+      {showFilter && (
+        <FormMessage id="filterLabel">
+          Filter: Showing {dataLength} {dataLength === 1 ? 'result' : resultName}
+        </FormMessage>
+      )}
     </label>
     <>{children}</>
   </BalanceTools>

--- a/src/components/FilterTools.tsx
+++ b/src/components/FilterTools.tsx
@@ -103,6 +103,7 @@ export const BalanceTools = styled.div<{ $css?: string | false }>`
 
 interface Props {
   customStyles?: string | false
+  className?: string
   dataLength: number
   resultName?: string
   searchValue: string
@@ -112,6 +113,7 @@ interface Props {
 
 const FilterTools: React.FC<Props> = ({
   children,
+  className,
   customStyles,
   dataLength,
   resultName = 'results',
@@ -119,7 +121,7 @@ const FilterTools: React.FC<Props> = ({
   showFilter,
   handleSearch,
 }) => (
-  <BalanceTools $css={customStyles}>
+  <BalanceTools className={className} $css={customStyles}>
     <label className="balances-searchTokens">
       <input
         placeholder="Search token by Name, Symbol or Address"

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -4,7 +4,6 @@ import { toast } from 'toastify'
 // types, utils and services
 import { TokenDetails } from 'types'
 import { isOrderUnlimited, isNeverExpiresOrder, calculatePrice, formatPrice, invertPrice } from '@gnosis.pm/dex-js'
-import { getTokenFromExchangeById } from 'services'
 
 // assets
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -27,8 +26,8 @@ import {
   dateToBatchId,
   getTimeRemainingInBatch,
 } from 'utils'
-import { onErrorFactory } from 'utils/onError'
-import { AuctionElement } from 'api/exchange/ExchangeApi'
+
+import { DetailedAuctionElement } from 'api/exchange/ExchangeApi'
 
 import { OrderRowWrapper } from 'components/OrdersWidget/OrderRow.styled'
 import { displayTokenSymbolOrLink } from 'utils/display'
@@ -247,24 +246,19 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
   )
 }
 
-async function fetchToken(
-  tokenId: number,
+function fetchToken(
   orderId: string,
-  networkId: number,
+  token: TokenDetails | null,
   setFn: React.Dispatch<React.SetStateAction<TokenDetails | null>>,
   isPendingOrder?: boolean,
-): Promise<void> {
-  const token = await getTokenFromExchangeById({ tokenId, networkId })
-
+): void {
   // It is unlikely the token ID coming form the order won't exist
   // Still, if that ever happens, store null and keep this order hidden
   setFn(token)
 
   // Also, inform the user this token failed and the order is hidden.
   if (!token && !isPendingOrder) {
-    toast.warn(
-      `Token id ${tokenId} used on orderId ${orderId} is not a valid ERC20 token. Order will not be displayed.`,
-    )
+    toast.warn(`Token used on orderId ${orderId} is not a valid ERC20 token. Order will not be displayed.`)
   }
 }
 
@@ -282,7 +276,7 @@ const ResponsiveRowSizeToggler: React.FC<ResponsiveRowSizeTogglerProps> = ({ han
 }
 
 interface Props {
-  order: AuctionElement
+  order: DetailedAuctionElement
   isOverBalance: boolean
   networkId: number
   pending?: boolean
@@ -292,8 +286,6 @@ interface Props {
   disabled: boolean
   isPendingOrder?: boolean
 }
-
-const onError = onErrorFactory('Failed to fetch token')
 
 const OrderRow: React.FC<Props> = props => {
   const {
@@ -314,8 +306,8 @@ const OrderRow: React.FC<Props> = props => {
   const [openCard, setOpenCard] = useSafeState(true)
 
   useEffect(() => {
-    fetchToken(order.buyTokenId, order.id, networkId, setBuyToken, isPendingOrder).catch(onError)
-    fetchToken(order.sellTokenId, order.id, networkId, setSellToken, isPendingOrder).catch(onError)
+    fetchToken(order.id, order.buyToken as TokenDetails, setBuyToken, isPendingOrder)
+    fetchToken(order.id, order.sellToken as TokenDetails, setSellToken, isPendingOrder)
   }, [isPendingOrder, networkId, order, setBuyToken, setSellToken])
 
   const isUnlimited = isOrderUnlimited(order.priceDenominator, order.priceNumerator)

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -315,7 +315,7 @@ const OrderRow: React.FC<Props> = props => {
   return (
     sellToken &&
     buyToken && (
-      <OrderRowWrapper className={pending ? 'pending' : ''} $open={openCard}>
+      <OrderRowWrapper data-order-id={order.id} className={pending ? 'pending' : ''} $open={openCard}>
         <DeleteOrder
           isMarkedForDeletion={isMarkedForDeletion}
           toggleMarkedForDeletion={toggleMarkedForDeletion}

--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -86,6 +86,22 @@ export const OrdersForm = styled.div`
     }
   }
 
+  .widgetFilterTools {
+    #filterLabel {
+      bottom: -1.2rem;
+    }
+
+    .balances-searchTokens {
+      height: 3.6rem;
+      margin: 0.8rem;
+      width: 100%;
+
+      > input {
+        width: 100%;
+      }
+    }
+  }
+
   .infoContainer {
     margin: 0 auto;
     display: flex;

--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -89,6 +89,7 @@ export const OrdersForm = styled.div`
   .widgetFilterTools {
     #filterLabel {
       bottom: -1.2rem;
+      border-radius: 0 0 1.6rem 0rem;
     }
 
     .balances-searchTokens {

--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import { MEDIA } from 'const'
+import FormMessage from 'components/TradeWidget/FormMessage'
 
 export const OrdersWrapper = styled.div`
   width: 100%;
@@ -75,8 +76,22 @@ export const OrdersForm = styled.div`
     }
   }
 
+  && {
+    ${FormMessage} {
+      color: initial;
+      font-size: x-small;
+      margin: 0;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: max-content;
+      padding: 0.1rem 1.6rem 0.1rem 0.5rem;
+      border-radius: 0 1.6rem 0rem 0rem;
+    }
+  }
+
   .infoContainer {
-    margin: 1rem auto 0;
+    margin: 0 auto;
     display: flex;
     flex-flow: row nowrap;
     width: 100%;

--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -76,20 +76,6 @@ export const OrdersForm = styled.div`
     }
   }
 
-  && {
-    ${FormMessage} {
-      color: initial;
-      font-size: x-small;
-      margin: 0;
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      width: max-content;
-      padding: 0.1rem 1.6rem 0.1rem 0.5rem;
-      border-radius: 0 1.6rem 0rem 0rem;
-    }
-  }
-
   .infoContainer {
     margin: 0 auto;
     display: flex;

--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -1,6 +1,5 @@
 import styled from 'styled-components'
 import { MEDIA } from 'const'
-import FormMessage from 'components/TradeWidget/FormMessage'
 
 export const OrdersWrapper = styled.div`
   width: 100%;
@@ -25,6 +24,17 @@ export const OrdersWrapper = styled.div`
     min-width: initial;
     min-height: 25rem;
     width: 100%;
+  }
+
+  > h5 {
+    width: 100%;
+    margin: 0 auto;
+    padding: 1.6rem 0 1rem;
+    font-weight: var(--font-weight-bold);
+    font-size: 1.6rem;
+    color: var(--color-text-primary);
+    letter-spacing: 0.03rem;
+    text-align: center;
   }
 
   > div {

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -257,6 +257,10 @@ const OrdersWidget: React.FC = () => {
                   // onChange={handleSearch}
                 />
               </label>
+              <label className="balances-hideZero">
+                <input type="checkbox" /* checked={hideZeroBalances} onChange={handleHideZeroBalances} */ />
+                <b>Hide untouched orders</b>
+              </label>
             </BalanceTools>
             <div className="infoContainer">
               <div className="countContainer">

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -97,8 +97,8 @@ function checkTokenAgainstSearch(token: TokenDetails | null, searchText: string)
   )
 }
 
-const filterOrdersFn = (searchTxt: string) => ({ id, buyToken, sellToken }: DetailedAuctionElement): boolean => {
-  if (searchTxt === '') return true
+const filterOrdersFn = (searchTxt: string) => ({ id, buyToken, sellToken }: DetailedAuctionElement): boolean | null => {
+  if (searchTxt === '') return null
 
   return (
     !!id.includes(searchTxt) ||

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -285,6 +285,7 @@ const OrdersWidget: React.FC<Props> = ({ isWidget = false }) => {
         <OrdersForm>
           <form action="submit" onSubmit={onSubmit}>
             <FilterTools
+              resultName="orders"
               customStyles={
                 isWidget &&
                 `

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -32,6 +32,9 @@ import { useDeleteOrders } from 'components/OrdersWidget/useDeleteOrders'
 import OrderRow from 'components/OrdersWidget/OrderRow'
 import { OrdersWrapper, ButtonWithIcon, OrdersForm } from 'components/OrdersWidget/OrdersWidget.styled'
 
+// Types/misc
+import { TokenDetails } from 'types'
+
 type OrderTabs = 'active' | 'liquidity' | 'closed'
 
 interface ShowOrdersButtonProps {
@@ -83,6 +86,25 @@ function classifyOrders(
       state.active[ordersType].push(order)
     }
   })
+}
+
+function checkTokenAgainstSearch(token: TokenDetails | null, searchText: string): boolean {
+  if (!token) return false
+  return (
+    token?.symbol?.toLowerCase().includes(searchText) ||
+    token?.name?.toLowerCase().includes(searchText) ||
+    token?.address.toLowerCase().includes(searchText)
+  )
+}
+
+const filterOrdersFn = (searchTxt: string) => ({ id, buyToken, sellToken }: DetailedAuctionElement): boolean => {
+  if (searchTxt === '') return true
+
+  return (
+    !!id.includes(searchTxt) ||
+    checkTokenAgainstSearch(buyToken as TokenDetails, searchTxt) ||
+    checkTokenAgainstSearch(sellToken as TokenDetails, searchTxt)
+  )
 }
 
 const compareFnFactory = (topic: TopicNames, asc: boolean) => (
@@ -237,22 +259,6 @@ const OrdersWidget: React.FC<Props> = ({ isWidget = false }) => {
       }
     },
     [deleteOrders, forceOrdersRefresh, markedForDeletion, selectedTab, setClassifiedOrders],
-  )
-
-  const filterOrdersFn = useCallback(
-    (searchTxt: string) => ({ buyToken, sellToken }: DetailedAuctionElement): boolean => {
-      if (searchTxt === '') return true
-
-      return Boolean(
-        buyToken?.symbol?.toLowerCase().includes(searchTxt) ||
-          buyToken?.name?.toLowerCase().includes(searchTxt) ||
-          buyToken?.address.toLowerCase().includes(searchTxt) ||
-          sellToken?.symbol?.toLowerCase().includes(searchTxt) ||
-          sellToken?.name?.toLowerCase().includes(searchTxt) ||
-          sellToken?.address.toLowerCase().includes(searchTxt),
-      )
-    },
-    [],
   )
 
   const { filteredData: filteredAndSortedOrders, search, handleSearch } = useDataFilter({

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -261,7 +261,11 @@ const OrdersWidget: React.FC<Props> = ({ isWidget = false }) => {
     [deleteOrders, forceOrdersRefresh, markedForDeletion, selectedTab, setClassifiedOrders],
   )
 
-  const { filteredData: filteredAndSortedOrders, search, handleSearch } = useDataFilter({
+  const {
+    filteredData: filteredAndSortedOrders,
+    search,
+    handlers: { handleSearch },
+  } = useDataFilter({
     data: sortedDisplayedOrders,
     filterFnFactory: filterOrdersFn,
   })

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -17,21 +17,20 @@ import useSafeState from 'hooks/useSafeState'
 import usePendingOrders, { DetailedPendingOrder } from 'hooks/usePendingOrders'
 import { useWalletConnection } from 'hooks/useWalletConnection'
 import useSortByTopic from 'hooks/useSortByTopic'
+import useDataFilter from 'hooks/useDataFilter'
 
 // Api
 import { DetailedAuctionElement } from 'api/exchange/ExchangeApi'
 
 // Components
-import FormMessage from 'components/TradeWidget/FormMessage'
 import { ConnectWalletBanner } from 'components/ConnectWalletBanner'
 import { CardTable } from 'components/Layout/Card'
+import FilterTools from 'components/FilterTools'
 
 // OrderWidget
 import { useDeleteOrders } from 'components/OrdersWidget/useDeleteOrders'
 import OrderRow from 'components/OrdersWidget/OrderRow'
 import { OrdersWrapper, ButtonWithIcon, OrdersForm } from 'components/OrdersWidget/OrdersWidget.styled'
-import { BalanceTools } from 'components/DepositWidget'
-import useDataFilter from 'hooks/useDataFilter'
 
 type OrderTabs = 'active' | 'liquidity' | 'closed'
 
@@ -97,7 +96,11 @@ const compareFnFactory = (topic: TopicNames, asc: boolean) => (
   }
 }
 
-const OrdersWidget: React.FC = () => {
+interface Props {
+  isWidget?: boolean
+}
+
+const OrdersWidget: React.FC<Props> = ({ isWidget = false }) => {
   const { orders: allOrders, forceOrdersRefresh } = useOrders()
   const allPendingOrders = usePendingOrders()
   // this page is behind login wall so networkId should always be set
@@ -300,25 +303,35 @@ const OrdersWidget: React.FC = () => {
       {!noOrders && networkId && (
         <OrdersForm>
           <form action="submit" onSubmit={onSubmit}>
-            <BalanceTools>
-              <label className="balances-searchTokens">
-                <input
-                  placeholder="Search token by Name, Symbol or Address"
-                  type="text"
-                  value={search}
-                  onChange={handleSearch}
-                />
-                {search && (
-                  <FormMessage className="warning">
-                    Filter: Showing {displayedPendingOrders.length + filteredAndSortedOrders.length} orders
-                  </FormMessage>
-                )}
-              </label>
-              <label className="balances-hideZero">
+            <FilterTools
+              customStyles={
+                isWidget &&
+                `
+                #filterLabel {
+                  bottom: -1.2rem;
+                }
+
+                .balances-searchTokens { 
+                    height: 3.6rem; 
+                    margin: 0.8rem; 
+                    width: 100%; 
+                    
+                    > input { 
+                      width: 100%; 
+                    } 
+                }`
+              }
+              searchValue={search}
+              handleSearch={handleSearch}
+              showFilter={!!search}
+              dataLength={displayedPendingOrders.length + filteredAndSortedOrders.length}
+            >
+              {/* implement later when better data concerning order state and can be saved to global state */}
+              <label className="not-implemented balances-hideZero">
                 <input type="checkbox" checked={hideUntouchedOrders} onChange={handleHideUntouchedOrders} />
                 <b>Hide untouched orders</b>
               </label>
-            </BalanceTools>
+            </FilterTools>
             <div className="infoContainer">
               <div className="countContainer">
                 <ShowOrdersButton

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -102,8 +102,8 @@ const filterOrdersFn = (searchTxt: string) => ({ id, buyToken, sellToken }: Deta
 
   return (
     !!id.includes(searchTxt) ||
-    checkTokenAgainstSearch(buyToken as TokenDetails, searchTxt) ||
-    checkTokenAgainstSearch(sellToken as TokenDetails, searchTxt)
+    checkTokenAgainstSearch(buyToken, searchTxt) ||
+    checkTokenAgainstSearch(sellToken, searchTxt)
   )
 }
 

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -239,21 +239,8 @@ const OrdersWidget: React.FC<Props> = ({ isWidget = false }) => {
     [deleteOrders, forceOrdersRefresh, markedForDeletion, selectedTab, setClassifiedOrders],
   )
 
-  const customFilterFnFactory = useCallback(
-    (customStopCheck?: (...any: unknown[]) => boolean) => (searchTxt: string) => ({
-      buyToken,
-      sellToken,
-    }: DetailedAuctionElement): boolean => {
-      if (
-        customStopCheck &&
-        customStopCheck({
-          buyToken,
-          sellToken,
-        })
-      ) {
-        return false
-      }
-
+  const filterOrdersFn = useCallback(
+    (searchTxt: string) => ({ buyToken, sellToken }: DetailedAuctionElement): boolean => {
       if (searchTxt === '') return true
 
       return Boolean(
@@ -268,25 +255,9 @@ const OrdersWidget: React.FC<Props> = ({ isWidget = false }) => {
     [],
   )
 
-  const customHideZeroFilterFn = useCallback(params => {
-    console.debug(params)
-    return true
-  }, [])
-
-  const { filteredData, search, handleSearch } = useDataFilter({
+  const { filteredData: filteredAndSortedOrders, search, handleSearch } = useDataFilter({
     data: sortedDisplayedOrders,
-    filterFnFactory: customFilterFnFactory(),
-  })
-
-  const {
-    filteredData: filteredAndSortedOrders,
-    showFilter: hideUntouchedOrders,
-    handleToggleFilter: handleHideUntouchedOrders,
-    // clearFilters,
-  } = useDataFilter({
-    data: filteredData,
-    filterFnFactory: () => customHideZeroFilterFn,
-    isSearchFilter: false,
+    filterFnFactory: filterOrdersFn,
   })
 
   return (
@@ -326,11 +297,12 @@ const OrdersWidget: React.FC<Props> = ({ isWidget = false }) => {
               showFilter={!!search}
               dataLength={displayedPendingOrders.length + filteredAndSortedOrders.length}
             >
-              {/* implement later when better data concerning order state and can be saved to global state */}
-              <label className="not-implemented balances-hideZero">
+              {/* implement later when better data concerning order state and can be saved to global state 
+              <label className="balances-hideZero">
                 <input type="checkbox" checked={hideUntouchedOrders} onChange={handleHideUntouchedOrders} />
                 <b>Hide untouched orders</b>
               </label>
+              */}
             </FilterTools>
             <div className="infoContainer">
               <div className="countContainer">

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -285,24 +285,8 @@ const OrdersWidget: React.FC<Props> = ({ isWidget = false }) => {
         <OrdersForm>
           <form action="submit" onSubmit={onSubmit}>
             <FilterTools
+              className={isWidget ? 'widgetFilterTools' : ''}
               resultName="orders"
-              customStyles={
-                isWidget &&
-                `
-                #filterLabel {
-                  bottom: -1.2rem;
-                }
-
-                .balances-searchTokens { 
-                    height: 3.6rem; 
-                    margin: 0.8rem; 
-                    width: 100%; 
-                    
-                    > input { 
-                      width: 100%; 
-                    } 
-                }`
-              }
               searchValue={search}
               handleSearch={handleSearch}
               showFilter={!!search}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -1013,7 +1013,7 @@ const TradeWidget: React.FC = () => {
         {/* Actual orders content */}
         <div>
           <h5>Your orders</h5>
-          <OrdersWidget />
+          <OrdersWidget isWidget />
         </div>
       </OrdersPanel>
       {/* React Forms DevTool debugger */}

--- a/src/hooks/useDataFilter.tsx
+++ b/src/hooks/useDataFilter.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
 import { useDebounce } from './useDebounce'
 
+type FilterFnFactory<T> = (searchTxt: string) => (params: T, index: number, array: T[]) => boolean | null
+
 interface InternalState<T> {
   debouncedSearch?: string
   showFilter?: boolean
@@ -23,7 +25,7 @@ export interface HookParams<T> {
   searchDebounceTime?: number
   isSearchFilter?: boolean
   userConditionalCheck?: (internalState?: InternalState<T>) => boolean
-  filterFnFactory: (searchTxt: string) => (params: T, index: number, array: T[]) => boolean
+  filterFnFactory: FilterFnFactory<T>
 }
 
 function useDataFilter<T>({
@@ -63,6 +65,9 @@ function useDataFilter<T>({
 
     const searchTxt = debouncedSearch.trim().toLowerCase()
     const customFilterFn = filterFnFactory(searchTxt)
+
+    // check null return from customFilterFn to opt out
+    if (!customFilterFn) return data
 
     return data.filter(customFilterFn)
   }, [debouncedSearch, data, isSearchFilter, showFilter, userConditionalCheck, filterFnFactory])

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -60,11 +60,18 @@ export function useOrders(): Result {
           offset,
         })
 
-        const ordersPromises = ordersPreTokenDetails.map(async order => ({
-          ...order,
-          sellToken: await getTokenFromExchangeById({ tokenId: order.sellTokenId, networkId }),
-          buyToken: await getTokenFromExchangeById({ tokenId: order.buyTokenId, networkId }),
-        }))
+        const ordersPromises = ordersPreTokenDetails.map(async order => {
+          const [sellToken, buyToken] = await Promise.all([
+            getTokenFromExchangeById({ tokenId: order.sellTokenId, networkId }),
+            getTokenFromExchangeById({ tokenId: order.buyTokenId, networkId }),
+          ])
+          return {
+            ...order,
+            sellToken,
+            buyToken,
+          }
+        })
+
         // check cancelled bool from parent scope
         if (cancelled) return
 

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -8,11 +8,12 @@ import { overwriteOrders, updateOffset, updateOrders } from 'reducers-actions/or
 import { useWalletConnection } from './useWalletConnection'
 import useSafeState from './useSafeState'
 import { exchangeApi } from 'api'
-import { AuctionElement } from 'api/exchange/ExchangeApi'
+import { DetailedAuctionElement } from 'api/exchange/ExchangeApi'
 import { useCheckWhenTimeRemainingInBatch } from './useTimeRemainingInBatch'
+import { getTokenFromExchangeById } from 'services'
 
 interface Result {
-  orders: AuctionElement[]
+  orders: DetailedAuctionElement[]
   forceOrdersRefresh: () => void
   isLoading: boolean
 }
@@ -53,11 +54,21 @@ export function useOrders(): Result {
 
       // contract call
       try {
-        const { orders, nextIndex } = await exchangeApi.getOrdersPaginated({ userAddress, networkId, offset })
+        const { orders: ordersPreTokenDetails, nextIndex } = await exchangeApi.getOrdersPaginated({
+          userAddress,
+          networkId,
+          offset,
+        })
 
+        const ordersPromises = ordersPreTokenDetails.map(async order => ({
+          ...order,
+          sellToken: await getTokenFromExchangeById({ tokenId: order.sellTokenId, networkId }),
+          buyToken: await getTokenFromExchangeById({ tokenId: order.buyTokenId, networkId }),
+        }))
         // check cancelled bool from parent scope
         if (cancelled) return
 
+        const orders: DetailedAuctionElement[] = await Promise.all(ordersPromises)
         // ensures we don't have multiple reruns for each update
         // i.e. offset change -> render
         //      isLoading change -> another render

--- a/src/hooks/usePendingOrders.ts
+++ b/src/hooks/usePendingOrders.ts
@@ -3,18 +3,34 @@ import { useEffect } from 'react'
 import useGlobalState from './useGlobalState'
 import useSafeState from './useSafeState'
 import { useWalletConnection } from './useWalletConnection'
-import { PendingTxObj } from 'api/exchange/ExchangeApi'
+import { DetailedAuctionElement } from 'api/exchange/ExchangeApi'
+import { getTokenFromExchangeById } from 'services'
 
-function usePendingOrders(): PendingTxObj[] {
+export interface DetailedPendingOrder extends DetailedAuctionElement {
+  txHash?: string
+}
+
+function usePendingOrders(): DetailedPendingOrder[] {
   const { userAddress, networkId } = useWalletConnection()
 
   const [{ pendingOrders: pendingOrdersGlobal }] = useGlobalState()
-  const [pendingOrders, setPendingOrders] = useSafeState<PendingTxObj[]>([])
+  const [pendingOrders, setPendingOrders] = useSafeState<DetailedPendingOrder[]>([])
 
   useEffect(() => {
-    if (userAddress && networkId) {
-      setPendingOrders(pendingOrdersGlobal[networkId][userAddress] || [])
+    async function getDetailedPendingOrders(): Promise<void> {
+      if (userAddress && networkId) {
+        const pendingOrdersByNetwork = pendingOrdersGlobal[networkId][userAddress] || []
+        const ordersPromises = pendingOrdersByNetwork.map(async order => ({
+          ...order,
+          sellToken: await getTokenFromExchangeById({ tokenId: order.sellTokenId, networkId }),
+          buyToken: await getTokenFromExchangeById({ tokenId: order.buyTokenId, networkId }),
+        }))
+
+        const orders: DetailedPendingOrder[] = await Promise.all(ordersPromises)
+        setPendingOrders(orders)
+      }
     }
+    getDetailedPendingOrders()
   }, [networkId, pendingOrdersGlobal, setPendingOrders, userAddress])
   return pendingOrders
 }

--- a/src/hooks/usePendingOrders.ts
+++ b/src/hooks/usePendingOrders.ts
@@ -20,11 +20,18 @@ function usePendingOrders(): DetailedPendingOrder[] {
     async function getDetailedPendingOrders(): Promise<void> {
       if (userAddress && networkId) {
         const pendingOrdersByNetwork = pendingOrdersGlobal[networkId][userAddress] || []
-        const ordersPromises = pendingOrdersByNetwork.map(async order => ({
-          ...order,
-          sellToken: await getTokenFromExchangeById({ tokenId: order.sellTokenId, networkId }),
-          buyToken: await getTokenFromExchangeById({ tokenId: order.buyTokenId, networkId }),
-        }))
+
+        const ordersPromises = pendingOrdersByNetwork.map(async order => {
+          const [sellToken, buyToken] = await Promise.all([
+            getTokenFromExchangeById({ tokenId: order.sellTokenId, networkId }),
+            getTokenFromExchangeById({ tokenId: order.buyTokenId, networkId }),
+          ])
+          return {
+            ...order,
+            sellToken,
+            buyToken,
+          }
+        })
 
         const orders: DetailedPendingOrder[] = await Promise.all(ordersPromises)
         setPendingOrders(orders)

--- a/src/reducers-actions/orders.ts
+++ b/src/reducers-actions/orders.ts
@@ -1,12 +1,12 @@
 import { Actions } from 'reducers-actions'
-import { AuctionElement } from 'api/exchange/ExchangeApi'
+import { DetailedAuctionElement } from 'api/exchange/ExchangeApi'
 import { addUnlistedTokensToUserTokenListById } from 'services'
 import { isOrderDeleted } from 'utils'
 
 export type ActionTypes = 'OVERWRITE_ORDERS' | 'APPEND_ORDERS' | 'UPDATE_ORDERS' | 'UPDATE_OFFSET'
 
 export interface OrdersState {
-  orders: AuctionElement[]
+  orders: DetailedAuctionElement[]
   offset: number
 }
 
@@ -14,17 +14,17 @@ type UpdateOrdersActionType = Actions<ActionTypes, Pick<OrdersState, 'orders'>>
 type UpdateOffsetActionType = Actions<ActionTypes, Pick<OrdersState, 'offset'>>
 type ReducerActionType = Actions<ActionTypes, OrdersState>
 
-export const overwriteOrders = (orders: AuctionElement[]): UpdateOrdersActionType => ({
+export const overwriteOrders = (orders: DetailedAuctionElement[]): UpdateOrdersActionType => ({
   type: 'OVERWRITE_ORDERS',
   payload: { orders },
 })
 
-export const appendOrders = (orders: AuctionElement[]): UpdateOrdersActionType => ({
+export const appendOrders = (orders: DetailedAuctionElement[]): UpdateOrdersActionType => ({
   type: 'APPEND_ORDERS',
   payload: { orders },
 })
 
-export const updateOrders = (orders: AuctionElement[]): UpdateOrdersActionType => ({
+export const updateOrders = (orders: DetailedAuctionElement[]): UpdateOrdersActionType => ({
   type: 'UPDATE_ORDERS',
   payload: { orders },
 })
@@ -67,7 +67,7 @@ export const reducer = (state: OrdersState, action: ReducerActionType): OrdersSt
 
       // First we process reversedNewOrders, then currentOrders.
       // Thanks to processedOrderIds newOrders override currentOrders with same id
-      const updatedOrders = reversedNewOrders.concat(currentOrders).reduce<AuctionElement[]>((acc, order) => {
+      const updatedOrders = reversedNewOrders.concat(currentOrders).reduce<DetailedAuctionElement[]>((acc, order) => {
         // already included a potentially updated order
         // or the order was deleted
         if (processedOrderIds.has(order.id)) {

--- a/src/services/factories/getTrades.ts
+++ b/src/services/factories/getTrades.ts
@@ -1,6 +1,7 @@
 import Web3 from 'web3'
 
-import { TokenDetails, calculatePrice } from '@gnosis.pm/dex-js'
+import { calculatePrice } from '@gnosis.pm/dex-js'
+import { TokenDetails } from 'types'
 
 import ExchangeApiImpl, { ExchangeApi, Trade, Order, AuctionElement } from 'api/exchange/ExchangeApi'
 


### PR DESCRIPTION
Closes #1032 

Dependent on #1094 

To test: head to `/orders` or `/trade` page and filter tokens by address/symbol/name

`useOrders`:

- Changes hook to call for token details inside `useEffect` and replace `OrderRow`'s previous responsibility on this
- orders returned now adhere to `DetailedAuctionElement` interface which is `AuctionElement` + `TokenDetails` for both `buyToken` and `sellToken`

Filter at work - `/orders`:
![Screenshot from 2020-06-11 11-54-44](https://user-images.githubusercontent.com/21335563/84371728-5fff2b80-abda-11ea-96c2-5427f2926697.png)

`/trade`:
![Screenshot from 2020-06-11 11-55-49](https://user-images.githubusercontent.com/21335563/84371814-845b0800-abda-11ea-9f92-4351525e0058.png)

