### PR TITLE
Fix locale ',' in input

### DIFF
--- a/src/components/WrapEtherBtn.tsx
+++ b/src/components/WrapEtherBtn.tsx
@@ -226,7 +226,15 @@ const WrapUnwrapEtherBtn: React.FC<WrapUnwrapEtherBtnProps> = (props: WrapUnwrap
         {amountFull} {symbolSource}
       </span>
     ) : (
-      <a onClick={(): void => setValue(INPUT_ID_AMOUNT, formatAmountFull(balance), true)}>
+      <a
+        onClick={(): void =>
+          setValue(
+            INPUT_ID_AMOUNT,
+            formatAmountFull({ amount: balance, precision: DEFAULT_PRECISION, isLocaleAware: false }),
+            true,
+          )
+        }
+      >
         {amountFull} {symbolSource}
       </a>
     )


### PR DESCRIPTION
Fixes #1166

We always ignore locale in inputs (in Deposit modal and on /trade max), but not in unwrap one