### PR TITLE
1163/non intrusive price suggestion

### DIFF
--- a/src/components/TradeWidget/Price.tsx
+++ b/src/components/TradeWidget/Price.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback } from 'react'
 import styled from 'styled-components'
 import { useFormContext } from 'react-hook-form'
 import { invertPrice } from '@gnosis.pm/dex-js'
@@ -175,6 +175,8 @@ interface Props {
   priceInputId: string
   priceInverseInputId: string
   tabIndex?: number
+  swapPrices: () => void
+  priceShown: 'INVERSE' | 'DIRECT'
 }
 
 export function invertPriceFromString(priceValue: string): string {
@@ -182,14 +184,16 @@ export function invertPriceFromString(priceValue: string): string {
   return price ? invertPrice(price).toString(10) : ''
 }
 
-const Price: React.FC<Props> = ({ sellToken, receiveToken, priceInputId, priceInverseInputId, tabIndex }) => {
+const Price: React.FC<Props> = ({
+  sellToken,
+  receiveToken,
+  priceInputId,
+  priceInverseInputId,
+  tabIndex,
+  swapPrices,
+  priceShown,
+}) => {
   const { register, errors, setValue } = useFormContext<TradeFormData>()
-
-  const [priceShown, setPriceShown] = useState<'INVERSE' | 'DIRECT'>('INVERSE')
-
-  const swapPrices = (): void => {
-    setPriceShown(oldPrice => (oldPrice === 'DIRECT' ? 'INVERSE' : 'DIRECT'))
-  }
 
   const errorPrice = errors[priceInputId]
   const errorPriceInverse = errors[priceInverseInputId]

--- a/src/components/TradeWidget/Price.tsx
+++ b/src/components/TradeWidget/Price.tsx
@@ -3,9 +3,6 @@ import styled from 'styled-components'
 import { useFormContext } from 'react-hook-form'
 import { invertPrice } from '@gnosis.pm/dex-js'
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faRetweet } from '@fortawesome/free-solid-svg-icons'
-
 // types, utils
 import { TokenDetails } from 'types'
 import { parseBigNumber } from 'utils'
@@ -18,6 +15,7 @@ import { OrderBookBtn } from 'components/OrderBookBtn'
 import { TradeFormData } from 'components/TradeWidget'
 import FormMessage, { FormInputError } from 'components/TradeWidget/FormMessage'
 import { useNumberInput } from 'components/TradeWidget/useNumberInput'
+import { SwapIcon } from 'components/TradeWidget/SwapIcon'
 
 const Wrapper = styled.div`
   display: flex;
@@ -72,11 +70,6 @@ export const PriceInputBox = styled.div<{ hidden?: boolean }>`
   @media ${MEDIA.mobile} {
     width: 100%;
     margin: 0 0 1.6rem;
-  }
-
-  .swap-icon {
-    padding: 0.7em 0.3em;
-    cursor: pointer;
   }
 
   label {
@@ -254,9 +247,7 @@ const Price: React.FC<Props> = ({
             <small title={receiveToken.symbol}>{receiveToken.symbol}</small>
             <small>per</small>
             <small title={sellToken.symbol}>{sellToken.symbol}</small>
-            <span className="swap-icon" onClick={swapPrices}>
-              <FontAwesomeIcon icon={faRetweet} />
-            </span>
+            <SwapIcon swap={swapPrices} />
           </div>
         </label>
         <FormInputError errorMessage={errorPrice?.message} />
@@ -278,9 +269,7 @@ const Price: React.FC<Props> = ({
             <small title={sellToken.symbol}>{sellToken.symbol}</small>
             <small>per</small>
             <small title={receiveToken.symbol}>{receiveToken.symbol}</small>
-            <span className="swap-icon" onClick={swapPrices}>
-              <FontAwesomeIcon icon={faRetweet} />
-            </span>
+            <SwapIcon swap={swapPrices} />
           </div>
         </label>
         <FormInputError errorMessage={errorPriceInverse?.message} />

--- a/src/components/TradeWidget/Price.tsx
+++ b/src/components/TradeWidget/Price.tsx
@@ -174,7 +174,12 @@ interface Props {
 
 export function invertPriceFromString(priceValue: string): string {
   const price = parseBigNumber(priceValue)
-  return price ? invertPrice(price).toString(10) : ''
+  if (!price) {
+    return ''
+  }
+  const invertedPrice = invertPrice(price)
+  // To avoid `Infinity` on price inputs
+  return invertedPrice.isFinite() ? invertedPrice.toString(10) : '0'
 }
 
 const Price: React.FC<Props> = ({

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -14,6 +14,7 @@ import Spinner from 'components/Spinner'
 
 import { TradeFormData } from 'components/TradeWidget'
 import { SwapIcon } from 'components/TradeWidget/SwapIcon'
+import { HelpTooltip, HelpTooltipContainer } from 'components/Tooltip'
 
 const Wrapper = styled.div`
   > strong {
@@ -87,6 +88,14 @@ function formatPriceToPrecision(price: BigNumber): string {
   return price.toFixed(PRICE_ESTIMATION_PRECISION)
 }
 
+const OnchainOrderbookTooltip = (
+  <HelpTooltipContainer>
+    Based on existing Onchain orders, taking into account possible ring trades. <br />
+    Price is affected by sell amount. <br />
+    Higher amounts might yield worse prices, or no price at all, considering what&apos;s available in the current batch.
+  </HelpTooltipContainer>
+)
+
 const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationProps> = props => {
   const { networkId, amount, baseToken, quoteToken, isPriceInverted, updatePrices, swapPrices } = props
   const { id: baseTokenId, decimals: baseTokenDecimals } = baseToken
@@ -116,7 +125,7 @@ const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationP
   return (
     <>
       <span>
-        Onchain orderbook price for selling{' '}
+        Onchain orderbook price <HelpTooltip tooltip={OnchainOrderbookTooltip} /> for selling{' '}
         <strong>
           {+amount || '1'} {displayTokenSymbolOrLink(quoteToken)}
         </strong>

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -92,8 +92,7 @@ const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationP
         Onchain orderbook price for selling <strong>{amount || '1'}</strong> {displayTokenSymbolOrLink(quoteToken)}:
       </span>
       <button disabled={isPriceLoading || displayPrice === 'N/A'} onClick={updatePrice(price, invertedPrice)}>
-        {isPriceLoading && <Spinner />}
-        {displayPrice}
+        {isPriceLoading ? <Spinner /> : displayPrice}
       </button>
       <small>
         {displayTokenSymbolOrLink(displayBaseToken)}/{displayTokenSymbolOrLink(displayQuoteToken)}

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -24,7 +24,7 @@ interface PriceEstimationsProps {
 }
 
 export const PriceEstimations: React.FC<PriceEstimationsProps> = props => {
-  const { isPriceInverted, priceInputId, priceInverseInputId } = props
+  const { amount, isPriceInverted, priceInputId, priceInverseInputId } = props
 
   const { setValue } = useFormContext<TradeFormData>()
 
@@ -45,7 +45,9 @@ export const PriceEstimations: React.FC<PriceEstimationsProps> = props => {
     <div>
       <strong>Price suggestions</strong>
       <OnchainOrderbookPriceEstimation {...props} amount="" updatePrices={updatePrices} />
-      <OnchainOrderbookPriceEstimation {...props} updatePrices={updatePrices} />
+      {amount && +amount != 0 && +amount != 1 && (
+        <OnchainOrderbookPriceEstimation {...props} updatePrices={updatePrices} />
+      )}
     </div>
   )
 }

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react'
+import styled from 'styled-components'
 import { useFormContext } from 'react-hook-form'
 import BigNumber from 'bignumber.js'
 
@@ -12,6 +13,28 @@ import { displayTokenSymbolOrLink } from 'utils/display'
 import Spinner from 'components/Spinner'
 
 import { TradeFormData } from 'components/TradeWidget'
+
+const Wrapper = styled.div`
+  > strong {
+    text-transform: capitalize;
+    margin: 0 0 1rem;
+    font-size: 1.5rem;
+    box-sizing: border-box;
+    display: block;
+  }
+
+  .container {
+    display: grid;
+    grid-template-columns: 4fr 1fr 1fr;
+    gap: 0.25rem;
+    font-size: 1.25rem;
+    align-items: center;
+
+    > small {
+      justify-self: end;
+    }
+  }
+`
 
 interface PriceEstimationsProps {
   networkId: number
@@ -42,13 +65,15 @@ export const PriceEstimations: React.FC<PriceEstimationsProps> = props => {
   )
 
   return (
-    <div>
+    <Wrapper>
       <strong>Price suggestions</strong>
-      <OnchainOrderbookPriceEstimation {...props} amount="" updatePrices={updatePrices} />
-      {amount && +amount != 0 && +amount != 1 && (
-        <OnchainOrderbookPriceEstimation {...props} updatePrices={updatePrices} />
-      )}
-    </div>
+      <div className="container">
+        <OnchainOrderbookPriceEstimation {...props} amount="" updatePrices={updatePrices} />
+        {amount && +amount != 0 && +amount != 1 && (
+          <OnchainOrderbookPriceEstimation {...props} updatePrices={updatePrices} />
+        )}
+      </div>
+    </Wrapper>
   )
 }
 
@@ -87,11 +112,13 @@ const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationP
   const displayQuoteToken = !isPriceInverted ? quoteToken : baseToken
 
   return (
-    <div
-      style={{ display: 'flex', justifyContent: 'space-between', padding: '0.1em 0 0.1em 0.5em', fontSize: '1.2rem' }}
-    >
+    <>
       <span>
-        Onchain orderbook price for selling <strong>{+amount || '1'}</strong> {displayTokenSymbolOrLink(quoteToken)}:
+        Onchain orderbook price for selling{' '}
+        <strong>
+          {+amount || '1'} {displayTokenSymbolOrLink(quoteToken)}
+        </strong>
+        :
       </span>
       <button disabled={isPriceLoading || displayPrice === 'N/A'} onClick={updatePrice(price, invertedPrice)}>
         {isPriceLoading ? <Spinner /> : displayPrice}
@@ -99,6 +126,6 @@ const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationP
       <small>
         {displayTokenSymbolOrLink(displayBaseToken)}/{displayTokenSymbolOrLink(displayQuoteToken)}
       </small>
-    </div>
+    </>
   )
 }

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -75,18 +75,23 @@ const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationP
     : '0'
   const displayPrice = price === 'Infinity' || invertedPrice === 'Infinity' ? 'N/A' : price
 
+  const displayBaseToken = isPriceInverted ? quoteToken : baseToken
+  const displayQuoteToken = !isPriceInverted ? quoteToken : baseToken
+
   return (
     <div
-      style={{ display: 'flex', justifyContent: 'space-between', padding: '0.1em 0 0.1em 0.5em', fontSize: '1.4rem' }}
+      style={{ display: 'flex', justifyContent: 'space-between', padding: '0.1em 0 0.1em 0.5em', fontSize: '1.2rem' }}
     >
       <span>
-        Onchain orderbook price for <strong>{amount || '1'}</strong>{' '}
-        {displayTokenSymbolOrLink(isPriceInverted ? baseToken : quoteToken)}:
+        Onchain orderbook price for selling <strong>{amount || '1'}</strong> {displayTokenSymbolOrLink(quoteToken)}:
       </span>
       <button disabled={isPriceLoading || displayPrice === 'N/A'} onClick={updatePrice(price, invertedPrice)}>
         {isPriceLoading && <Spinner />}
         {displayPrice}
       </button>
+      <small>
+        {displayTokenSymbolOrLink(displayBaseToken)}/{displayTokenSymbolOrLink(displayQuoteToken)}
+      </small>
     </div>
   )
 }

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react'
 import { useFormContext } from 'react-hook-form'
+import BigNumber from 'bignumber.js'
 
 import { TokenDetails, invertPrice } from '@gnosis.pm/dex-js'
 
@@ -53,6 +54,10 @@ interface OnchainOrderbookPriceEstimationProps extends Omit<PriceEstimationsProp
   updatePrice: (price: string, invertedPrice: string) => () => void
 }
 
+function formatPriceToPrecision(price: BigNumber): string {
+  return price.toFixed(PRICE_ESTIMATION_PRECISION)
+}
+
 const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationProps> = props => {
   const { networkId, amount, baseToken, quoteToken, isPriceInverted, updatePrice } = props
   const { id: baseTokenId, decimals: baseTokenDecimals } = baseToken
@@ -67,12 +72,13 @@ const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationP
     quoteTokenDecimals,
   })
 
-  const price = priceEstimation
-    ? (isPriceInverted ? invertPrice(priceEstimation) : priceEstimation).toFixed(PRICE_ESTIMATION_PRECISION)
-    : '0'
-  const invertedPrice = priceEstimation
-    ? (!isPriceInverted ? invertPrice(priceEstimation) : priceEstimation).toFixed(PRICE_ESTIMATION_PRECISION)
-    : '0'
+  let price = 'N/A'
+  let invertedPrice = 'N/A'
+
+  if (priceEstimation) {
+    price = formatPriceToPrecision(isPriceInverted ? invertPrice(priceEstimation) : priceEstimation)
+    invertedPrice = formatPriceToPrecision(!isPriceInverted ? invertPrice(priceEstimation) : priceEstimation)
+  }
   const displayPrice = price === 'Infinity' || invertedPrice === 'Infinity' ? 'N/A' : price
 
   const displayBaseToken = isPriceInverted ? quoteToken : baseToken

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -101,6 +101,11 @@ const OnchainOrderbookTooltip = (
   </HelpTooltipContainer>
 )
 
+const HighlightedText = styled.span`
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+`
+
 const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationProps> = props => {
   const { networkId, amount, baseToken, quoteToken, isPriceInverted, updatePrices, swapPrices } = props
   const { id: baseTokenId, decimals: baseTokenDecimals } = baseToken
@@ -130,7 +135,8 @@ const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationP
   return (
     <>
       <span>
-        Onchain orderbook price <HelpTooltip tooltip={OnchainOrderbookTooltip} /> for selling{' '}
+        <HighlightedText>Onchain orderbook price</HighlightedText> <HelpTooltip tooltip={OnchainOrderbookTooltip} /> for
+        selling{' '}
         <strong>
           {+amount || '1'} {displayTokenSymbolOrLink(quoteToken)}
         </strong>

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -93,6 +93,11 @@ const OnchainOrderbookTooltip = (
     Based on existing Onchain orders, taking into account possible ring trades. <br />
     Price is affected by sell amount. <br />
     Higher amounts might yield worse prices, or no price at all, considering what&apos;s available in the current batch.
+    <br />
+    <a href="https://docs.gnosis.io/protocol/docs/introduction1/" rel="noopener noreferrer" target="_blank">
+      More details
+    </a>
+    .
   </HelpTooltipContainer>
 )
 

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -28,7 +28,7 @@ export const PriceEstimations: React.FC<PriceEstimationsProps> = props => {
 
   const { setValue } = useFormContext<TradeFormData>()
 
-  const updatePrice = useCallback(
+  const updatePrices = useCallback(
     (price: string, invertedPrice) => (): void => {
       if (!isPriceInverted) {
         setValue(priceInputId, price)
@@ -44,14 +44,14 @@ export const PriceEstimations: React.FC<PriceEstimationsProps> = props => {
   return (
     <div>
       <strong>Price suggestions</strong>
-      <OnchainOrderbookPriceEstimation {...props} amount="" updatePrice={updatePrice} />
-      <OnchainOrderbookPriceEstimation {...props} updatePrice={updatePrice} />
+      <OnchainOrderbookPriceEstimation {...props} amount="" updatePrices={updatePrices} />
+      <OnchainOrderbookPriceEstimation {...props} updatePrices={updatePrices} />
     </div>
   )
 }
 
 interface OnchainOrderbookPriceEstimationProps extends Omit<PriceEstimationsProps, 'inputId'> {
-  updatePrice: (price: string, invertedPrice: string) => () => void
+  updatePrices: (price: string, invertedPrice: string) => () => void
 }
 
 function formatPriceToPrecision(price: BigNumber): string {
@@ -59,7 +59,7 @@ function formatPriceToPrecision(price: BigNumber): string {
 }
 
 const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationProps> = props => {
-  const { networkId, amount, baseToken, quoteToken, isPriceInverted, updatePrice } = props
+  const { networkId, amount, baseToken, quoteToken, isPriceInverted, updatePrices: updatePrice } = props
   const { id: baseTokenId, decimals: baseTokenDecimals } = baseToken
   const { id: quoteTokenId, decimals: quoteTokenDecimals } = quoteToken
 

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -13,6 +13,7 @@ import { displayTokenSymbolOrLink } from 'utils/display'
 import Spinner from 'components/Spinner'
 
 import { TradeFormData } from 'components/TradeWidget'
+import { SwapIcon } from 'components/TradeWidget/SwapIcon'
 
 const Wrapper = styled.div`
   > strong {
@@ -44,6 +45,7 @@ interface PriceEstimationsProps {
   isPriceInverted: boolean
   priceInputId: string
   priceInverseInputId: string
+  swapPrices: () => void
 }
 
 export const PriceEstimations: React.FC<PriceEstimationsProps> = props => {
@@ -86,7 +88,7 @@ function formatPriceToPrecision(price: BigNumber): string {
 }
 
 const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationProps> = props => {
-  const { networkId, amount, baseToken, quoteToken, isPriceInverted, updatePrices: updatePrice } = props
+  const { networkId, amount, baseToken, quoteToken, isPriceInverted, updatePrices, swapPrices } = props
   const { id: baseTokenId, decimals: baseTokenDecimals } = baseToken
   const { id: quoteTokenId, decimals: quoteTokenDecimals } = quoteToken
 
@@ -120,11 +122,12 @@ const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationP
         </strong>
         :
       </span>
-      <button disabled={isPriceLoading || displayPrice === 'N/A'} onClick={updatePrice(price, invertedPrice)}>
+      <button disabled={isPriceLoading || displayPrice === 'N/A'} onClick={updatePrices(price, invertedPrice)}>
         {isPriceLoading ? <Spinner /> : displayPrice}
       </button>
       <small>
         {displayTokenSymbolOrLink(displayBaseToken)}/{displayTokenSymbolOrLink(displayQuoteToken)}
+        <SwapIcon swap={swapPrices} />
       </small>
     </>
   )

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -91,7 +91,7 @@ const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationP
       style={{ display: 'flex', justifyContent: 'space-between', padding: '0.1em 0 0.1em 0.5em', fontSize: '1.2rem' }}
     >
       <span>
-        Onchain orderbook price for selling <strong>{amount || '1'}</strong> {displayTokenSymbolOrLink(quoteToken)}:
+        Onchain orderbook price for selling <strong>{+amount || '1'}</strong> {displayTokenSymbolOrLink(quoteToken)}:
       </span>
       <button disabled={isPriceLoading || displayPrice === 'N/A'} onClick={updatePrice(price, invertedPrice)}>
         {isPriceLoading ? <Spinner /> : displayPrice}

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -122,7 +122,11 @@ const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationP
         </strong>
         :
       </span>
-      <button disabled={isPriceLoading || displayPrice === 'N/A'} onClick={updatePrices(price, invertedPrice)}>
+      <button
+        type="button"
+        disabled={isPriceLoading || displayPrice === 'N/A'}
+        onClick={updatePrices(price, invertedPrice)}
+      >
         {isPriceLoading ? <Spinner /> : displayPrice}
       </button>
       <small>

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -1,0 +1,89 @@
+import React, { useCallback } from 'react'
+import { useFormContext } from 'react-hook-form'
+import BigNumber from 'bignumber.js'
+
+import { TokenDetails, invertPrice } from '@gnosis.pm/dex-js'
+
+import { usePriceEstimationWithSlippage } from 'hooks/usePriceEstimation'
+
+import { PRICE_ESTIMATION_PRECISION } from 'const'
+import { displayTokenSymbolOrLink } from 'utils/display'
+
+import Spinner from 'components/Spinner'
+
+import { TradeFormData } from 'components/TradeWidget'
+
+interface PriceEstimationsProps {
+  networkId: number
+  baseToken: TokenDetails
+  quoteToken: TokenDetails
+  amount: string
+  isPriceInverted: boolean
+  priceInputId: string
+  priceInverseInputId: string
+}
+
+export const PriceEstimations: React.FC<PriceEstimationsProps> = props => {
+  const { isPriceInverted, priceInputId, priceInverseInputId } = props
+
+  const { setValue } = useFormContext<TradeFormData>()
+
+  const updatePrice = useCallback(
+    (price: string) => (): void => {
+      if (!isPriceInverted) {
+        setValue(priceInputId, price)
+        setValue(priceInverseInputId, invertPrice(new BigNumber(price)).toFixed(PRICE_ESTIMATION_PRECISION))
+      } else {
+        setValue(priceInverseInputId, price)
+        setValue(priceInputId, invertPrice(new BigNumber(price)).toFixed(PRICE_ESTIMATION_PRECISION))
+      }
+    },
+    [isPriceInverted, setValue, priceInputId, priceInverseInputId],
+  )
+
+  return (
+    <div>
+      <strong>Price suggestions</strong>
+      <OnchainOrderbookPriceEstimation {...props} amount="" updatePrice={updatePrice} />
+      <OnchainOrderbookPriceEstimation {...props} updatePrice={updatePrice} />
+    </div>
+  )
+}
+
+interface OnchainOrderbookPriceEstimationProps extends Omit<PriceEstimationsProps, 'inputId'> {
+  updatePrice: (price: string) => () => void
+}
+
+const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationProps> = props => {
+  const { networkId, amount, baseToken, quoteToken, isPriceInverted, updatePrice } = props
+  const { id: baseTokenId, decimals: baseTokenDecimals } = baseToken
+  const { id: quoteTokenId, decimals: quoteTokenDecimals } = quoteToken
+
+  const { priceEstimation, isPriceLoading } = usePriceEstimationWithSlippage({
+    networkId,
+    amount,
+    baseTokenId,
+    baseTokenDecimals,
+    quoteTokenId,
+    quoteTokenDecimals,
+  })
+
+  const displayPrice = priceEstimation
+    ? (isPriceInverted ? invertPrice(priceEstimation) : priceEstimation).toFixed(PRICE_ESTIMATION_PRECISION)
+    : '0'
+
+  return (
+    <div
+      style={{ display: 'flex', justifyContent: 'space-between', padding: '0.1em 0 0.1em 0.5em', fontSize: '1.4rem' }}
+    >
+      <span>
+        Onchain orderbook price for <strong>{amount || '1'}</strong>{' '}
+        {displayTokenSymbolOrLink(isPriceInverted ? baseToken : quoteToken)}:
+      </span>
+      <button disabled={isPriceLoading} onClick={updatePrice(displayPrice)}>
+        {isPriceLoading && <Spinner />}
+        {displayPrice}
+      </button>
+    </div>
+  )
+}

--- a/src/components/TradeWidget/SwapIcon.tsx
+++ b/src/components/TradeWidget/SwapIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import styled from 'styled-components'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faRetweet } from '@fortawesome/free-solid-svg-icons'
+
+const Wrapper = styled.span`
+  padding: 0.7em 0.3em;
+  cursor: pointer;
+`
+
+interface Props {
+  swap: () => void
+}
+
+export const SwapIcon: React.FC<Props> = ({ swap }) => {
+  return (
+    <Wrapper onClick={swap}>
+      <FontAwesomeIcon icon={faRetweet} />
+    </Wrapper>
+  )
+}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -505,9 +505,7 @@ const TradeWidget: React.FC = () => {
 
   const [priceShown, setPriceShown] = useState<'INVERSE' | 'DIRECT'>('INVERSE')
 
-  const swapPrices = (): void => {
-    setPriceShown(oldPrice => (oldPrice === 'DIRECT' ? 'INVERSE' : 'DIRECT'))
-  }
+  const swapPrices = (): void => setPriceShown(oldPrice => (oldPrice === 'DIRECT' ? 'INVERSE' : 'DIRECT'))
 
   const defaultFormValues: TradeFormData = {
     [sellInputId]: defaultSellAmount,

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -510,6 +510,12 @@ const TradeWidget: React.FC = () => {
   const defaultValidFrom = trade.validFrom || validFromParam
   const defaultValidUntil = trade.validUntil || validUntilParam
 
+  const [priceShown, setPriceShown] = useState<'INVERSE' | 'DIRECT'>('INVERSE')
+
+  const swapPrices = (): void => {
+    setPriceShown(oldPrice => (oldPrice === 'DIRECT' ? 'INVERSE' : 'DIRECT'))
+  }
+
   const defaultFormValues: TradeFormData = {
     [sellInputId]: defaultSellAmount,
     [receiveInputId]: '',
@@ -979,6 +985,8 @@ const TradeWidget: React.FC = () => {
             sellToken={sellToken}
             receiveToken={receiveToken}
             tabIndex={1}
+            swapPrices={swapPrices}
+            priceShown={priceShown}
           />
           <OrderValidity
             validFromInputId={validFromId}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react'
+import React, { useState, useMemo, useCallback, useEffect } from 'react'
 import { unstable_batchedUpdates as batchUpdateState } from 'react-dom'
 import { useForm, FormContext } from 'react-hook-form'
 import { useParams } from 'react-router'
@@ -9,13 +9,23 @@ import Modali from 'modali'
 import BN from 'bn.js'
 import { isAddress } from 'web3-utils'
 
+import { encodeTokenSymbol, decodeSymbol } from '@gnosis.pm/dex-js'
+
 // assets
 import { SwitcherSVG } from 'assets/img/SVG'
 import arrow from 'assets/img/arrow.svg'
 
 // const, types
-import { MEDIA, PRICE_ESTIMATION_PRECISION, PRICE_ESTIMATION_DEBOUNCE_TIME } from 'const'
+import { ZERO } from 'const'
+import { MEDIA, PRICE_ESTIMATION_DEBOUNCE_TIME } from 'const'
 import { TokenDetails, Network } from 'types'
+
+// utils
+import { getToken, parseAmount, parseBigNumber, dateToBatchId, resolverFactory, formatTimeToFromBatch } from 'utils'
+
+// api
+import { PendingTxObj } from 'api/exchange/ExchangeApi'
+import { tokenListApi } from 'api'
 
 // components
 import Widget from 'components/Layout/Widget'
@@ -29,6 +39,9 @@ import { Spinner } from 'components/Spinner'
 import TokenRow from 'components/TradeWidget/TokenRow'
 import OrderValidity from 'components/TradeWidget/OrderValidity'
 import FormMessage from 'components/TradeWidget/FormMessage'
+import { PriceEstimations } from 'components/TradeWidget/PriceEstimations'
+import validationSchema from 'components/TradeWidget/validationSchema'
+import Price, { invertPriceFromString } from 'components/TradeWidget/Price'
 
 // hooks and reducers
 import useURLParams from 'hooks/useURLParams'
@@ -38,30 +51,10 @@ import { usePlaceOrder } from 'hooks/usePlaceOrder'
 import { useQuery, buildSearchQuery } from 'hooks/useQuery'
 import { useDebounce } from 'hooks/useDebounce'
 import useGlobalState from 'hooks/useGlobalState'
-import { savePendingOrdersAction } from 'reducers-actions/pendingOrders'
-
-import {
-  getToken,
-  parseAmount,
-  parseBigNumber,
-  dateToBatchId,
-  logDebug,
-  resolverFactory,
-  formatTimeToFromBatch,
-} from 'utils'
-
-import { ZERO } from 'const'
-
-import Price, { invertPriceFromString } from './Price'
 import { useConnectWallet } from 'hooks/useConnectWallet'
-import { PendingTxObj } from 'api/exchange/ExchangeApi'
-import { usePriceEstimationWithSlippage } from 'hooks/usePriceEstimation'
-import { updateTradeState } from 'reducers-actions/trade'
-import { tokenListApi } from 'api'
-
-import validationSchema from './validationSchema'
 import { useBetterAddTokenModal } from 'hooks/useBetterAddTokenModal'
-import { encodeTokenSymbol, decodeSymbol } from '@gnosis.pm/dex-js'
+import { savePendingOrdersAction } from 'reducers-actions/pendingOrders'
+import { updateTradeState } from 'reducers-actions/trade'
 
 import { DevTool } from 'HookFormDevtool'
 
@@ -597,15 +590,6 @@ const TradeWidget: React.FC = () => {
   // Avoid querying for a new price at every input change
   const { value: debouncedSellValue } = useDebounce(sellValue, PRICE_ESTIMATION_DEBOUNCE_TIME)
 
-  const { priceEstimation, isPriceLoading } = usePriceEstimationWithSlippage({
-    networkId: networkIdOrDefault,
-    baseTokenId: receiveToken.id,
-    baseTokenDecimals: receiveToken.decimals,
-    quoteTokenId: sellToken.id,
-    quoteTokenDecimals: sellToken.decimals,
-    amount: debouncedSellValue,
-  })
-
   // Updating global trade state on change
   useEffect(() => {
     dispatch(
@@ -619,37 +603,6 @@ const TradeWidget: React.FC = () => {
       }),
     )
   }, [dispatch, priceValue, sellValue, sellToken, receiveToken, validFromValue, validUntilValue])
-
-  const initialPrice = useRef(defaultPrice)
-
-  useEffect(() => {
-    // We DON'T want to use the price estimation when the page is being loaded with a price in the URL.
-    // For example when sharing the URL or when filling in from Telegram bot suggestions
-    // We DO want to use price estimation when there's no price coming from the URL
-    const shouldUsePriceEstimation = !initialPrice.current || +initialPrice.current === 0
-
-    // Only try to update price estimation when not loading
-    if (!isPriceLoading) {
-      // If there was a price set coming from the URL, reset it
-      // It was supposed to be used only once. Initial price doesn't matter anymore
-      if (initialPrice.current) {
-        initialPrice.current = ''
-      }
-
-      logDebug(`[TradeWidget] priceEstimation ${priceEstimation}`)
-
-      if (shouldUsePriceEstimation) {
-        // Price estimation can be null. In that case, set the input to 0
-        const newPrice = priceEstimation ? priceEstimation.toFixed(PRICE_ESTIMATION_PRECISION) : '0'
-
-        setValue(priceInputId, newPrice)
-        setValue(priceInverseInputId, invertPriceFromString(newPrice))
-
-        setValue(receiveInputId, calculateReceiveAmount(priceValue, sellValue))
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [priceEstimation, isPriceLoading])
 
   // Update receive amount
   useEffect(() => {
@@ -987,6 +940,15 @@ const TradeWidget: React.FC = () => {
             tabIndex={1}
             swapPrices={swapPrices}
             priceShown={priceShown}
+          />
+          <PriceEstimations
+            networkId={networkIdOrDefault}
+            baseToken={receiveToken}
+            quoteToken={sellToken}
+            amount={debouncedSellValue}
+            isPriceInverted={priceShown === 'INVERSE'}
+            priceInputId={priceInputId}
+            priceInverseInputId={priceInverseInputId}
           />
           <OrderValidity
             validFromInputId={validFromId}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -62,7 +62,7 @@ const WrappedWidget = styled(Widget)`
   overflow-x: visible;
   min-width: 0;
   margin: 0 auto;
-  height: 63rem;
+  height: 75rem;
   width: auto;
   flex-flow: row nowrap;
   display: flex;

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -947,6 +947,7 @@ const TradeWidget: React.FC = () => {
             isPriceInverted={priceShown === 'INVERSE'}
             priceInputId={priceInputId}
             priceInverseInputId={priceInverseInputId}
+            swapPrices={swapPrices}
           />
           <OrderValidity
             validFromInputId={validFromId}


### PR DESCRIPTION
## Update July 2

- Added swap icon
- No longer showing `infinity` prices
- Added tooltip. Please validate text contents:
![screenshot_2020-07-02_13-53-28](https://user-images.githubusercontent.com/43217/86408316-a12fac00-bc6b-11ea-9775-51f7bde9359c.png)


## Update Jun 30

- Did a minimal styling, properly aligning things and matching other parts of the app
- Adjusted widget height to fit the new entry
- No longer displaying `infinity` for bad prices. Using `N/A` instead
- Disabling input when `N/A`
- Added base/quote token suffix to be explicit on what this price refers too (although being a bit redundant)
- Added `selling` word to sentence to make it clear what the amount refers to: `Onchain orderbook price for selling <amount> <symbol|name|address>`
- Fixed the displayed symbol in the sentence. Previously it was changing every time the price was inverted
- Displaying second price estimation only when amount is different from default of 1 unit. 

Worst case scenario (long token symbols):
![screenshot_2020-06-30_14-49-37](https://user-images.githubusercontent.com/43217/86181517-fd1af900-bae2-11ea-8b36-b32d2ae261d9.png)

Regular use case (short token symbols):
![screenshot_2020-06-30_15-05-39](https://user-images.githubusercontent.com/43217/86181570-20de3f00-bae3-11ea-9362-74a502000ada.png)

### TODO:
- [ ] Show % difference between prices (slippage?)
- [x] Add tooltips
- [x] Add swap price buttons

## Proposal

No longer automatically update price inputs with price suggestion.
Instead, show a button and allow the user to make the choice.

Closes #1163

This change adds mostly the logic of fetching the prices and displaying it in a button.

I added 1 price for a single unit and one price for the selected amount.
This way the user has a reference of the `slippage` given his amount.

When switching to the inverse price, the suggestion is also inverted.
When clicking in a button, both prices are filled.

![screenshot_2020-06-29_15-09-52](https://user-images.githubusercontent.com/43217/86060981-b3ff7200-ba1a-11ea-8d09-f8a566c69708.png)

It's hideous, I know. Will work on that.

As always, open for suggestions/feedback.

## TODO:
- [x] Style
- [x] Do not show `infinity` when one of the prices is too big/too small
- [x] More testing, look for edge cases, etc

