### PR TITLE
Updating how we calculate whether a token is enabled.

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -31,6 +31,8 @@ export const ONE_HUNDRED_BIG_NUMBER = new BigNumber(100)
 // ∴ when the amount is < 5 the order will be considered filled.
 export const ORDER_FILLED_FACTOR = new BN(10000) // 0.01%
 
+export const MINIMUM_ALLOWANCE_DECIMALS = 12
+
 export const APP_NAME = 'fuse'
 
 export const ETHER_PNG =

--- a/src/hooks/useTokenBalances.ts
+++ b/src/hooks/useTokenBalances.ts
@@ -7,8 +7,7 @@ import { erc20Api, depositApi } from 'api'
 import useSafeState from './useSafeState'
 import { useWalletConnection } from './useWalletConnection'
 
-import { formatSmart, logDebug } from 'utils'
-import { ALLOWANCE_FOR_ENABLED_TOKEN } from 'const'
+import { formatSmart, logDebug, isTokenEnabled } from 'utils'
 import { TokenBalanceDetails, TokenDetails } from 'types'
 import { WalletInfo } from 'api/wallet/WalletApi'
 import { PendingFlux } from 'api/deposit/DepositApi'
@@ -60,7 +59,7 @@ async function fetchBalancesForToken(
     pendingWithdraw,
     claimable: pendingWithdraw.amount.isZero() ? false : pendingWithdraw.batchId < currentBatchId,
     walletBalance,
-    enabled: allowance.gt(ALLOWANCE_FOR_ENABLED_TOKEN),
+    enabled: isTokenEnabled(allowance, token),
   }
 }
 

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -1,8 +1,11 @@
+import BN from 'bn.js'
+
 import { TokenDetails, Unpromise } from 'types'
 import { AssertionError } from 'assert'
 import { AuctionElement } from 'api/exchange/ExchangeApi'
 import { batchIdToDate } from './time'
-import { ORDER_FILLED_FACTOR } from 'const'
+import { ORDER_FILLED_FACTOR, MINIMUM_ALLOWANCE_DECIMALS } from 'const'
+import { TEN } from '@gnosis.pm/dex-js'
 
 export function assertNonNull<T>(val: T, message: string): asserts val is NonNullable<T> {
   if (val === undefined || val === null) {
@@ -70,6 +73,11 @@ export const delay = <T>(ms = 100, result?: T): Promise<T> => new Promise(resolv
 export function getImageUrl(tokenAddress?: string): string | undefined {
   if (!tokenAddress) return undefined
   return `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/${tokenAddress}/logo.png`
+}
+
+export function isTokenEnabled(allowance: BN, { decimals = 18 }: TokenDetails): boolean {
+  const allowanceValue = TEN.pow(new BN(decimals + MINIMUM_ALLOWANCE_DECIMALS))
+  return allowance.gte(allowanceValue)
 }
 
 export function isOrderFilled(order: AuctionElement): boolean {


### PR DESCRIPTION
Instead of a hard value of max uint128, we now check
whether allowance is >= 10**(token.decimals + 12)

The assumption we had before did not hold for DMG token.
We set the allowance to maxint256, but on their contract the amount is downcast to utin128 (https://etherscan.io/address/0xed91879919b71bb6905f23af0a68d231ecf87b14#code)

So doesn't matter how many times the allowance is called, the UI still considers it as not enabled.

## Testing:

1. Enable DMG in mainnet https://dex.dev.gnosisdev.com
    Refresh the page.
    Should still show the `Enable` button.

2. Check DMG balance on https://pr1147--dexreact.review.gnosisdev.com/wallet
    Should show the `+` sign