### PR TITLE
1029.2/david style take

### DIFF
--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -105,6 +105,10 @@ export interface ExchangeApi extends DepositApi {
   cancelOrders(params: CancelOrdersParams): Promise<Receipt>
 }
 
+export interface DetailedPendingOrder extends DetailedAuctionElement {
+  txHash?: string
+}
+
 export interface DetailedAuctionElement extends AuctionElement {
   buyToken: TokenDetails | null
   sellToken: TokenDetails | null

--- a/src/components/DepositWidget/Styled.tsx
+++ b/src/components/DepositWidget/Styled.tsx
@@ -40,7 +40,7 @@ export const TokenRow = styled.tr`
     border-radius: 2.4rem;
     height: 2.4rem;
     width: 2.4rem;
-    margin: 0 0 0 1rem;
+    margin-left: 0.5rem;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -57,9 +57,13 @@ const BalancesWidget = styled(CardWidgetWrapper)`
         flex-flow: row nowrap;
       }
 
-      &[data-label='Token'] > div > b {
-        display: block;
-        color: var(--color-text-primary);
+      &[data-label='Token'] > div {
+        word-break: break-word;
+
+        > b {
+          display: block;
+          color: var(--color-text-primary);
+        }
       }
     }
   }
@@ -224,7 +228,7 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
   const { modalProps, toggleModal } = useManageTokens()
 
   return (
-    <BalancesWidget $columns="repeat(auto-fit, minmax(5rem, 1fr));">
+    <BalancesWidget $columns="minmax(13.2rem,0.8fr) repeat(2,minmax(10rem,1fr)) minmax(14.5rem, 1fr) minmax(13.8rem, 0.8fr)">
       <FilterTools
         resultName="tokens"
         searchValue={search}
@@ -243,7 +247,7 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
       {error ? (
         <ErrorMsg title="oops..." message="Something happened while loading the balances" />
       ) : (
-        <CardTable className="balancesOverview">
+        <CardTable className="balancesOverview" $gap="0 1rem">
           <thead>
             <tr>
               <th>Token</th>

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -37,17 +37,30 @@ interface WithdrawState {
 }
 
 const BalancesWidget = styled(CardWidgetWrapper)`
-  ${CardTable} > tbody > tr:not([class^="Card__CardRowDrawer"]) > td {
-    &[data-label='Token'] {
-      font-family: var(--font-default);
-      letter-spacing: 0;
-      line-height: 1.2;
-      flex-flow: row nowrap;
+  ${CardTable} {
+    > thead,
+    > tbody {
+      > tr:not([class^='Card__CardRowDrawer']) {
+        > td,
+        > th {
+          justify-content: flex-end;
+          text-align: right;
+        }
+      }
     }
 
-    &[data-label='Token'] > div > b {
-      display: block;
-      color: var(--color-text-primary);
+    > tbody > tr:not([class^='Card__CardRowDrawer']) > td {
+      &[data-label='Token'] {
+        font-family: var(--font-default);
+        letter-spacing: 0;
+        line-height: 1.2;
+        flex-flow: row nowrap;
+      }
+
+      &[data-label='Token'] > div > b {
+        display: block;
+        color: var(--color-text-primary);
+      }
     }
   }
   // button

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -40,7 +40,7 @@ const BalancesWidget = styled(CardWidgetWrapper)`
   ${CardTable} {
     > thead,
     > tbody {
-      > tr:not([class^='Card__CardRowDrawer']) {
+      > tr:not(.cardRowDrawer) {
         > td,
         > th {
           justify-content: flex-end;
@@ -49,7 +49,7 @@ const BalancesWidget = styled(CardWidgetWrapper)`
       }
     }
 
-    > tbody > tr:not([class^='Card__CardRowDrawer']) > td {
+    > tbody > tr:not(.cardRowDrawer) > td {
       &[data-label='Token'] {
         font-family: var(--font-default);
         letter-spacing: 0;

--- a/src/components/Layout/Card/Card.tsx
+++ b/src/components/Layout/Card/Card.tsx
@@ -102,7 +102,7 @@ export const CardDrawer = React.forwardRef<HTMLTableRowElement, CardDrawerProps>
   ref,
 ) {
   return (
-    <CardRowDrawer className=".cardRowDrawer" ref={ref}>
+    <CardRowDrawer className="cardRowDrawer" ref={ref}>
       <td>
         <CardDrawerCloser onClick={closeDrawer}>&times;</CardDrawerCloser>
         {children}

--- a/src/components/Layout/Card/Card.tsx
+++ b/src/components/Layout/Card/Card.tsx
@@ -259,21 +259,24 @@ export const CardTable = styled.table<{
 export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
   display: flex;
   flex-flow: column nowrap;
+  justify-content: flex-start;
+
   width: auto;
+  margin: 0 auto;
   padding: 0 0 2.4rem;
+  min-height: 54rem;
   min-width: 85rem;
   max-width: 140rem;
+
   background: var(--color-background-pageWrapper);
   box-shadow: 0 -1rem 4rem 0 rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.02) 0 0.276726rem 0.221381rem 0,
     rgba(0, 0, 0, 0.027) 0 0.666501rem 0.532008rem 0, rgba(0, 0, 0, 0.035) 0 1.25216rem 1.0172rem 0,
     rgba(0, 0, 0, 0.043) 0 2.23363rem 1.7869rem 0, rgba(0, 0, 0, 0.05) 0 4.17776rem 3.34221rem 0,
     rgba(0, 0, 0, 0.07) 0 10rem 8rem 0;
+
   border-radius: 0.6rem;
-  margin: 0 auto;
-  min-height: 54rem;
   font-size: 1.6rem;
   line-height: 1;
-  justify-content: flex-start;
 
   @media ${MEDIA.tablet} {
     min-width: 100vw;
@@ -312,7 +315,6 @@ export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
         font-size: 1.1rem;
         color: var(--color-text-primary);
         letter-spacing: 0;
-        padding: 0.8rem;
         text-transform: uppercase;
       }
     }
@@ -334,7 +336,6 @@ export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
         display: flex;
         flex-flow: row wrap;
         align-items: center;
-        padding: 0 0.5rem;
         word-break: break-all;
         white-space: normal;
 
@@ -390,6 +391,7 @@ export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
         &:first-of-type {
           text-align: left;
           justify-content: flex-start;
+          padding-left: 2rem;
         }
       }
     }

--- a/src/components/Layout/Card/Card.tsx
+++ b/src/components/Layout/Card/Card.tsx
@@ -203,7 +203,7 @@ export const CardTable = styled.table<{
 
       > th {
         color: inherit;
-        line-height: 0.6;
+        line-height: 1.2;
         font-size: 1.1rem;
         height: 4rem;
 
@@ -385,7 +385,7 @@ export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
     > tbody > tr:not(.cardRowDrawer) {
       ${({ $columns }): string => ($columns ? `grid-template-columns: ${$columns}` : '')};
       text-align: left;
-      padding: 0.8rem;
+      padding: 0.8rem 1.6rem;
       margin: 0;
       justify-content: flex-end;
 
@@ -402,7 +402,6 @@ export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
         &:first-of-type {
           text-align: left;
           justify-content: flex-start;
-          padding: 0 0.8rem;
         }
       }
     }

--- a/src/components/Layout/Card/Card.tsx
+++ b/src/components/Layout/Card/Card.tsx
@@ -102,7 +102,7 @@ export const CardDrawer = React.forwardRef<HTMLTableRowElement, CardDrawerProps>
   ref,
 ) {
   return (
-    <CardRowDrawer ref={ref}>
+    <CardRowDrawer className=".cardRowDrawer" ref={ref}>
       <td>
         <CardDrawerCloser onClick={closeDrawer}>&times;</CardDrawerCloser>
         {children}
@@ -146,7 +146,7 @@ export const CardTable = styled.table<{
   }
 
   > thead, tbody {
-    > tr:not(${CardRowDrawer}) {
+    > tr:not(.cardRowDrawer) {
       position: relative;
       display: grid;
       grid-template-columns: ${({ $columns }): string => $columns || `repeat(auto-fit, minmax(3rem, 1fr))`};
@@ -235,7 +235,7 @@ export const CardTable = styled.table<{
   }
   
   tbody {
-    > tr:not(${CardRowDrawer}) {
+    > tr:not(.cardRowDrawer) {
 
       > td {
         &.cardOpener {
@@ -322,7 +322,7 @@ export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
         display: none;
       }
 
-      > tr:not([class^='Card__CardRowDrawer']) > th {
+      > tr:not(.cardRowDrawer) > th {
         font-size: 1.1rem;
         color: var(--color-text-primary);
         letter-spacing: 0;
@@ -343,7 +343,7 @@ export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
         width: 100%;
       }
 
-      > tr:not([class^='Card__CardRowDrawer']) > td {
+      > tr:not(.cardRowDrawer) > td {
         display: flex;
         flex-flow: row wrap;
         align-items: center;
@@ -381,8 +381,8 @@ export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
     /////////////////////
     // ALL TABLE ROWS
     /////////////////////
-    > thead > tr:not([class^='Card__CardRowDrawer']),
-    > tbody > tr:not([class^='Card__CardRowDrawer']) {
+    > thead > tr:not(.cardRowDrawer),
+    > tbody > tr:not(.cardRowDrawer) {
       ${({ $columns }): string => ($columns ? `grid-template-columns: ${$columns}` : '')};
       text-align: left;
       padding: 0.8rem;
@@ -402,7 +402,7 @@ export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
         &:first-of-type {
           text-align: left;
           justify-content: flex-start;
-          padding-left: 2rem;
+          padding: 0 0.8rem;
         }
       }
     }

--- a/src/components/Layout/Card/Card.tsx
+++ b/src/components/Layout/Card/Card.tsx
@@ -159,6 +159,8 @@ export const CardTable = styled.table<{
       border-bottom: .1rem solid rgba(159,180,201,0.50);
       border-radius: 0;
 
+      min-height: 4rem;
+
       // How much separation between ROWS
       margin: ${({ $rowSeparation = '1rem' }): string => `${$rowSeparation} 0`};
       text-align: center;
@@ -182,6 +184,9 @@ export const CardTable = styled.table<{
       // Separation between CELLS
       > th,
       > td {
+        display: flex;
+        align-items: center;
+
         text-overflow: ellipsis;
         overflow: hidden;
         text-align: left;
@@ -204,9 +209,9 @@ export const CardTable = styled.table<{
 
       > th {
         color: inherit;
-        line-height: 1;
+        line-height: 0.6;
         font-size: 1.1rem;
-        padding: 1.3rem 0;
+        height: 4rem;
 
         &.sortable {
           cursor: pointer;
@@ -270,117 +275,122 @@ export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
   line-height: 1;
   justify-content: flex-start;
 
-    @media ${MEDIA.tablet} {
-      min-width: 100vw;
-      min-width: calc(100vw - 4.8rem);
-      width: 100%;
-      max-width: 100%;
-    }
+  @media ${MEDIA.tablet} {
+    min-width: 100vw;
+    min-width: calc(100vw - 4.8rem);
+    width: 100%;
+    max-width: 100%;
+  }
 
-    @media ${MEDIA.mobile} {
-      max-width: 100%;
-      min-width: initial;
-      width: 100%;
+  @media ${MEDIA.mobile} {
+    max-width: 100%;
+    min-width: initial;
+    width: 100%;
 
-      > div {
-        flex-flow: row wrap;
-      }
+    > div {
+      flex-flow: row wrap;
     }
-    
+  }
+
   ${CardTable} {
     display: flex;
     flex-flow: column nowrap;
     width: auto;
-    order: 2;
-  }
 
-  ${CardTable} > tbody {
-    font-size: 1.3rem;
-    line-height: 1;
+    /////////////////////
+    // TABLE HEADERS
+    /////////////////////
+    > thead {
+      background: var(--color-background);
+      border-radius: 0.6rem;
 
-    @media ${MEDIA.mobile} {
-      display: flex;
-      flex-flow: column wrap;
-      width: 100%;
-    }
-  }
+      @media ${MEDIA.mobile} {
+        display: none;
+      }
 
-  ${CardTable} > thead {
-    background: var(--color-background);
-    border-radius: 0.6rem;
-
-    @media ${MEDIA.mobile} {
-      display: none;
-    }
-  }
-
-  ${CardTable} > thead > tr:not([class^="Card__CardRowDrawer"]),
-  ${CardTable} > tbody > tr:not([class^="Card__CardRowDrawer"]) {
-    ${({ $columns }): string => ($columns ? `grid-template-columns: ${$columns}` : '')};
-    text-align: right;
-    padding: 0.8rem;
-    margin: 0;
-    justify-content: flex-start;
-
-    @media ${MEDIA.mobile} {
-      padding: 1.6rem 0.8rem;
-      display: table;
-      flex-flow: column wrap;
-      width: 100%;
-      border-bottom: 0.2rem solid rgba(159, 180, 201, 0.5);
-    }
-  }
-
-  ${CardTable} > thead > tr:not([class^="Card__CardRowDrawer"]) > th {
-    font-size: 1.1rem;
-    color: var(--color-text-primary);
-    letter-spacing: 0;
-    text-align: right;
-    padding: 0.8rem;
-    text-transform: uppercase;
-
-    &:first-of-type {
-      text-align: left;
-    }
-  }
-
-  ${CardTable} > tbody > tr:not([class^="Card__CardRowDrawer"]) > td {
-    display: flex;
-    flex-flow: row wrap;
-    align-items: center;
-    padding: 0 0.5rem;
-    text-align: right;
-    justify-content: flex-end;
-    word-break: break-all;
-    white-space: normal;
-
-    @media ${MEDIA.mobile} {
-      width: 100%;
-      border-bottom: 0.1rem solid rgba(0, 0, 0, 0.14);
-      padding: 1rem 0.5rem;
-      flex-flow: row nowrap;
-
-      &:last-of-type {
-        border: 0;
+      > tr:not([class^='Card__CardRowDrawer']) > th {
+        font-size: 1.1rem;
+        color: var(--color-text-primary);
+        letter-spacing: 0;
+        padding: 0.8rem;
+        text-transform: uppercase;
       }
     }
 
-    &:first-of-type {
-      text-align: left;
-      justify-content: flex-start;
-    }
-    &::before {
+    /////////////////////
+    // TABLE BODY
+    /////////////////////
+    > tbody {
+      font-size: 1.3rem;
+      line-height: 1;
+
       @media ${MEDIA.mobile} {
-        content: attr(data-label);
-        margin-right: auto;
-        font-weight: var(--font-weight-bold);
-        text-transform: uppercase;
-        font-size: 1rem;
-        font-family: var(--font-default);
-        letter-spacing: 0;
-        white-space: nowrap;
-        padding: 0 0.5rem 0 0;
-        color: var(--color-text-primary);
+        display: flex;
+        flex-flow: column wrap;
+        width: 100%;
+      }
+
+      > tr:not([class^='Card__CardRowDrawer']) > td {
+        display: flex;
+        flex-flow: row wrap;
+        align-items: center;
+        padding: 0 0.5rem;
+        word-break: break-all;
+        white-space: normal;
+
+        @media ${MEDIA.mobile} {
+          width: 100%;
+          border-bottom: 0.1rem solid rgba(0, 0, 0, 0.14);
+          padding: 1rem 0.5rem;
+          flex-flow: row nowrap;
+
+          &:last-of-type {
+            border: 0;
+          }
+        }
+
+        &::before {
+          @media ${MEDIA.mobile} {
+            content: attr(data-label);
+            margin-right: auto;
+            font-weight: var(--font-weight-bold);
+            text-transform: uppercase;
+            font-size: 1rem;
+            font-family: var(--font-default);
+            letter-spacing: 0;
+            white-space: nowrap;
+            padding: 0 0.5rem 0 0;
+            color: var(--color-text-primary);
+          }
+        }
+      }
+    }
+
+    /////////////////////
+    // ALL TABLE ROWS
+    /////////////////////
+    > thead > tr:not([class^='Card__CardRowDrawer']),
+    > tbody > tr:not([class^='Card__CardRowDrawer']) {
+      ${({ $columns }): string => ($columns ? `grid-template-columns: ${$columns}` : '')};
+      text-align: left;
+      padding: 0.8rem;
+      margin: 0;
+      justify-content: flex-end;
+
+      @media ${MEDIA.mobile} {
+        padding: 1.6rem 0.8rem;
+        display: table;
+        flex-flow: column wrap;
+        width: 100%;
+        border-bottom: 0.2rem solid rgba(159, 180, 201, 0.5);
+      }
+
+      > td,
+      > th {
+        &:first-of-type {
+          text-align: left;
+          justify-content: flex-start;
+        }
       }
     }
   }

--- a/src/components/Layout/Card/Card.tsx
+++ b/src/components/Layout/Card/Card.tsx
@@ -192,13 +192,7 @@ export const CardTable = styled.table<{
         text-align: left;
       }
     }
-  }
-  
-  .lowBalance {
-    color: #B27800;
-    display: block;
-    > img {margin: 0 0 0 .25rem;}
-  }
+  }  
   
   // Table Header
   > thead {
@@ -246,6 +240,23 @@ export const CardTable = styled.table<{
       > td {
         &.cardOpener {
           display: none;
+        }
+
+        // td.status
+        &.status {
+          flex-flow: column;
+          align-items: flex-start;
+
+          > .lowBalance {
+            color: #B27800;
+            display: flex;
+            margin: 0.2rem 0;
+            font-size: smaller;
+        
+            > img {
+              margin: 0 0 0.2rem 0.45rem;
+            }
+          }
         }
       }
 

--- a/src/components/OrdersWidget/OrderRow.styled.ts
+++ b/src/components/OrdersWidget/OrderRow.styled.ts
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 
 export const OrderRowWrapper = styled.tr<{ $color?: string; $open?: boolean }>`
   color: ${({ $color = '' }): string => $color};
-  min-height: 4rem;
 
   &.pending {
     background: rgba(33, 141, 255, 0.1);

--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -19,6 +19,10 @@ export const OrdersWrapper = styled.div`
   max-width: 140rem;
   /* ====================================================================== */
 
+  @media ${MEDIA.tabletSmall} {
+    min-width: ${MEDIA.smallScreen};
+  }
+
   @media ${MEDIA.mobile} {
     max-width: 100%;
     min-width: initial;

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -368,8 +368,9 @@ const OrdersWidget: React.FC<Props> = ({ isWidget = false }) => {
               // ACTIVE / LIQUIDITY / CLOSED ORDERS
               <div className="ordersContainer">
                 <CardTable
-                  $columns="3.2rem repeat(2, 1fr) repeat(2, minmax(5.2rem, 0.6fr))"
+                  $columns="3.2rem repeat(2,1fr) minmax(5.2rem,0.6fr) minmax(7.2rem, 0.3fr)"
                   $gap="0 0.6rem"
+                  $padding="0 0.8rem"
                   $rowSeparation="0"
                 >
                   <thead>

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -349,7 +349,7 @@ const OrdersWidget: React.FC<Props> = ({ isWidget = false }) => {
             </div>
             {selectedTab === 'fills' ? (
               <div className="ordersContainer">
-                <InnerTradesWidget trades={trades} />
+                <InnerTradesWidget isTab trades={trades} />
               </div>
             ) : ordersCount > 0 ? (
               <div className="ordersContainer">

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -9,6 +9,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 // Const and utils
 import { isOrderActive, isPendingOrderActive } from 'utils'
 import { DEFAULT_ORDERS_SORTABLE_TOPIC } from 'const'
+import { filterTradesFn, filterOrdersFn } from 'utils/filter'
 
 // Hooks
 import { useOrders } from 'hooks/useOrders'
@@ -19,7 +20,7 @@ import useSortByTopic from 'hooks/useSortByTopic'
 import { useWalletConnection } from 'hooks/useWalletConnection'
 
 // Api
-import { DetailedAuctionElement } from 'api/exchange/ExchangeApi'
+import { DetailedAuctionElement, DetailedPendingOrder, Trade } from 'api/exchange/ExchangeApi'
 
 // Components
 import { ConnectWalletBanner } from 'components/ConnectWalletBanner'
@@ -31,10 +32,6 @@ import FilterTools from 'components/FilterTools'
 import { useDeleteOrders } from 'components/OrdersWidget/useDeleteOrders'
 import OrderRow from 'components/OrdersWidget/OrderRow'
 import { OrdersWrapper, ButtonWithIcon, OrdersForm } from 'components/OrdersWidget/OrdersWidget.styled'
-
-// Types/misc
-import { DetailedPendingOrder } from 'hooks/usePendingOrders'
-import { TokenDetails } from 'types'
 
 type OrderTabs = 'active' | 'liquidity' | 'closed' | 'fills'
 
@@ -87,25 +84,6 @@ function classifyOrders(
       state.active[ordersType].push(order)
     }
   })
-}
-
-function checkTokenAgainstSearch(token: TokenDetails | null, searchText: string): boolean {
-  if (!token) return false
-  return (
-    token?.symbol?.toLowerCase().includes(searchText) ||
-    token?.name?.toLowerCase().includes(searchText) ||
-    token?.address.toLowerCase().includes(searchText)
-  )
-}
-
-const filterOrdersFn = (searchTxt: string) => ({ id, buyToken, sellToken }: DetailedAuctionElement): boolean | null => {
-  if (searchTxt === '') return null
-
-  return (
-    !!id.includes(searchTxt) ||
-    checkTokenAgainstSearch(buyToken, searchTxt) ||
-    checkTokenAgainstSearch(sellToken, searchTxt)
-  )
 }
 
 const compareFnFactory = (topic: TopicNames, asc: boolean) => (
@@ -277,10 +255,42 @@ const OrdersWidget: React.FC<Props> = ({ isWidget = false }) => {
     filteredData: filteredAndSortedOrders,
     search,
     handlers: { handleSearch },
-  } = useDataFilter({
+  } = useDataFilter<DetailedAuctionElement>({
     data: sortedDisplayedOrders,
     filterFnFactory: filterOrdersFn,
   })
+
+  const {
+    filteredData: filteredTrades,
+    search: tradesSearch,
+    handlers: { handleSearch: handleTradesSearch },
+  } = useDataFilter<Trade>({
+    data: trades,
+    filterFnFactory: filterTradesFn,
+  })
+
+  const { handleTabSpecificSearch, tabSpecficSearch, tabSpecificResultName, tabSpecificDataLength } = useMemo(
+    () => ({
+      handleTabSpecificSearch: (e: React.ChangeEvent<HTMLInputElement>): void =>
+        selectedTab === 'fills' ? handleTradesSearch(e) : handleSearch(e),
+      tabSpecficSearch: selectedTab === 'fills' ? tradesSearch : search,
+      tabSpecificResultName: selectedTab === 'fills' ? 'trades' : 'orders',
+      tabSpecificDataLength:
+        selectedTab === 'fills'
+          ? filteredTrades.length
+          : displayedPendingOrders.length + filteredAndSortedOrders.length,
+    }),
+    [
+      selectedTab,
+      displayedPendingOrders.length,
+      filteredAndSortedOrders.length,
+      filteredTrades.length,
+      search,
+      tradesSearch,
+      handleSearch,
+      handleTradesSearch,
+    ],
+  )
 
   return (
     <OrdersWrapper>
@@ -299,11 +309,11 @@ const OrdersWidget: React.FC<Props> = ({ isWidget = false }) => {
           <form action="submit" onSubmit={onSubmit}>
             <FilterTools
               className={isWidget ? 'widgetFilterTools' : ''}
-              resultName="orders"
-              searchValue={search}
-              handleSearch={handleSearch}
-              showFilter={!!search}
-              dataLength={displayedPendingOrders.length + filteredAndSortedOrders.length}
+              resultName={tabSpecificResultName}
+              searchValue={tabSpecficSearch}
+              handleSearch={handleTabSpecificSearch}
+              showFilter={!!tabSpecficSearch}
+              dataLength={tabSpecificDataLength}
             >
               {/* implement later when better data concerning order state and can be saved to global state 
               <label className="balances-hideZero">
@@ -312,6 +322,7 @@ const OrdersWidget: React.FC<Props> = ({ isWidget = false }) => {
               </label>
               */}
             </FilterTools>
+            {/* ORDERS TABS: ACTIVE/FILLS/LIQUIDITY/CLOSED */}
             <div className="infoContainer">
               <div className="countContainer">
                 <ShowOrdersButton
@@ -340,6 +351,7 @@ const OrdersWidget: React.FC<Props> = ({ isWidget = false }) => {
                 />
               </div>
             </div>
+            {/* DELETE ORDERS ROW */}
             <div className="deleteContainer" data-disabled={markedForDeletion.size === 0 || deleting}>
               <b>↴</b>
               <ButtonWithIcon disabled={markedForDeletion.size === 0 || deleting} type="submit">
@@ -347,11 +359,13 @@ const OrdersWidget: React.FC<Props> = ({ isWidget = false }) => {
                 {['active', 'liquidity'].includes(selectedTab) ? 'Cancel' : 'Delete'} {markedForDeletion.size} orders
               </ButtonWithIcon>
             </div>
+            {/* FILLS AKA TRADES */}
             {selectedTab === 'fills' ? (
               <div className="ordersContainer">
-                <InnerTradesWidget isTab trades={trades} />
+                <InnerTradesWidget isTab trades={filteredTrades} />
               </div>
             ) : ordersCount > 0 ? (
+              // ACTIVE / LIQUIDITY / CLOSED ORDERS
               <div className="ordersContainer">
                 <CardTable
                   $columns="3.2rem repeat(2, 1fr) repeat(2, minmax(5.2rem, 0.6fr))"

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react'
 import styled from 'styled-components'
 import BigNumber from 'bignumber.js'
 
-import { formatPrice, formatSmart, formatAmountFull, DEFAULT_PRECISION } from '@gnosis.pm/dex-js'
+import { formatPrice, formatSmart, formatAmountFull, invertPrice, DEFAULT_PRECISION } from '@gnosis.pm/dex-js'
 
 import { Trade, TradeType } from 'api/exchange/ExchangeApi'
 
@@ -84,6 +84,10 @@ export const TradeRow: React.FC<TradeRowProps> = params => {
   } = trade
   const buyTokenDecimals = buyToken.decimals || DEFAULT_PRECISION
   const sellTokenDecimals = sellToken.decimals || DEFAULT_PRECISION
+  // Calculate the inverse price - just make sure Limit Price is defined and isn't ZERO
+  // don't want none of that divide by zero and destroy the world stuff
+  const invertedLimitPrice = limitPrice && !limitPrice.isZero() && invertPrice(limitPrice)
+  const invertedFillPrice = invertPrice(fillPrice)
 
   const typeColumnTitle = useMemo(() => {
     switch (type) {
@@ -118,14 +122,16 @@ export const TradeRow: React.FC<TradeRowProps> = params => {
       </td>
       <td
         data-label="Limit Price / Fill Price"
-        title={`${limitPrice ? formatPrice({ price: limitPrice, decimals: 8 }) : 'N/A'} / ${formatPrice({
-          price: fillPrice,
-          decimals: 8,
-        })}`}
+        title={`${invertedLimitPrice ? formatPrice({ price: invertedLimitPrice, decimals: 8 }) : 'N/A'} / ${formatPrice(
+          {
+            price: invertedFillPrice,
+            decimals: 8,
+          },
+        )}`}
       >
-        {limitPrice ? formatPrice(limitPrice) : 'N/A'}
+        {invertedLimitPrice ? formatPrice(invertedLimitPrice) : 'N/A'}
         <br />
-        {formatPrice(fillPrice)}
+        {formatPrice(invertedFillPrice)}
       </td>
       <td
         data-label="Amount / Received"

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -24,6 +24,7 @@ const CsvButtonContainer = styled.div`
   display: flex;
   justify-content: space-around;
   align-items: center;
+  width: 100%;
 `
 
 const SplitHeaderTitle = styled.div`
@@ -119,12 +120,7 @@ export const InnerTradesWidget: React.FC<InnerTradesWidgetProps> = props => {
   )
 
   return (
-    <CardTable
-      $rowSeparation="0"
-      $gap="0 0.6rem"
-      $padding="0.5em 0 0.5em 1em"
-      $columns="1.2fr 1fr 0.9fr 1.2fr 0.9fr 1.23fr"
-    >
+    <CardTable $rowSeparation="0" $gap="0 0.6rem" $padding="0 0 0 1.5em" $columns="1fr 0.8fr 0.9fr 1.2fr 6.5rem 1.23fr">
       <thead>
         <tr>
           <th>Date</th>

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -6,18 +6,21 @@ import styled from 'styled-components'
 
 import { formatPrice, TokenDetails, formatAmount } from '@gnosis.pm/dex-js'
 
+import FilterTools from 'components/FilterTools'
 import { CardTable, CardWidgetWrapper } from 'components/Layout/Card'
 import { ConnectWalletBanner } from 'components/ConnectWalletBanner'
 import { FileDownloaderLink } from 'components/FileDownloaderLink'
+import { TradeRow } from 'components/TradesWidget/TradeRow'
 
 import { useWalletConnection } from 'hooks/useWalletConnection'
 import { useTrades } from 'hooks/useTrades'
+import useDataFilter from 'hooks/useDataFilter'
 
 import { Trade } from 'api/exchange/ExchangeApi'
 
 import { toCsv, CsvColumns } from 'utils/csv'
+import { filterTradesFn } from 'utils/filter'
 
-import { TradeRow } from 'components/TradesWidget/TradeRow'
 import { getNetworkFromId, isTradeSettled, isTradeReverted } from 'utils'
 
 const CsvButtonContainer = styled.div`
@@ -170,11 +173,28 @@ export const TradesWidget: React.FC = () => {
   const { isConnected } = useWalletConnection()
   const trades = useTrades()
 
+  const {
+    filteredData,
+    search,
+    handlers: { handleSearch },
+  } = useDataFilter<Trade>({
+    data: trades,
+    filterFnFactory: filterTradesFn,
+  })
+
   return !isConnected ? (
     <ConnectWalletBanner />
   ) : (
     <CardWidgetWrapper>
-      <InnerTradesWidget trades={trades} />
+      <FilterTools
+        className="widgetFilterTools"
+        resultName="trades"
+        searchValue={search}
+        handleSearch={handleSearch}
+        showFilter={!!search}
+        dataLength={filteredData.length}
+      />
+      <InnerTradesWidget trades={filteredData} />
     </CardWidgetWrapper>
   )
 }

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -94,10 +94,11 @@ const CSV_FILE_OPTIONS = { type: 'text/csv;charset=utf-8;' }
 
 interface InnerTradesWidgetProps {
   trades: Trade[]
+  isTab?: boolean
 }
 
 export const InnerTradesWidget: React.FC<InnerTradesWidgetProps> = props => {
-  const { trades } = props
+  const { isTab, trades } = props
 
   const { networkId, userAddress } = useWalletConnection()
 
@@ -120,7 +121,12 @@ export const InnerTradesWidget: React.FC<InnerTradesWidgetProps> = props => {
   )
 
   return (
-    <CardTable $rowSeparation="0" $gap="0 0.6rem" $padding="0 0 0 1.5em" $columns="1fr 0.8fr 0.9fr 1.2fr 6.5rem 1.23fr">
+    <CardTable
+      $rowSeparation="0"
+      $gap="0 0.6rem"
+      $padding="0 0 0 2rem"
+      $columns={`1fr 0.8fr 0.9fr 1.2fr 6.5rem ${isTab ? '1.23fr' : '0.74fr'}`}
+    >
       <thead>
         <tr>
           <th>Date</th>

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -33,9 +33,6 @@ const CsvButtonContainer = styled.div`
 const SplitHeaderTitle = styled.div`
   display: flex;
   flex-flow: column;
-  > span {
-    margin: 0.25rem 0;
-  }
 `
 
 function symbolOrAddress(token: TokenDetails): string {

--- a/src/components/WrapEtherBtn.tsx
+++ b/src/components/WrapEtherBtn.tsx
@@ -354,14 +354,7 @@ const WrapUnwrapEtherBtn: React.FC<WrapUnwrapEtherBtnProps> = (props: WrapUnwrap
 
   return (
     <>
-      <TooltipWrapper
-        as="button"
-        type="button"
-        className={className}
-        style={{ minWidth: '7em' }}
-        onClick={toggleModal}
-        tooltip={tooltipText}
-      >
+      <TooltipWrapper as="button" type="button" className={className} onClick={toggleModal} tooltip={tooltipText}>
         {loading && <FontAwesomeIcon icon={faSpinner} spin />} {label || title}
       </TooltipWrapper>
       <Modali.Modal {...modalHook} />

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -9,12 +9,12 @@ import { overwriteOrders, updateOffset, updateOrders } from 'reducers-actions/or
 import useSafeState from './useSafeState'
 import useGlobalState from './useGlobalState'
 import { useWalletConnection } from './useWalletConnection'
-import usePendingOrders, { DetailedPendingOrder } from './usePendingOrders'
+import usePendingOrders from './usePendingOrders'
 import { useCheckWhenTimeRemainingInBatch } from './useTimeRemainingInBatch'
 
 // Constants/Types
 import { REFRESH_WHEN_SECONDS_LEFT } from 'const'
-import { DetailedAuctionElement } from 'api/exchange/ExchangeApi'
+import { DetailedAuctionElement, DetailedPendingOrder } from 'api/exchange/ExchangeApi'
 
 interface Result {
   orders: DetailedAuctionElement[]
@@ -70,6 +70,7 @@ export function useOrders(): Result {
             getTokenFromExchangeById({ tokenId: order.sellTokenId, networkId }),
             getTokenFromExchangeById({ tokenId: order.buyTokenId, networkId }),
           ])
+
           return {
             ...order,
             sellToken,

--- a/src/hooks/usePendingOrders.ts
+++ b/src/hooks/usePendingOrders.ts
@@ -9,7 +9,7 @@ import { useWalletConnection } from './useWalletConnection'
 import { removePendingOrdersAction } from 'reducers-actions/pendingOrders'
 // Constants/Types/Misc.
 import { EMPTY_ARRAY } from 'const'
-import { DetailedAuctionElement, AuctionElement } from 'api/exchange/ExchangeApi'
+import { AuctionElement, DetailedPendingOrder } from 'api/exchange/ExchangeApi'
 import { getTokenFromExchangeById } from 'services'
 
 async function getDetailedPendingOrders({
@@ -35,10 +35,6 @@ async function getDetailedPendingOrders({
 
   const detailedOrders: DetailedPendingOrder[] = await Promise.all(ordersPromises)
   return setFn(detailedOrders)
-}
-
-export interface DetailedPendingOrder extends DetailedAuctionElement {
-  txHash?: string
 }
 
 function usePendingOrders(): DetailedPendingOrder[] {

--- a/src/utils/display.tsx
+++ b/src/utils/display.tsx
@@ -9,3 +9,34 @@ export function displayTokenSymbolOrLink(token: TokenDetails): React.ReactNode |
   }
   return displayName
 }
+
+/**
+ * computeMarketProp
+ * @description returns array of potentially accepted market names by:: BUYTOKEN <SEPARATOR> SELLTOKEN
+ * @param { sellToken, buyToken, acceptedSeparators: string[] }
+ */
+export function computeMarketProp({
+  sellToken,
+  buyToken,
+  acceptedSeparators = ['-', '/', ''],
+  inverseMarket = false,
+}: {
+  sellToken: TokenDetails
+  buyToken: TokenDetails
+  acceptedSeparators?: string[]
+  inverseMarket?: boolean
+}): string[] {
+  const buyTokenFormatted = safeTokenName(buyToken).toLowerCase()
+  const sellTokenFormatted = safeTokenName(sellToken).toLowerCase()
+
+  // BUYTOKEN/SELLTOKEN
+  const marketList = acceptedSeparators.map(sep => `${buyTokenFormatted}${sep}${sellTokenFormatted}`)
+
+  if (inverseMarket) {
+    // SELLTOKEN/BUYTOKEN
+    const inverseMarketList = acceptedSeparators.map(sep => `${sellTokenFormatted}${sep}${buyTokenFormatted}`)
+    return marketList.concat(inverseMarketList)
+  }
+
+  return marketList
+}

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -1,0 +1,33 @@
+import { TokenDetails } from 'types'
+import { DetailedAuctionElement, Trade } from 'api/exchange/ExchangeApi'
+import { computeMarketProp } from './display'
+
+export function checkTokenAgainstSearch(token: TokenDetails | null, searchText: string): boolean {
+  if (!token) return false
+  return (
+    token?.symbol?.toLowerCase().includes(searchText) ||
+    token?.name?.toLowerCase().includes(searchText) ||
+    token?.address.toLowerCase().includes(searchText)
+  )
+}
+
+const filterTradesAndOrdersFnFactory = (includeInverseMarket?: boolean) => (searchTxt: string) => ({
+  id,
+  buyToken,
+  sellToken,
+}: Trade | DetailedAuctionElement): boolean | null => {
+  if (searchTxt === '') return null
+
+  const market =
+    sellToken && buyToken && computeMarketProp({ sellToken, buyToken, inverseMarket: includeInverseMarket })
+
+  return (
+    !!id.includes(searchTxt) ||
+    (market && !!market.includes(searchTxt)) ||
+    checkTokenAgainstSearch(buyToken, searchTxt) ||
+    checkTokenAgainstSearch(sellToken, searchTxt)
+  )
+}
+
+export const filterOrdersFn = filterTradesAndOrdersFnFactory(true)
+export const filterTradesFn = filterTradesAndOrdersFnFactory()


### PR DESCRIPTION
Merges into #1096 

Optimises CSS

`/trades` formatting was a bit strange due to `CardWidget`s default CSS which was optimised for `Balances` page
  a. edited to better fit 

Added `isTab` prop to `TradesWidget` to optimise column sizes for both formats

Standardised `thead` size across all tables


# Update 19.06
**Waterfall PRs**

1. adds filtering for `trades` aka Fills
2. uses inverse price for fills widget/tab
3. adds market filtering e.g `WETH/DAI` or `WETH-DAI` or `WETHDAI` and inverse (inverse search only for `Active/Liquidity/Closed` orders, not for fills
4. css fixes on table styling etc