### PR TITLE
Fix trust gas issue

### DIFF
--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -171,7 +171,7 @@ export const composeProvider = <T extends Provider>(
         if (!txConfig.gas) {
           const gasLimit = await web3.eth.estimateGas(txConfig)
           logDebug('[composeProvider] No gas Limit. Using estimation ' + gasLimit)
-          txConfig.gas = gasLimit
+          txConfig.gas = numberToHex(gasLimit)
         } else {
           logDebug('[composeProvider] Gas Limit: ' + txConfig.gas)
         }

--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -70,10 +70,17 @@ const createConditionalMiddleware = <T extends unknown>(
     // if not condition, skip and got to next middleware
     if (!condition(req)) return next()
 
-    // if handled fully, end here
-    if (await handle(req, res)) return end()
-    // otherwise continue to next middleware
-    next()
+    try {
+      const isHandled = await handle(req, res)
+
+      // If handled fully, end here
+      if (isHandled) return end()
+
+      // Otherwise continue to next middleware
+      next()
+    } catch (error) {
+      end(error)
+    }
   }
 }
 

--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -9,7 +9,7 @@ import providerFromEngine from 'eth-json-rpc-middleware/providerFromEngine'
 import { TransactionConfig } from 'web3-core'
 import { numberToHex } from 'web3-utils'
 import { isWalletConnectProvider, Provider } from './providerUtils'
-import { logDebug, logInfo } from 'utils'
+import { logDebug } from 'utils'
 import { web3 } from 'api'
 
 // custom providerAsMiddleware

--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -163,14 +163,11 @@ export const composeProvider = <T extends Provider>(
 
         if (!txConfig.gas) {
           const gasLimit = await web3.eth.estimateGas(txConfig)
-          // const gasLimit = '100000000'
           logDebug('[composeProvider] No gas Limit. Using estimation ' + gasLimit)
           txConfig.gas = gasLimit
         } else {
           logDebug('[composeProvider] Gas Limit: ' + txConfig.gas)
         }
-
-        logInfo('[composeProvider] Send transaction: ', JSON.stringify(txConfig, null, 2))
 
         // don't mark as handled
         // pass modified tx on


### PR DESCRIPTION
## Context
The app doesn't send currently the gas. It assumes the Wallet does the estimation of it.
This is the case for most of the wallets, but is not true for Trust Wallet, at least, it's not true any more.

In the past, Trust Wallet was working even if you don't provide the gas, not sure if it was GETH doing it for them, or they were actually doing it.

Checking the JSON RPC documentation I can see that, although it's OPTIONAL, the default is not that the node should estimate, the default is to use 90K.

![image](https://user-images.githubusercontent.com/2352112/86162867-bdb6d180-bb0f-11ea-9336-2d8bcdc9fa73.png)

For this reason it's important to provide the gas limit. This will solve many of the errors in Trust Wallet, and potentially other wallets.

This fix along is not enough for some of the issues reported by users. They also need to update to the latest Trust Wallet. At least, it was not enough in my case 😅



## Included in this PR
This PR does two things:
* Estimate and include the "gas limit" in every transaction
* Error handling for provider middlewares


## TESTING

* It would be good to test this, with all the operations of the UI and in as many wallets as possible
* Ideally we would test to make the provider UNDERESTIMATE onpurposee and test the error handling