### PR TITLE
`Filled` status takes precedence over `Expired`

### DIFF
--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -211,10 +211,10 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
     <td className="status">
       {pending ? (
         pending
-      ) : isExpiredOrder ? (
-        'Expired'
       ) : isFilled ? (
         'Filled'
+      ) : isExpiredOrder ? (
+        'Expired'
       ) : isActiveNextBatch ? (
         <>
           {`Active in next batch: `} <StatusCountdown />


### PR DESCRIPTION
Closes #1093

![screenshot_2020-06-12_15-37-05](https://user-images.githubusercontent.com/43217/84551432-800a1a00-acc2-11ea-817d-68e0dc363587.png)
