### PR TITLE
fix ordervalidity input sanitzation when ASAP/Unlimited

### DIFF
--- a/src/components/TradeWidget/OrderValidity.tsx
+++ b/src/components/TradeWidget/OrderValidity.tsx
@@ -266,14 +266,18 @@ const OrderValidity: React.FC<Props> = ({
   const handleShowConfig = useCallback((): void => {
     if (showOrderConfig) {
       // sanitize inputs as multiples of 5
-      const sanitizedFromValue = makeMultipleOf(5, validFromInputValue).toString()
-      const sanitizedUntilValue = makeMultipleOf(5, validUntilInputValue).toString()
+      const sanitizedFromValue = makeMultipleOf(5, validFromInputValue)
+      const sanitizedUntilValue = makeMultipleOf(5, validUntilInputValue)
 
       batchedUpdates(() => {
-        if (!sanitizedFromValue) setAsap(true)
-        if (!sanitizedUntilValue) setUnlimited(true)
-        setValue(validFromInputId, sanitizedFromValue, true)
-        setValue(validUntilInputId, sanitizedUntilValue, true)
+        if (!sanitizedFromValue || !sanitizedUntilValue) {
+          !sanitizedFromValue
+            ? (setAsap(true), setValue(validFromInputId, undefined, true))
+            : setValue(validFromInputId, sanitizedFromValue.toString(), true)
+          !sanitizedUntilValue
+            ? (setUnlimited(true), setValue(validUntilInputId, undefined, true))
+            : setValue(validUntilInputId, sanitizedUntilValue.toString(), true)
+        }
       })
     }
 

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -1,7 +1,7 @@
 import { useLocation } from 'react-router'
 import { useMemo } from 'react'
 import { sanitizeInput, sanitizeNegativeAndMakeMultipleOf } from 'utils'
-import { DEFAULT_FORM_STATE } from 'components/TradeWidget'
+// import { DEFAULT_FORM_STATE } from 'components/TradeWidget'
 
 export function useQuery(): { sellAmount: string; price: string; validFrom?: string; validUntil?: string } {
   const { search } = useLocation()
@@ -13,7 +13,7 @@ export function useQuery(): { sellAmount: string; price: string; validFrom?: str
       sellAmount: sanitizeInput(query.get('sell')),
       price: sanitizeInput(query.get('price')),
       validFrom: Number(query.get('from')) ? sanitizeNegativeAndMakeMultipleOf(query.get('from')) : undefined,
-      validUntil: sanitizeNegativeAndMakeMultipleOf(query.get('expires'), DEFAULT_FORM_STATE.validUntil ?? ''),
+      validUntil: Number(query.get('from')) ? sanitizeNegativeAndMakeMultipleOf(query.get('expires')) : undefined,
     }
   }, [search])
 }

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -1,7 +1,6 @@
 import { useLocation } from 'react-router'
 import { useMemo } from 'react'
 import { sanitizeInput, sanitizeNegativeAndMakeMultipleOf } from 'utils'
-// import { DEFAULT_FORM_STATE } from 'components/TradeWidget'
 
 export function useQuery(): { sellAmount: string; price: string; validFrom?: string; validUntil?: string } {
   const { search } = useLocation()


### PR DESCRIPTION
Closes #1131 

Some changes somewhere changed the modal closing behaviour and was sanitising `undefined` values indicating `ASAP` or `Never` ending orders back to `0` which fail form validity checks

To test: in url remove either or both `from=` &/or `expire=` or set as shown and check order submits. Also click the gear icon to set custom times and try clicking ASAP and/or Never - modal should close no problemo