### PR TITLE
Substitute acc

### DIFF
--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -106,6 +106,28 @@ export const composeProvider = <T extends Provider>(
     ),
   )
 
+  if (process.env.NODE_ENV === 'development') {
+    // hack to be able to use interface as if from a different account
+    // read-only of course
+    // account will update on the next eth_accounts call
+    // normally on new block in a few seconds
+    engine.push(
+      createConditionalMiddleware(
+        req => req.method === 'eth_accounts',
+        (_req, res) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          if ((window as any).__acc) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            res.result = [(window as any).__acc]
+            return true
+          }
+
+          return false
+        },
+      ),
+    )
+  }
+
   engine.push(
     createConditionalMiddleware<TransactionConfig[]>(
       req => req.method === 'eth_sendTransaction',

--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -111,14 +111,15 @@ export const composeProvider = <T extends Provider>(
     // read-only of course
     // account will update on the next eth_accounts call
     // normally on new block in a few seconds
+
+    let substituteAccount = ''
+
     engine.push(
       createConditionalMiddleware(
         req => req.method === 'eth_accounts',
         (_req, res) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          if ((window as any).__acc) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            res.result = [(window as any).__acc]
+          if (substituteAccount) {
+            res.result = [substituteAccount]
             return true
           }
 
@@ -126,6 +127,10 @@ export const composeProvider = <T extends Provider>(
         },
       ),
     )
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).loginAs = (address: string): void => {
+      substituteAccount = address
+    }
   }
 
   engine.push(


### PR DESCRIPTION
Hack for easier debugging from an arbitrary account's perspective

`window.loginAs('0x1234ef...')` to enable for account
call `window.loginAs('')` with anything falsy to disable

Read-only access obviously, no sending txs.
Development only.