### PR TITLE
Hotfix/1.0.4

### DIFF
--- a/src/components/TradeWidget/Price.tsx
+++ b/src/components/TradeWidget/Price.tsx
@@ -93,8 +93,6 @@ export const PriceInputBox = styled.div<{ hidden?: boolean }>`
 
   label > div:not(.radio-container) {
     position: absolute;
-    min-width: 7.7rem;
-    max-width: 10rem;
     right: 1rem;
     top: 0;
     bottom: 0;
@@ -116,14 +114,12 @@ export const PriceInputBox = styled.div<{ hidden?: boolean }>`
     }
     > small:not(:nth-child(2)) {
       font-size: inherit;
-      max-width: 47%;
+      max-width: 6ch;
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;
     }
     > small:nth-child(2) {
-      max-width: 10%;
-      min-width: min-content;
       margin: 0 0.3rem;
       font-size: 1rem;
     }
@@ -141,7 +137,7 @@ export const PriceInputBox = styled.div<{ hidden?: boolean }>`
     box-sizing: border-box;
     border-bottom: 0.2rem solid transparent;
     font-weight: var(--font-weight-normal);
-    padding: 0 11.1rem 0 1rem;
+    padding: 0 15ch 0 1rem;
     outline: 0;
 
     @media ${MEDIA.mobile} {


### PR DESCRIPTION
Switched to `zero character width` (`ch`) units for Token symbols length
In practice anything longer than `000000` will get elided...

![localhost_8080_trade_oETH%20%24100%20Put%2004%2F24%2F20-WETH_sell=0 price=0 00000 from= expires=2880](https://user-images.githubusercontent.com/5121491/85406524-9dfd3780-b56a-11ea-880e-882e18ba49c7.png)

![localhost_8080_trade_oETH%20%24100%20Put%2004%2F24%2F20-WETH_sell=0 price=0 00000 from= expires=2880 (1)](https://user-images.githubusercontent.com/5121491/85406609-ba00d900-b56a-11ea-89fc-ba9872adabd4.png)
