### PR TITLE
added long press capabilities

### DIFF
--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -16,6 +16,7 @@ import { ResponsiveRowSizeToggler } from 'components/Layout/Card'
 
 // hooks
 import useSafeState from 'hooks/useSafeState'
+import useLongPress from 'hooks/useLongPress'
 
 import {
   formatSmart,
@@ -25,11 +26,11 @@ import {
   dateToBatchId,
   getTimeRemainingInBatch,
 } from 'utils'
+import { displayTokenSymbolOrLink } from 'utils/display'
 
 import { DetailedAuctionElement } from 'api/exchange/ExchangeApi'
 
 import { OrderRowWrapper, ResponsiveTitleRow } from 'components/OrdersWidget/OrderRow.styled'
-import { displayTokenSymbolOrLink } from 'utils/display'
 
 const PendingLink: React.FC<Pick<Props, 'transactionHash'>> = props => {
   const { transactionHash } = props
@@ -291,10 +292,21 @@ const OrderRow: React.FC<Props> = props => {
     fetchToken(order.id, order.sellToken as TokenDetails, setSellToken, isPendingOrder)
   }, [isPendingOrder, networkId, order, setBuyToken, setSellToken])
 
+  const handleDeleteOrder = toggleMarkedForDeletion
+  const { handleLongPress, handleClearTimeout } = useLongPress(handleDeleteOrder)
+
   return (
     sellToken &&
     buyToken && (
-      <OrderRowWrapper data-order-id={order.id} className={pending ? 'pending' : 'orderRowWrapper'} $open={openCard}>
+      <OrderRowWrapper
+        data-order-id={order.id}
+        className={pending ? 'pending' : 'orderRowWrapper'}
+        $open={openCard}
+        onTouchStart={handleLongPress}
+        onTouchEnd={handleClearTimeout}
+        onMouseDown={handleLongPress}
+        onMouseUp={handleClearTimeout}
+      >
         <DeleteOrder
           isMarkedForDeletion={isMarkedForDeletion}
           toggleMarkedForDeletion={toggleMarkedForDeletion}

--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -3,6 +3,23 @@ import { MEDIA } from 'const'
 import { CardWidgetWrapper } from 'components/Layout/Card'
 import { StandaloneCardWrapper } from 'components/Layout/PageWrapper'
 
+export const MobileLongPressBanner = styled.tr`
+  &&&&& {
+    border: none;
+    min-height: auto;
+    padding: 0.3rem 0;
+
+    > .message {
+      display: inline;
+      color: var(--color-text-alternate);
+    }
+
+    &:hover {
+      background: initial;
+    }
+  }
+`
+
 export const OrdersWrapper = styled(StandaloneCardWrapper)`
   > h5 {
     width: 100%;

--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -1,21 +1,34 @@
 import styled from 'styled-components'
-import { MEDIA } from 'const'
 import { CardWidgetWrapper } from 'components/Layout/Card'
 import { StandaloneCardWrapper } from 'components/Layout/PageWrapper'
+import { MEDIA } from 'const'
 
 export const MobileLongPressBanner = styled.tr`
   &&&&& {
+    display: none;
+    grid-template-columns: max-content;
+    justify-content: flex-start;
+    // width: max-content;
+    font-size: smaller;
     border: none;
     min-height: auto;
-    padding: 0.3rem 0;
+    padding: 0;
 
     > .message {
       display: inline;
       color: var(--color-text-alternate);
+      padding: 0.5rem;
+      margin: 0;
+      > svg {
+        margin-right: 0.5rem;
+      }
     }
 
     &:hover {
       background: initial;
+    }
+    @media ${MEDIA.mobile} {
+      display: inline-flex;
     }
   }
 `

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -3,7 +3,7 @@ import React, { useMemo, useCallback, useEffect } from 'react'
 import { unstable_batchedUpdates } from 'react-dom'
 
 // Assets
-import { faTrashAlt, faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
+import { faTrashAlt, faChevronDown, faChevronUp, faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 // Const and utils
@@ -31,7 +31,13 @@ import FilterTools from 'components/FilterTools'
 // OrderWidget
 import { useDeleteOrders } from 'components/OrdersWidget/useDeleteOrders'
 import OrderRow from 'components/OrdersWidget/OrderRow'
-import { OrdersWrapper, ButtonWithIcon, OrdersForm } from 'components/OrdersWidget/OrdersWidget.styled'
+import {
+  OrdersWrapper,
+  ButtonWithIcon,
+  OrdersForm,
+  MobileLongPressBanner,
+} from 'components/OrdersWidget/OrdersWidget.styled'
+import FormMessage from 'components/TradeWidget/FormMessage'
 
 type OrderTabs = 'active' | 'liquidity' | 'closed' | 'fills'
 
@@ -429,6 +435,11 @@ const OrdersWidget: React.FC = () => {
                       </tr>
                     </thead>
                     <tbody>
+                      <MobileLongPressBanner>
+                        <FormMessage className="warning message">
+                          <FontAwesomeIcon icon={faInfoCircle} size="sm" /> Press and hold to select
+                        </FormMessage>
+                      </MobileLongPressBanner>
                       {filteredAndSortedPendingOrders.map(order => (
                         <OrderRow
                           key={order.id}

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -435,11 +435,14 @@ const OrdersWidget: React.FC = () => {
                       </tr>
                     </thead>
                     <tbody>
-                      <MobileLongPressBanner>
-                        <FormMessage className="warning message">
-                          <FontAwesomeIcon icon={faInfoCircle} size="sm" /> Press and hold to select
-                        </FormMessage>
-                      </MobileLongPressBanner>
+                      {ordersCount > 0 && (
+                        <MobileLongPressBanner>
+                          <FormMessage as="td" className="warning message">
+                            <FontAwesomeIcon icon={faInfoCircle} size="sm" />
+                            Press and hold cards to select them. Use the arrow below each card to expand/fold content.
+                          </FormMessage>
+                        </MobileLongPressBanner>
+                      )}
                       {filteredAndSortedPendingOrders.map(order => (
                         <OrderRow
                           key={order.id}

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react'
+import { noop } from 'utils'
+
+interface HookReturn {
+  handleLongPress: () => boolean
+  handleClearTimeout: () => void
+}
+
+function useLongPress(clickHandler: Function = noop): HookReturn {
+  return useMemo(() => {
+    let pressTimer: NodeJS.Timeout
+    return {
+      handleLongPress: (): boolean => {
+        clearTimeout(pressTimer)
+        pressTimer = setTimeout(function() {
+          clickHandler()
+        }, 1000)
+        return false
+      },
+      handleClearTimeout: (): void => clearTimeout(pressTimer),
+    }
+  }, [clickHandler])
+}
+
+export default useLongPress

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -14,7 +14,7 @@ export function assertNonNull<T>(val: T, message: string): asserts val is NonNul
 }
 
 // eslint-disable-next-line
-function noop(..._args: any[]): void {}
+export function noop(..._args: any[]): void {}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const logInfo = process.env.NODE_ENV === 'test' ? noop : (...args: any[]): void => console.log(...args)


### PR DESCRIPTION
Waterfalls into #1158 

Allows more mobile friendly longpress to select capabilities, not sure how we feel about it

To test (it also works in desktop but can be disabled if u guys want, i saw no harm in keeping it right now)

1. head into mobile view
2. click on card and hold click down until it says delete sth
3. had a banner to show as tip