### PR TITLE
Trades localStorage fixes

### DIFF
--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -88,9 +88,10 @@ const Trades: React.FC = () => {
   const { networkId, userAddress, isConnected } = useWalletConnection()
   const trades = useTrades()
 
-  const filteredTrades = useMemo(() => trades.filter(trade => isTradeSettled(trade) && !isTradeReverted(trade)), [
-    trades,
-  ])
+  const filteredTrades = useMemo(
+    () => trades.filter(trade => trade && isTradeSettled(trade) && !isTradeReverted(trade)),
+    [trades],
+  )
 
   const generateCsv = useCallback(
     () =>

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -183,3 +183,7 @@ export async function retry<T extends () => any>(fn: T, options?: RetryOptions):
 export function flattenMapOfLists<K, T>(map: Map<K, T[]>): T[] {
   return Array.from(map.values()).reduce<T[]>((acc, list) => acc.concat(list), [])
 }
+
+export function flattenMapOfSets<K, T>(map: Map<K, Set<T>>): T[] {
+  return Array.from(map.values()).reduce<T[]>((acc, set) => acc.concat(Array.from(set)), [])
+}


### PR DESCRIPTION
## Update Jun 23

- Now working 100% :+1: 
- Addressed edge case with pending trades causing duplicates errors all over the place
- Working internally with sets/maps, transforming during serialization/deserialization
- Keeping track of all trade ids on global state to avoid duplicates and not need to go through the whole list of trades on every update.

----

Fixing bug reported by Anxo regarding pending trades and JSON serialization/de-serialization of Maps.

Still getting some duplicates. Using Sets to try and avoid that but didn't help much.
Will spend more time on this next Monday.