### PR TITLE
1029/styling take 3 mobile opt

### DIFF
--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -12,9 +12,8 @@ import { ZERO, MEDIA } from 'const'
 import { TokenBalanceDetails } from 'types'
 
 // Components
-import { CardTable } from 'components/Layout/Card'
+import { CardTable, CardWidgetWrapper } from 'components/Layout/Card'
 import ErrorMsg from 'components/ErrorMsg'
-import Widget from 'components/Layout/Widget'
 
 // DepositWidget: subcomponents
 import { Row } from 'components/DepositWidget/Row'
@@ -29,6 +28,8 @@ import { useDebounce } from 'hooks/useDebounce'
 import { useManageTokens } from 'hooks/useManageTokens'
 import useGlobalState from 'hooks/useGlobalState'
 import { useEthBalances } from 'hooks/useEthBalance'
+
+// Reducer/Actions
 import { TokenLocalState } from 'reducers-actions'
 
 interface WithdrawState {
@@ -36,125 +37,8 @@ interface WithdrawState {
   tokenAddress: string
 }
 
-const BalancesWidget = styled(Widget)`
-  display: flex;
-  flex-flow: column nowrap;
-  width: auto;
-  padding: 0 0 2.4rem;
-  min-width: 85rem;
-  max-width: 140rem;
-  background: var(--color-background-pageWrapper);
-  box-shadow: 0 -1rem 4rem 0 rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.02) 0 0.276726rem 0.221381rem 0,
-    rgba(0, 0, 0, 0.027) 0 0.666501rem 0.532008rem 0, rgba(0, 0, 0, 0.035) 0 1.25216rem 1.0172rem 0,
-    rgba(0, 0, 0, 0.043) 0 2.23363rem 1.7869rem 0, rgba(0, 0, 0, 0.05) 0 4.17776rem 3.34221rem 0,
-    rgba(0, 0, 0, 0.07) 0 10rem 8rem 0;
-  border-radius: 0.6rem;
-  margin: 0 auto;
-  min-height: 54rem;
-  font-size: 1.6rem;
-  line-height: 1;
-  justify-content: flex-start;
-  
-    @media ${MEDIA.tablet} {
-      min-width: 100vw;
-      min-width: calc(100vw - 4.8rem);
-      width: 100%;
-      max-width: 100%;
-    }
-
-    @media ${MEDIA.mobile} {
-      max-width: 100%;
-      min-width: initial;
-      width: 100%;
-
-      > div {
-        flex-flow: row wrap;
-      }
-    }
-    
-  ${CardTable}.balancesOverview {
-    display: flex;
-    flex-flow: column nowrap;
-    width: auto;
-    order: 2;
-  }
-
-  ${CardTable}.balancesOverview > tbody {
-    font-size: 1.3rem;
-    line-height: 1;
-
-    @media ${MEDIA.mobile} {
-      display: flex;
-      flex-flow: column wrap;
-      width: 100%;
-    }
-  }
-
-  ${CardTable}.balancesOverview > thead {
-    background: var(--color-background);
-    border-radius: 0.6rem;
-
-    @media ${MEDIA.mobile} {
-      display: none;
-    }
-  }
-
-  ${CardTable}.balancesOverview > thead > tr:not([class^="Card__CardRowDrawer"]),
-  ${CardTable}.balancesOverview > tbody > tr:not([class^="Card__CardRowDrawer"]) {
-    grid-template-columns: repeat(auto-fit, minmax(5rem, 1fr));
-    text-align: right;
-    padding: 0.8rem;
-    margin: 0;
-    justify-content: flex-start;
-
-    @media ${MEDIA.mobile} {
-      padding: 1.6rem 0.8rem;
-      display: table;
-      flex-flow: column wrap;
-      width: 100%;
-      border-bottom: 0.2rem solid rgba(159, 180, 201, 0.5);
-    }
-  }
-
-  ${CardTable}.balancesOverview > thead > tr:not([class^="Card__CardRowDrawer"]) > th {
-    font-size: 1.1rem;
-    color: var(--color-text-primary);
-    letter-spacing: 0;
-    text-align: right;
-    padding: 0.8rem;
-    text-transform: uppercase;
-
-    &:first-of-type {
-      text-align: left;
-    }
-  }
-
-  ${CardTable}.balancesOverview > tbody > tr:not([class^="Card__CardRowDrawer"]) > td {
-    display: flex;
-    flex-flow: row wrap;
-    align-items: center;
-    padding: 0 0.5rem;
-    text-align: right;
-    justify-content: flex-end;
-    word-break: break-all;
-    white-space: normal;
-
-    @media ${MEDIA.mobile} {
-      width: 100%;
-      border-bottom: 0.1rem solid rgba(0, 0, 0, 0.14);
-      padding: 1rem 0.5rem;
-      flex-flow: row nowrap;
-
-      &:last-of-type {
-        border: 0;
-      }
-    }
-
-    &:first-of-type {
-      text-align: left;
-      justify-content: flex-start;
-    }
-
+const BalancesWidget = styled(CardWidgetWrapper)`
+  ${CardTable} > tbody > tr:not([class^="Card__CardRowDrawer"]) > td {
     &[data-label='Token'] {
       font-family: var(--font-default);
       letter-spacing: 0;
@@ -165,21 +49,6 @@ const BalancesWidget = styled(Widget)`
     &[data-label='Token'] > div > b {
       display: block;
       color: var(--color-text-primary);
-    }
-
-    &::before {
-      @media ${MEDIA.mobile} {
-        content: attr(data-label);
-        margin-right: auto;
-        font-weight: var(--font-weight-bold);
-        text-transform: uppercase;
-        font-size: 1rem;
-        font-family: var(--font-default);
-        letter-spacing: 0;
-        white-space: nowrap;
-        padding: 0 0.5rem 0 0;
-        color: var(--color-text-primary);
-      }
     }
   }
 `
@@ -398,7 +267,7 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
   const { modalProps, toggleModal } = useManageTokens()
 
   return (
-    <BalancesWidget>
+    <BalancesWidget $columns="repeat(auto-fit, minmax(5rem, 1fr));">
       <BalanceTools>
         <label className="balances-searchTokens">
           <input

--- a/src/components/Layout/Card/Card.tsx
+++ b/src/components/Layout/Card/Card.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
+
+import Widget from '../Widget'
 import { MEDIA } from 'const'
 
 const CardRowDrawer = styled.tr`
@@ -247,4 +249,139 @@ export const CardTable = styled.table<{
 
   // Top level custom CSS
   ${({ $webCSS }): string | undefined => $webCSS}
+`
+
+export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
+  display: flex;
+  flex-flow: column nowrap;
+  width: auto;
+  padding: 0 0 2.4rem;
+  min-width: 85rem;
+  max-width: 140rem;
+  background: var(--color-background-pageWrapper);
+  box-shadow: 0 -1rem 4rem 0 rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.02) 0 0.276726rem 0.221381rem 0,
+    rgba(0, 0, 0, 0.027) 0 0.666501rem 0.532008rem 0, rgba(0, 0, 0, 0.035) 0 1.25216rem 1.0172rem 0,
+    rgba(0, 0, 0, 0.043) 0 2.23363rem 1.7869rem 0, rgba(0, 0, 0, 0.05) 0 4.17776rem 3.34221rem 0,
+    rgba(0, 0, 0, 0.07) 0 10rem 8rem 0;
+  border-radius: 0.6rem;
+  margin: 0 auto;
+  min-height: 54rem;
+  font-size: 1.6rem;
+  line-height: 1;
+  justify-content: flex-start;
+
+    @media ${MEDIA.tablet} {
+      min-width: 100vw;
+      min-width: calc(100vw - 4.8rem);
+      width: 100%;
+      max-width: 100%;
+    }
+
+    @media ${MEDIA.mobile} {
+      max-width: 100%;
+      min-width: initial;
+      width: 100%;
+
+      > div {
+        flex-flow: row wrap;
+      }
+    }
+    
+  ${CardTable} {
+    display: flex;
+    flex-flow: column nowrap;
+    width: auto;
+    order: 2;
+  }
+
+  ${CardTable} > tbody {
+    font-size: 1.3rem;
+    line-height: 1;
+
+    @media ${MEDIA.mobile} {
+      display: flex;
+      flex-flow: column wrap;
+      width: 100%;
+    }
+  }
+
+  ${CardTable} > thead {
+    background: var(--color-background);
+    border-radius: 0.6rem;
+
+    @media ${MEDIA.mobile} {
+      display: none;
+    }
+  }
+
+  ${CardTable} > thead > tr:not([class^="Card__CardRowDrawer"]),
+  ${CardTable} > tbody > tr:not([class^="Card__CardRowDrawer"]) {
+    ${({ $columns }): string => ($columns ? `grid-template-columns: ${$columns}` : '')};
+    text-align: right;
+    padding: 0.8rem;
+    margin: 0;
+    justify-content: flex-start;
+
+    @media ${MEDIA.mobile} {
+      padding: 1.6rem 0.8rem;
+      display: table;
+      flex-flow: column wrap;
+      width: 100%;
+      border-bottom: 0.2rem solid rgba(159, 180, 201, 0.5);
+    }
+  }
+
+  ${CardTable} > thead > tr:not([class^="Card__CardRowDrawer"]) > th {
+    font-size: 1.1rem;
+    color: var(--color-text-primary);
+    letter-spacing: 0;
+    text-align: right;
+    padding: 0.8rem;
+    text-transform: uppercase;
+
+    &:first-of-type {
+      text-align: left;
+    }
+  }
+
+  ${CardTable} > tbody > tr:not([class^="Card__CardRowDrawer"]) > td {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: center;
+    padding: 0 0.5rem;
+    text-align: right;
+    justify-content: flex-end;
+    word-break: break-all;
+    white-space: normal;
+
+    @media ${MEDIA.mobile} {
+      width: 100%;
+      border-bottom: 0.1rem solid rgba(0, 0, 0, 0.14);
+      padding: 1rem 0.5rem;
+      flex-flow: row nowrap;
+
+      &:last-of-type {
+        border: 0;
+      }
+    }
+
+    &:first-of-type {
+      text-align: left;
+      justify-content: flex-start;
+    }
+    &::before {
+      @media ${MEDIA.mobile} {
+        content: attr(data-label);
+        margin-right: auto;
+        font-weight: var(--font-weight-bold);
+        text-transform: uppercase;
+        font-size: 1rem;
+        font-family: var(--font-default);
+        letter-spacing: 0;
+        white-space: nowrap;
+        padding: 0 0.5rem 0 0;
+        color: var(--color-text-primary);
+      }
+    }
+  }
 `

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -128,7 +128,7 @@ export const TradeRow: React.FC<TradeRowProps> = params => {
       <td data-label="Date" title={new Date(timestamp).toLocaleString()}>
         {formatDateFromBatchId(batchId, { strict: true })}
       </td>
-      <td>
+      <td data-label="Trade">
         {displayTokenSymbolOrLink(buyToken)}/{displayTokenSymbolOrLink(sellToken)}
       </td>
       <td data-label="Limit Price" title={limitPrice && formatPrice({ price: limitPrice, decimals: 8 })}>
@@ -146,7 +146,7 @@ export const TradeRow: React.FC<TradeRowProps> = params => {
       <td data-label="Type" title={typeColumnTitle}>
         <TypePill tradeType={tradeType}>{tradeType}</TypePill>
       </td>
-      <td>
+      <td data-label="View on Etherscan">
         <EtherscanLink type={'event'} identifier={txHash} networkId={networkId} />
       </td>
     </tr>

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -6,8 +6,7 @@ import styled from 'styled-components'
 
 import { formatPrice, TokenDetails, formatAmount } from '@gnosis.pm/dex-js'
 
-import { ContentPage } from 'components/Layout/PageWrapper'
-import { CardTable } from 'components/Layout/Card'
+import { CardTable, CardWidgetWrapper } from 'components/Layout/Card'
 import { ConnectWalletBanner } from 'components/ConnectWalletBanner'
 import { FileDownloaderLink } from 'components/FileDownloaderLink'
 
@@ -105,13 +104,8 @@ const Trades: React.FC = () => {
   return !isConnected ? (
     <ConnectWalletBanner />
   ) : (
-    <ContentPage>
-      <CardTable
-        $columns="1.2fr 1fr repeat(2, 0.7fr) repeat(2, 1.2fr) 0.9fr 1fr"
-        $rowSeparation="0"
-        $gap="0 0.6rem"
-        $padding="0.5em 0"
-      >
+    <CardWidgetWrapper $columns="1.2fr 1fr repeat(2, 0.7fr) repeat(2, 1.2fr) 0.9fr 1fr">
+      <CardTable $rowSeparation="0" $gap="0 0.6rem" $padding="0.5em 0">
         <thead>
           <tr>
             <th>Date</th>
@@ -146,7 +140,7 @@ const Trades: React.FC = () => {
           ))}
         </tbody>
       </CardTable>
-    </ContentPage>
+    </CardWidgetWrapper>
   )
 }
 

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -104,7 +104,7 @@ const Trades: React.FC = () => {
   return !isConnected ? (
     <ConnectWalletBanner />
   ) : (
-    <CardWidgetWrapper $columns="1.2fr 1fr repeat(2, 0.7fr) repeat(2, 1.2fr) 0.9fr 1fr">
+    <CardWidgetWrapper $columns="1.2fr 1fr repeat(2, 0.7fr) repeat(2, 1.2fr) 0.9fr 1.23fr">
       <CardTable $rowSeparation="0" $gap="0 0.6rem" $padding="0.5em 0">
         <thead>
           <tr>


### PR DESCRIPTION
Depends and would merge into #1029 

Re-factor `CardTable` wrapper used in `BalanceWidget` to be agnostic-er and re-usable in DepositWidget and now TradesWidget (trades, not trade)

Allows card-in-mobile view akin to `DepositWidget` style
![Screenshot from 2020-06-11 12-53-21](https://user-images.githubusercontent.com/21335563/84377230-9476e580-abe2-11ea-8672-157f25e87e5e.png)

@alfetopito 