### PR TITLE
Fix pending orders

### DIFF
--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -719,6 +719,7 @@ const TradeWidget: React.FC = () => {
         userAddress,
         validFromWithBatchID,
         validUntilWithBatchID,
+        expiresNever,
       },
       resetStateOptions: Partial<TradeFormData> = DEFAULT_FORM_STATE,
     ): void => {
@@ -742,7 +743,8 @@ const TradeWidget: React.FC = () => {
         remainingAmount: priceDenominator,
         sellTokenBalance: ZERO,
         validFrom: validFromWithBatchID,
-        validUntil: validUntilWithBatchID,
+        //  when expiresNever == true, validUntilWithBatchID == validFromWithBatchID
+        validUntil: expiresNever ? 0 : validUntilWithBatchID,
         txHash,
       }
 
@@ -814,6 +816,7 @@ const TradeWidget: React.FC = () => {
                   sellToken,
                   validFromWithBatchID,
                   validUntilWithBatchID,
+                  expiresNever: isNever,
                 },
                 {
                   ...DEFAULT_FORM_STATE,
@@ -855,6 +858,7 @@ const TradeWidget: React.FC = () => {
                   userAddress,
                   validFromWithBatchID,
                   validUntilWithBatchID,
+                  expiresNever: isNever,
                 },
                 {
                   ...DEFAULT_FORM_STATE,


### PR DESCRIPTION
When an order is submitted with `validUntil == NEVER` due to default values on the form it becomes 0
and `validUntilWithBatchID == validFromWithBatchID`, and `isPendingOrderActive` in the part of
```js
batchIdToDate(order.validUntil) >= now
```
marks order as inactive
So that pending order is put into [closed](https://github.com/gnosis/dex-react/blob/1fb0a3110e9ccc85bc013951e5669fa625fcec95/src/components/OrdersWidget/index.tsx#L72) category

This here be fix for that