### PR TITLE
Batch tooltip looooong

### DIFF
--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -69,9 +69,17 @@ const CountDownStyled = styled.div`
 
 const DevdocTooltip = (
   <HelpTooltipContainer>
-    <a href="https://docs.gnosis.io/protocol/docs/intro-batches" target="_blank" rel="noopener noreferrer">
-      What Is a Batch and a Batch ID?
-    </a>
+    <p>
+      On Gnosis Protocol, orders placed on-chain are not immediately executed, but rather collected and aggregated to be
+      settled in batches. These batch order settlements occur every 5 minutes consecutively.
+    </p>
+    <p>
+      Learn more{' '}
+      <a href="https://docs.gnosis.io/protocol/docs/intro-batches" target="_blank" rel="noopener noreferrer">
+        here
+      </a>
+      .
+    </p>
   </HelpTooltipContainer>
 )
 


### PR DESCRIPTION
Supersede https://github.com/gnosis/dex-react/pull/1212  so it contains a longer message:


![image](https://user-images.githubusercontent.com/2352112/87072568-4cb49f80-c21c-11ea-8ede-6b35e8c17b03.png)
