### PR TITLE
Filter /Orders by market

### DIFF
--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -105,16 +105,11 @@ export interface ExchangeApi extends DepositApi {
   cancelOrders(params: CancelOrdersParams): Promise<Receipt>
 }
 
-// Where market = 'WETH-TUSD'
-export interface Market {
-  market?: string
-}
-
-export interface DetailedPendingOrder extends DetailedAuctionElement, Market {
+export interface DetailedPendingOrder extends DetailedAuctionElement {
   txHash?: string
 }
 
-export interface DetailedAuctionElement extends AuctionElement, Market {
+export interface DetailedAuctionElement extends AuctionElement {
   buyToken: TokenDetails | null
   sellToken: TokenDetails | null
 }
@@ -163,7 +158,7 @@ export type TradeType = 'full' | 'partial' | 'liquidity' | 'unknown'
 /**
  * Trade enriches BaseTradeEvent with block, order and token data
  */
-export interface Trade extends EventWithBlockInfo, Market {
+export interface Trade extends EventWithBlockInfo {
   revertTimestamp?: number
   revertId?: string
   settlingTimestamp: number

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react'
 import styled from 'styled-components'
 import BigNumber from 'bignumber.js'
 
-import { formatPrice, formatSmart, formatAmountFull, DEFAULT_PRECISION } from '@gnosis.pm/dex-js'
+import { formatPrice, formatSmart, formatAmountFull, invertPrice, DEFAULT_PRECISION } from '@gnosis.pm/dex-js'
 
 import { Trade, TradeType } from 'api/exchange/ExchangeApi'
 
@@ -84,6 +84,10 @@ export const TradeRow: React.FC<TradeRowProps> = params => {
   } = trade
   const buyTokenDecimals = buyToken.decimals || DEFAULT_PRECISION
   const sellTokenDecimals = sellToken.decimals || DEFAULT_PRECISION
+  // Calculate the inverse price - just make sure Limit Price is defined and isn't ZERO
+  // don't want none of that divide by zero and destroy the world stuff
+  const invertedLimitPrice = limitPrice && !limitPrice.isZero() && invertPrice(limitPrice)
+  const invertedFillPrice = invertPrice(fillPrice)
 
   const typeColumnTitle = useMemo(() => {
     switch (type) {
@@ -118,14 +122,16 @@ export const TradeRow: React.FC<TradeRowProps> = params => {
       </td>
       <td
         data-label="Limit Price / Fill Price"
-        title={`${limitPrice ? formatPrice({ price: limitPrice, decimals: 8 }) : 'N/A'} / ${formatPrice({
-          price: fillPrice,
-          decimals: 8,
-        })}`}
+        title={`${invertedLimitPrice ? formatPrice({ price: invertedLimitPrice, decimals: 8 }) : 'N/A'} / ${formatPrice(
+          {
+            price: invertedFillPrice,
+            decimals: 8,
+          },
+        )}`}
       >
-        {limitPrice ? formatPrice(limitPrice) : 'N/A'}
+        {invertedLimitPrice ? formatPrice(invertedLimitPrice) : 'N/A'}
         <br />
-        {formatPrice(fillPrice)}
+        {formatPrice(invertedFillPrice)}
       </td>
       <td
         data-label="Amount / Received"

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -19,7 +19,7 @@ import useDataFilter from 'hooks/useDataFilter'
 import { Trade } from 'api/exchange/ExchangeApi'
 
 import { toCsv, CsvColumns } from 'utils/csv'
-import { filterOrdersFn } from 'utils/filter'
+import { filterTradesFn } from 'utils/filter'
 
 import { getNetworkFromId, isTradeSettled, isTradeReverted } from 'utils'
 
@@ -179,7 +179,7 @@ export const TradesWidget: React.FC = () => {
     handlers: { handleSearch },
   } = useDataFilter<Trade>({
     data: trades,
-    filterFnFactory: filterOrdersFn,
+    filterFnFactory: filterTradesFn,
   })
 
   return !isConnected ? (

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -15,8 +15,6 @@ import { useCheckWhenTimeRemainingInBatch } from './useTimeRemainingInBatch'
 // Constants/Types
 import { REFRESH_WHEN_SECONDS_LEFT } from 'const'
 import { DetailedAuctionElement, DetailedPendingOrder } from 'api/exchange/ExchangeApi'
-// Utils
-import { computeMarketProp } from 'utils/display'
 
 interface Result {
   orders: DetailedAuctionElement[]
@@ -83,16 +81,7 @@ export function useOrders(): Result {
         // check cancelled bool from parent scope
         if (cancelled) return
 
-        const orders: DetailedAuctionElement[] = (await Promise.all(ordersPromises)).map(order => {
-          if (!order.sellToken || !order.buyToken) return order
-
-          const market = computeMarketProp({ sellToken: order.sellToken, buyToken: order.buyToken })
-
-          return {
-            ...order,
-            market,
-          }
-        })
+        const orders: DetailedAuctionElement[] = await Promise.all(ordersPromises)
         // ensures we don't have multiple reruns for each update
         // i.e. offset change -> render
         //      isLoading change -> another render

--- a/src/hooks/useTrades.ts
+++ b/src/hooks/useTrades.ts
@@ -15,7 +15,6 @@ import useGlobalState from 'hooks/useGlobalState'
 import { BATCH_TIME_IN_MS } from 'const'
 
 import { getTimeRemainingInBatch } from 'utils'
-import { computeMarketProp } from 'utils/display'
 
 export function useTrades(): Trade[] {
   const [
@@ -62,20 +61,9 @@ export function useTrades(): Trade[] {
           return
         }
 
-        // concat derived prop "market" onto Trade e.g ETH-DAI
-        const tradesWithMarkets = newTrades.map(trade => {
-          const market = computeMarketProp({ sellToken: trade.sellToken, buyToken: trade.buyToken })
-          if (!market) return trade
-
-          return {
-            ...trade,
-            market,
-          }
-        })
-
         dispatch(
-          tradesWithMarkets.length > 0 || reverts.length > 0
-            ? appendTrades({ lastCheckedBlock: toBlock, networkId, userAddress, trades: tradesWithMarkets, reverts })
+          newTrades.length > 0 || reverts.length > 0
+            ? appendTrades({ lastCheckedBlock: toBlock, networkId, userAddress, trades: newTrades, reverts })
             : updateLastCheckedBlock({ lastCheckedBlock: toBlock, networkId, userAddress }),
         )
       }

--- a/src/utils/display.tsx
+++ b/src/utils/display.tsx
@@ -10,12 +10,31 @@ export function displayTokenSymbolOrLink(token: TokenDetails): React.ReactNode |
   return displayName
 }
 
+/**
+ * computeMarketProp
+ * @description returns array of potentially accepted market names by:: SELLTOKEN <SEPARATOR> BUYTOKEN
+ * @param { sellToken, buyToken, acceptedSeparators: string[] }
+ */
 export function computeMarketProp({
   sellToken,
   buyToken,
+  acceptedSeparators = ['-', '/', ' '],
+  inverseMarket = false,
 }: {
   sellToken: TokenDetails
   buyToken: TokenDetails
-}): string {
-  return `${safeTokenName(sellToken).toLowerCase()}-${safeTokenName(buyToken).toLowerCase()}`
+  acceptedSeparators?: string[]
+  inverseMarket?: boolean
+}): string[] {
+  const sellTokenFormatted = safeTokenName(sellToken).toLowerCase()
+  const buyTokenFormatted = safeTokenName(buyToken).toLowerCase()
+
+  const marketList = acceptedSeparators.map(sep => `${sellTokenFormatted}${sep}${buyTokenFormatted}`)
+
+  if (inverseMarket) {
+    const inverseMarketList = acceptedSeparators.map(sep => `${buyTokenFormatted}${sep}${sellTokenFormatted}`)
+    return marketList.concat(inverseMarketList)
+  }
+
+  return marketList
 }

--- a/src/utils/display.tsx
+++ b/src/utils/display.tsx
@@ -18,7 +18,7 @@ export function displayTokenSymbolOrLink(token: TokenDetails): React.ReactNode |
 export function computeMarketProp({
   sellToken,
   buyToken,
-  acceptedSeparators = ['-', '/', ' '],
+  acceptedSeparators = ['-', '/', ''],
   inverseMarket = false,
 }: {
   sellToken: TokenDetails

--- a/src/utils/display.tsx
+++ b/src/utils/display.tsx
@@ -16,8 +16,6 @@ export function computeMarketProp({
 }: {
   sellToken: TokenDetails
   buyToken: TokenDetails
-}): string | null {
-  if (!sellToken || !buyToken) return null
-
+}): string {
   return `${safeTokenName(sellToken).toLowerCase()}-${safeTokenName(buyToken).toLowerCase()}`
 }

--- a/src/utils/display.tsx
+++ b/src/utils/display.tsx
@@ -12,7 +12,7 @@ export function displayTokenSymbolOrLink(token: TokenDetails): React.ReactNode |
 
 /**
  * computeMarketProp
- * @description returns array of potentially accepted market names by:: SELLTOKEN <SEPARATOR> BUYTOKEN
+ * @description returns array of potentially accepted market names by:: BUYTOKEN <SEPARATOR> SELLTOKEN
  * @param { sellToken, buyToken, acceptedSeparators: string[] }
  */
 export function computeMarketProp({
@@ -26,13 +26,15 @@ export function computeMarketProp({
   acceptedSeparators?: string[]
   inverseMarket?: boolean
 }): string[] {
-  const sellTokenFormatted = safeTokenName(sellToken).toLowerCase()
   const buyTokenFormatted = safeTokenName(buyToken).toLowerCase()
+  const sellTokenFormatted = safeTokenName(sellToken).toLowerCase()
 
-  const marketList = acceptedSeparators.map(sep => `${sellTokenFormatted}${sep}${buyTokenFormatted}`)
+  // BUYTOKEN/SELLTOKEN
+  const marketList = acceptedSeparators.map(sep => `${buyTokenFormatted}${sep}${sellTokenFormatted}`)
 
   if (inverseMarket) {
-    const inverseMarketList = acceptedSeparators.map(sep => `${buyTokenFormatted}${sep}${sellTokenFormatted}`)
+    // SELLTOKEN/BUYTOKEN
+    const inverseMarketList = acceptedSeparators.map(sep => `${sellTokenFormatted}${sep}${buyTokenFormatted}`)
     return marketList.concat(inverseMarketList)
   }
 

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -1,5 +1,6 @@
 import { TokenDetails } from 'types'
 import { DetailedAuctionElement, Trade } from 'api/exchange/ExchangeApi'
+import { computeMarketProp } from './display'
 
 export function checkTokenAgainstSearch(token: TokenDetails | null, searchText: string): boolean {
   if (!token) return false
@@ -10,13 +11,15 @@ export function checkTokenAgainstSearch(token: TokenDetails | null, searchText: 
   )
 }
 
-export const filterOrdersFn = (searchTxt: string) => ({
+const filterTradesAndOrdersFnFactory = (includeInverseMarket?: boolean) => (searchTxt: string) => ({
   id,
   buyToken,
   sellToken,
-  market,
 }: Trade | DetailedAuctionElement): boolean | null => {
   if (searchTxt === '') return null
+
+  const market =
+    sellToken && buyToken && computeMarketProp({ sellToken, buyToken, inverseMarket: includeInverseMarket })
 
   return (
     !!id.includes(searchTxt) ||
@@ -25,3 +28,6 @@ export const filterOrdersFn = (searchTxt: string) => ({
     checkTokenAgainstSearch(sellToken, searchTxt)
   )
 }
+
+export const filterOrdersFn = filterTradesAndOrdersFnFactory(true)
+export const filterTradesFn = filterTradesAndOrdersFnFactory()


### PR DESCRIPTION
Closes #1118

Test:
1. head to /orders or on /trade
2. search via:
  a. WETH-TUSD
  b. WETH/TUSD
  c. WETH TUSD
  d. (`/orders` and/or `Active` | `Liquidity` | `Closed` tabs only): 
      i. WETH-TUSD (or variations with "/" or " ") and the inverse market too: TUSD-WETH

Query: <sellToken>[SEPARATOR]<buyToken>