### PR TITLE
1206/market column on orders tab

### DIFF
--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -86,14 +86,10 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({ buyToken, sellToken, order 
     <td data-label="Price" className="showResponsive">
       <div className="order-details">
         <strong>
-          {priceInverse} {displayTokenSymbolOrLink(buyToken)}
-          {'/'}
-          {displayTokenSymbolOrLink(sellToken)}
+          {priceInverse} {displayTokenSymbolOrLink(sellToken)}
         </strong>
         <br />
-        {price} {displayTokenSymbolOrLink(sellToken)}
-        {'/'}
-        {displayTokenSymbolOrLink(buyToken)}
+        {price} {displayTokenSymbolOrLink(buyToken)}
       </div>
     </td>
   )

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -55,6 +55,17 @@ const DeleteOrder: React.FC<Pick<
   </td>
 )
 
+interface MarketProps {
+  sellToken: TokenDetails
+  buyToken: TokenDetails
+}
+
+const Market: React.FC<MarketProps> = ({ sellToken, buyToken }) => (
+  <td data-label="Market">
+    {displayTokenSymbolOrLink(buyToken)}/{displayTokenSymbolOrLink(sellToken)}
+  </td>
+)
+
 interface OrderDetailsProps extends Pick<Props, 'order' | 'pending'> {
   buyToken: TokenDetails
   sellToken: TokenDetails
@@ -301,6 +312,7 @@ const OrderRow: React.FC<Props> = props => {
           pending={pending}
           disabled={disabled || isPendingOrder || pending}
         />
+        <Market sellToken={sellToken} buyToken={buyToken} />
         <OrderDetails order={order} sellToken={sellToken} buyToken={buyToken} />
         <Amounts order={order} sellToken={sellToken} />
         <Expires order={order} pending={pending} isPendingOrder={isPendingOrder} />

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -402,7 +402,7 @@ const OrdersWidget: React.FC = () => {
               <div className="ordersContainer">
                 <CardWidgetWrapper className="widgetCardWrapper">
                   <CardTable
-                    $columns="3.2rem repeat(2,1fr) minmax(5.2rem,0.6fr) minmax(8.6rem, 0.3fr)"
+                    $columns="3.2rem minmax(8.6rem, 0.3fr) repeat(2,1fr) minmax(5.2rem,0.6fr) minmax(8.6rem, 0.3fr)"
                     $gap="0 0.6rem"
                     $rowSeparation="0"
                   >
@@ -416,6 +416,7 @@ const OrdersWidget: React.FC = () => {
                             disabled={deleting}
                           />
                         </th>
+                        <th>Market</th>
                         <th>Limit price</th>
                         <th className="filled">Filled / Total</th>
                         <th


### PR DESCRIPTION
Part of #1206

Before:
![screenshot_2020-07-09_14-19-56](https://user-images.githubusercontent.com/43217/87092875-19a8e680-c1f1-11ea-8070-c54ca99db917.png)

After:
![screenshot_2020-07-09_14-18-52](https://user-images.githubusercontent.com/43217/87092885-1ca3d700-c1f1-11ea-9632-db81f8bf8cb8.png)

Where:
1. The market here is fixed (inverted) in another PR: https://github.com/gnosis/dex-react/pull/1215
2. Buy `Market` column added
3. Building on top of #1216, displaying only the unit instead of the full market
4. Default price seen here is the same as the `buy` price on `3`