### PR TITLE
Orders widget height fix

### DIFF
--- a/src/components/Layout/PageWrapper.tsx
+++ b/src/components/Layout/PageWrapper.tsx
@@ -44,16 +44,16 @@ export const ContentPage = styled.div`
 `
 
 export const StandaloneCardWrapper = styled.div`
+  height: 100%;
   width: 100%;
   display: flex;
   flex-flow: column wrap;
   position: relative;
 
-  /* In use when accessed as a dedicated page and not part of OrdersPanel */
+  /* In use when accessed as a dedicated page and not part of ExpandableOrdersPanel */
   background: var(--color-background-pageWrapper);
   box-shadow: var(--box-shadow-wrapper);
   border-radius: 0.6rem;
-  min-height: 54rem;
   min-width: 85rem;
   max-width: 140rem;
   /* ====================================================================== */

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -12,6 +12,14 @@ import Header from 'components/Layout/Header'
 import Footer from 'components/Layout/Footer'
 import LegalBanner from 'components/LegalBanner'
 
+export const EllipsisText = styled.div<{ $maxWidth?: string }>`
+  font-size: inherit;
+  max-width: ${({ $maxWidth = '6ch' }): string => $maxWidth};
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+`
+
 const Wrapper = styled.div`
   width: 100%;
   min-height: 100%;

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -292,7 +292,7 @@ const OrderRow: React.FC<Props> = props => {
   return (
     sellToken &&
     buyToken && (
-      <OrderRowWrapper data-order-id={order.id} className={pending ? 'pending' : 'orderRowWrapper'}>
+      <OrderRowWrapper data-order-id={order.id} className={`orderRowWrapper${pending ? ' pending' : ''}`}>
         <DeleteOrder
           isMarkedForDeletion={isMarkedForDeletion}
           toggleMarkedForDeletion={toggleMarkedForDeletion}

--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -3,7 +3,12 @@ import { MEDIA } from 'const'
 import { CardWidgetWrapper } from 'components/Layout/Card'
 import { StandaloneCardWrapper } from 'components/Layout/PageWrapper'
 
+// OrdersWidget outside wrapper
 export const OrdersWrapper = styled(StandaloneCardWrapper)`
+  height: 73rem;
+  width: 100%;
+  flex: 1;
+
   > h5 {
     width: 100%;
     margin: 0 auto;
@@ -16,6 +21,7 @@ export const OrdersWrapper = styled(StandaloneCardWrapper)`
   }
 
   > div {
+    height: 100%;
     width: 100%;
     position: relative;
     display: flex;
@@ -90,7 +96,8 @@ export const OrdersForm = styled.div`
   > form {
     display: flex;
     flex-flow: column nowrap;
-    height: 71rem;
+    // height: 71rem;
+    height: 100%;
 
     @media ${MEDIA.tablet} {
       height: inherit;

--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -43,10 +43,9 @@ export const OrdersWrapper = styled(StandaloneCardWrapper)`
     > table {
       > tbody {
         > tr.orderRowWrapper {
-          padding-right: 4.3rem;
-
           @media ${MEDIA.mobile} {
             display: flex;
+            padding-right: 4.3rem;
 
             > td.checked {
               position: absolute;

--- a/src/components/PoolingWidget/CreateStrategy.styled.ts
+++ b/src/components/PoolingWidget/CreateStrategy.styled.ts
@@ -23,9 +23,10 @@ export const CreateStrategyWrapper = styled.div`
   > strong {
     margin: 0 0 1rem 0;
     color: var(--color-text-primary);
+    text-decoration: underline dashed;
   }
   > p {
-    margin: 0 0 2.4rem;
+    margin: 0 0 1.8rem;
     font-size: inherit;
     line-height: inherit;
   }

--- a/src/components/PoolingWidget/DefineSpread.styled.ts
+++ b/src/components/PoolingWidget/DefineSpread.styled.ts
@@ -7,7 +7,7 @@ export const DefineSpreadWrapper = styled(InputBox)`
   height: auto;
 
   > strong {
-    margin: 0 0 1rem 0;
+    margin: 0 0 0.3rem 0;
     color: var(--color-text-primary);
   }
 
@@ -27,12 +27,14 @@ export const SpreadInformationWrapper = styled.div`
   display: flex;
   flex-flow: column wrap;
   width: 100%;
+
   > strong {
     margin: 0 0 1rem 0;
     color: var(--color-text-primary);
+    text-decoration: underline dashed;
   }
   > p {
-    margin: 0 0 2.4rem;
+    margin: 0 0 1.2rem;
     font-size: inherit;
     line-height: inherit;
   }

--- a/src/components/PoolingWidget/PoolingWidget.styled.ts
+++ b/src/components/PoolingWidget/PoolingWidget.styled.ts
@@ -63,9 +63,13 @@ export const PoolingInterfaceWrapper = styled(WrappedWidget)`
 
   @media ${MEDIA.mobile} {
     flex-flow: column wrap;
-    padding: 1.6rem 1.6rem 0;
     width: 100%;
     font-size: 1.3rem;
+
+    > form {
+      max-width: 100%;
+      padding: 1.6rem;
+    }
 
     ${StepDescriptionWrapper} {
       width: 100%;

--- a/src/components/PoolingWidget/PoolingWidget.styled.ts
+++ b/src/components/PoolingWidget/PoolingWidget.styled.ts
@@ -35,7 +35,6 @@ export const StepDescriptionWrapper = styled.div`
 `
 
 export const PoolingInterfaceWrapper = styled(WrappedWidget)`
-  min-height: 67rem;
   font-size: 1.35rem;
   line-height: 1.25;
 

--- a/src/components/PoolingWidget/PoolingWidget.styled.ts
+++ b/src/components/PoolingWidget/PoolingWidget.styled.ts
@@ -7,6 +7,33 @@ import arrowWhite from 'assets/img/arrow-white.svg'
 // components
 import { WrappedWidget } from 'components/TradeWidget'
 
+export const StepDescriptionWrapper = styled.div`
+  width: 50%;
+  padding: 0 2.4rem 0 0;
+  box-sizing: border-box;
+
+  .liqContent {
+    color: var(--color-text-primary);
+    font-size: inherit;
+    line-height: inherit;
+    margin: 1.6rem 0 0;
+
+    > ul {
+      list-style: none;
+      padding-inline-start: 2rem;
+      padding: 0;
+    }
+
+    > ul > li {
+      margin: 0 0 0.5rem;
+    }
+
+    > ul > li > img {
+      margin: 0 0.5rem 0 0;
+    }
+  }
+`
+
 export const PoolingInterfaceWrapper = styled(WrappedWidget)`
   min-height: 67rem;
   font-size: 1.35rem;
@@ -40,6 +67,11 @@ export const PoolingInterfaceWrapper = styled(WrappedWidget)`
     padding: 1.6rem 1.6rem 0;
     width: 100%;
     font-size: 1.3rem;
+
+    ${StepDescriptionWrapper} {
+      width: 100%;
+      padding: 0;
+    }
   }
 `
 
@@ -240,38 +272,6 @@ export const BarWrapper = styled.div<{ $bgColor?: string; $minHeight?: string }>
   > ${StepSeparator} {
     @media ${MEDIA.mobile} {
       margin: 0 0 2.1rem;
-    }
-  }
-`
-
-export const StepDescriptionWrapper = styled.div`
-  width: 50%;
-  padding: 0 2.4rem 0 0;
-  box-sizing: border-box;
-
-  @media ${MEDIA.mobile} {
-    width: 100%;
-    padding: 0;
-  }
-
-  .liqContent {
-    color: var(--color-text-primary);
-    font-size: inherit;
-    line-height: inherit;
-    margin: 1.6rem 0 0;
-
-    > ul {
-      list-style: none;
-      padding-inline-start: 2rem;
-      padding: 0;
-    }
-
-    > ul > li {
-      margin: 0 0 0.5rem;
-    }
-
-    > ul > li > img {
-      margin: 0 0.5rem 0 0;
     }
   }
 `

--- a/src/components/PoolingWidget/index.tsx
+++ b/src/components/PoolingWidget/index.tsx
@@ -13,7 +13,7 @@ import { TokenDetails, ZERO } from '@gnosis.pm/dex-js'
 import { maxAmountsForSpread, resolverFactory, NUMBER_VALIDATION_KEYS } from 'utils'
 
 // components
-import { OrdersPanel, OrdersToggler } from 'components/TradeWidget'
+import { ExpandableOrdersPanel, OrdersToggler } from 'components/TradeWidget'
 
 // PoolingWidget: subcomponents
 import ProgressBar from 'components/PoolingWidget/ProgressBar'
@@ -93,6 +93,8 @@ const ContentWrapper = styled.div`
   flex-flow: row wrap;
   font-size: inherit;
   line-height: inherit;
+
+  overflow-y: auto;
 `
 
 const LiquidityMessage = styled.div`
@@ -320,7 +322,7 @@ const PoolingInterface: React.FC = () => {
           />
         </form>
       </FormContext>
-      <OrdersPanel>
+      <ExpandableOrdersPanel>
         {/* Toggle panel visibility (arrow) */}
         <OrdersToggler
           type="button"
@@ -329,7 +331,7 @@ const PoolingInterface: React.FC = () => {
         />
         {/* Actual orders content */}
         <OrdersWidget displayOnly="liquidity" />
-      </OrdersPanel>
+      </ExpandableOrdersPanel>
     </PoolingInterfaceWrapper>
   )
 }

--- a/src/components/TradeWidget/Price.tsx
+++ b/src/components/TradeWidget/Price.tsx
@@ -16,6 +16,7 @@ import { TradeFormData } from 'components/TradeWidget'
 import FormMessage, { FormInputError } from 'components/TradeWidget/FormMessage'
 import { useNumberInput } from 'components/TradeWidget/useNumberInput'
 import { SwapIcon } from 'components/TradeWidget/SwapIcon'
+import { EllipsisText } from 'components/Layout'
 
 const Wrapper = styled.div`
   display: flex;
@@ -104,13 +105,6 @@ export const PriceInputBox = styled.div<{ hidden?: boolean }>`
     @media ${MEDIA.mobile} {
       font-size: 1rem;
       letter-spacing: 0.03rem;
-    }
-    > small:not(:nth-child(2)) {
-      font-size: inherit;
-      max-width: 6ch;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      white-space: nowrap;
     }
     > small:nth-child(2) {
       margin: 0 0.3rem;
@@ -249,9 +243,13 @@ const Price: React.FC<Props> = ({
             tabIndex={tabIndex}
           />
           <div>
-            <small title={receiveToken.symbol}>{receiveToken.symbol}</small>
+            <EllipsisText as="small" title={receiveToken.symbol}>
+              {receiveToken.symbol}
+            </EllipsisText>
             <small>per</small>
-            <small title={sellToken.symbol}>{sellToken.symbol}</small>
+            <EllipsisText as="small" title={sellToken.symbol}>
+              {sellToken.symbol}
+            </EllipsisText>
             <SwapIcon swap={swapPrices} />
           </div>
         </label>
@@ -271,9 +269,13 @@ const Price: React.FC<Props> = ({
             tabIndex={tabIndex}
           />
           <div>
-            <small title={sellToken.symbol}>{sellToken.symbol}</small>
+            <EllipsisText as="small" title={sellToken.symbol}>
+              {sellToken.symbol}
+            </EllipsisText>
             <small>per</small>
-            <small title={receiveToken.symbol}>{receiveToken.symbol}</small>
+            <EllipsisText as="small" title={receiveToken.symbol}>
+              {receiveToken.symbol}
+            </EllipsisText>
             <SwapIcon swap={swapPrices} />
           </div>
         </label>

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -30,7 +30,8 @@ const Wrapper = styled.div`
     grid-template-columns: 4fr 1fr 1fr;
     gap: 0.25rem;
     font-size: 1.25rem;
-    align-items: center;
+    align-items: flex-start;
+    line-height: 1.4;
 
     > small {
       justify-self: end;

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { useFormContext } from 'react-hook-form'
 import BigNumber from 'bignumber.js'
 
-import { TokenDetails, invertPrice } from '@gnosis.pm/dex-js'
+import { TokenDetails, invertPrice, safeTokenName } from '@gnosis.pm/dex-js'
 
 import { usePriceEstimationWithSlippage } from 'hooks/usePriceEstimation'
 
@@ -15,6 +15,7 @@ import Spinner from 'components/Spinner'
 import { TradeFormData } from 'components/TradeWidget'
 import { SwapIcon } from 'components/TradeWidget/SwapIcon'
 import { HelpTooltip, HelpTooltipContainer } from 'components/Tooltip'
+import { EllipsisText } from 'components/Layout'
 
 const Wrapper = styled.div`
   > strong {
@@ -27,14 +28,30 @@ const Wrapper = styled.div`
 
   .container {
     display: grid;
-    grid-template-columns: 4fr 1fr 1fr;
+    grid-template-columns: 4fr 1fr 1.5fr;
     gap: 0.25rem;
     font-size: 1.25rem;
     align-items: flex-start;
     line-height: 1.4;
 
-    > small {
-      justify-self: end;
+    > div {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+
+      > ${EllipsisText} {
+        display: inline-block;
+        font-size: smaller;
+      }
+
+      > div:nth-child(2) {
+        font-size: larger;
+        margin: 0 0.1rem;
+      }
+
+      > span:last-child {
+        padding: 0 0.2rem 0 0.4rem;
+      }
     }
   }
 `
@@ -133,13 +150,16 @@ const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationP
   const displayBaseToken = isPriceInverted ? quoteToken : baseToken
   const displayQuoteToken = !isPriceInverted ? quoteToken : baseToken
 
+  const displayBtName = displayTokenSymbolOrLink(displayBaseToken)
+  const displayQtName = displayTokenSymbolOrLink(displayQuoteToken)
+
   return (
     <>
       <span>
         <HighlightedText>Onchain orderbook price</HighlightedText> <HelpTooltip tooltip={OnchainOrderbookTooltip} /> for
         selling{' '}
         <strong>
-          {+amount || '1'} {displayTokenSymbolOrLink(quoteToken)}
+          {+amount || '1'} {displayQtName}
         </strong>
         :
       </span>
@@ -150,10 +170,12 @@ const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationP
       >
         {isPriceLoading ? <Spinner /> : displayPrice}
       </button>
-      <small>
-        {displayTokenSymbolOrLink(displayBaseToken)}/{displayTokenSymbolOrLink(displayQuoteToken)}
+      <div>
+        <EllipsisText title={safeTokenName(displayBaseToken)}>{displayBtName}</EllipsisText>
+        <div>/</div>
+        <EllipsisText title={safeTokenName(displayQuoteToken)}>{displayQtName}</EllipsisText>
         <SwapIcon swap={swapPrices} />
-      </small>
+      </div>
     </>
   )
 }

--- a/src/components/TradeWidget/TokenRow.tsx
+++ b/src/components/TradeWidget/TokenRow.tsx
@@ -211,20 +211,21 @@ const TokenRow: React.FC<Props> = ({
     <FormInputError errorMessage={error.message as string} />
   ) : (
     overMax.gt(ZERO) && (
-      <FormMessage className="warning">
+      <FormMessage className="warning tradeWarning">
         <i>
           Have you already deposited <b>{selectedToken.symbol}</b> into the exchange wallet?{' '}
         </i>
-        <i>Sell amount exceeds your balance by</i>
-        <strong>
-          {formatSmart({ amount: overMax, precision: selectedToken.decimals })} {selectedToken.symbol}.
-        </strong>
         {editableAndConnected && !tokenDisabled && (
           <div className="btn" onClick={(): void => showForm('deposit')}>
             + Deposit {selectedToken.symbol}
           </div>
         )}
-        {/* This creates a standing order. <a href="#">Read more</a>. */}
+        <i>
+          Sell amount exceeds your balance by:{' '}
+          <strong>
+            {formatSmart({ amount: overMax, precision: selectedToken.decimals })} {selectedToken.symbol}
+          </strong>
+        </i>
       </FormMessage>
     )
   )

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -59,10 +59,10 @@ import { updateTradeState } from 'reducers-actions/trade'
 import { DevTool } from 'HookFormDevtool'
 
 export const WrappedWidget = styled(Widget)`
+  height: 73rem;
   overflow-x: visible;
   min-width: 0;
   margin: 0 auto;
-  height: 73rem;
   width: auto;
   flex-flow: row nowrap;
   display: flex;
@@ -74,6 +74,8 @@ export const WrappedWidget = styled(Widget)`
   line-height: 1;
 
   &.expanded {
+    width: calc(50vw + 50rem);
+
     > form {
       width: 0;
       overflow: hidden;
@@ -253,7 +255,8 @@ export const ExpandableOrdersPanel = styled.div`
 
   // Orders widget when inside the ExpandableOrdersPanel
   ${OrdersWrapper} {
-    height: 100%;
+    width: calc(100% - 1.6rem);
+    height: 90%;
     background: transparent;
     box-shadow: none;
     border-radius: 0;
@@ -284,7 +287,7 @@ export const ExpandableOrdersPanel = styled.div`
 
   > div.ordersTogglerContainer {
     height: 100%;
-    width: calc(100% - 1.6rem);
+    width: 100%;
     box-sizing: border-box;
     display: flex;
     flex-flow: column nowrap;
@@ -295,6 +298,7 @@ export const ExpandableOrdersPanel = styled.div`
       flex: 0 0 5rem;
       align-items: center;
       justify-content: center;
+      height: 10%;
       width: 100%;
       margin: 0;
       padding: 0;

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -62,7 +62,7 @@ export const WrappedWidget = styled(Widget)`
   overflow-x: visible;
   min-width: 0;
   margin: 0 auto;
-  min-height: 75rem;
+  height: 73rem;
   width: auto;
   flex-flow: row nowrap;
   display: flex;
@@ -98,7 +98,7 @@ export const WrappedWidget = styled(Widget)`
 
 const WrappedForm = styled.form`
   display: flex;
-  flex-flow: column wrap;
+  flex-flow: column nowrap;
   flex: 1 0 42rem;
   max-width: 50rem;
   padding: 1.6rem;
@@ -140,9 +140,12 @@ const WrappedForm = styled.form`
 
   ${FormMessage} {
     font-size: 1.3rem;
+    line-height: 1.2;
     margin: 0.5rem 0 0;
     flex-flow: row wrap;
     justify-content: flex-start;
+
+    overflow-y: auto;
 
     @media ${MEDIA.mediumUp} {
       max-height: 11rem;
@@ -151,14 +154,21 @@ const WrappedForm = styled.form`
     > b {
       margin: 0.3rem;
     }
+
     > i {
-      margin: 0.3rem 0 0.3rem 0;
+      margin: 0.3rem 0;
       font-style: normal;
+      width: 100%;
+
+      > strong {
+        margin: 0.3rem 0 0.3rem 0.3rem;
+        font-size: 1.3rem;
+        word-break: break-all;
+      }
     }
-    > strong {
-      margin: 0.3rem 0 0.3rem 0.3rem;
-      font-size: 1.3rem;
-      word-break: break-word;
+
+    > .btn {
+      margin: 0.3rem 0;
     }
   }
 `
@@ -210,7 +220,7 @@ const SubmitButton = styled.button`
   }
 `
 
-export const OrdersPanel = styled.div`
+export const ExpandableOrdersPanel = styled.div`
   overflow: hidden;
   display: flex;
   flex-flow: column wrap;
@@ -241,13 +251,12 @@ export const OrdersPanel = styled.div`
     box-shadow: none;
   }
 
-  // Orders widget when inside the OrdersPanel
+  // Orders widget when inside the ExpandableOrdersPanel
   ${OrdersWrapper} {
+    height: 100%;
     background: transparent;
     box-shadow: none;
     border-radius: 0;
-    min-height: initial;
-    max-width: initial;
 
     @media ${MEDIA.desktop} {
       min-width: initial;
@@ -273,13 +282,36 @@ export const OrdersPanel = styled.div`
     }
   }
 
-  > div {
-    width: 100%;
+  > div.ordersTogglerContainer {
+    height: 100%;
     width: calc(100% - 1.6rem);
     box-sizing: border-box;
     display: flex;
-    flex-flow: row wrap;
+    flex-flow: column nowrap;
     border-radius: 0 0.6rem 0.6rem 0;
+
+    > h5 {
+      display: flex;
+      flex: 0 0 5rem;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      margin: 0;
+      padding: 0;
+
+      font-weight: var(--font-weight-bold);
+      font-size: 1.6rem;
+      color: var(--color-text-primary);
+      letter-spacing: 0.03rem;
+      text-align: center;
+
+      > a {
+        font-size: 1.3rem;
+        font-weight: var(--font-weight-normal);
+        color: var(--color-text-active);
+        text-decoration: underline;
+      }
+    }
 
     @media ${MEDIA.tablet} {
       width: 100%;
@@ -288,7 +320,7 @@ export const OrdersPanel = styled.div`
     }
 
     @media ${MEDIA.mobile} {
-      &.hideOnMobile {
+      &.ordersTogglerContainer {
         display: none;
       }
 
@@ -302,33 +334,6 @@ export const OrdersPanel = styled.div`
         overflow-y: scroll;
       }
     }
-  }
-
-  > div > h5 {
-    width: 100%;
-    margin: 0 auto;
-    padding: 1.6rem 0 1rem;
-    font-weight: var(--font-weight-bold);
-    font-size: 1.6rem;
-    color: var(--color-text-primary);
-    letter-spacing: 0.03rem;
-    text-align: center;
-    box-sizing: border-box;
-    text-align: center;
-  }
-
-  > div > h5 > a {
-    font-size: 1.3rem;
-    font-weight: var(--font-weight-normal);
-    color: var(--color-text-active);
-    text-decoration: underline;
-  }
-
-  > div > h5 > a {
-    font-size: 1.3rem;
-    font-weight: var(--font-weight-normal);
-    color: var(--color-text-active);
-    text-decoration: underline;
   }
 `
 
@@ -921,7 +926,7 @@ const TradeWidget: React.FC = () => {
   return (
     <WrappedWidget className={ordersVisible ? '' : 'expanded'}>
       <TokensAdder tokenAddresses={tokenAddressesToAdd} networkId={networkIdOrDefault} onTokensAdded={onTokensAdded} />
-      {/* Toggle Class 'expanded' on WrappedWidget on click of the <OrdersPanel> <button> */}
+      {/* Toggle Class 'expanded' on WrappedWidget on click of the <ExpandableOrdersPanel> <button> */}
       <FormContext {...methods}>
         <WrappedForm onSubmit={handleSubmit(onSubmit)} autoComplete="off" noValidate>
           {sameToken && <WarningLabel>Tokens cannot be the same!</WarningLabel>}
@@ -994,7 +999,7 @@ const TradeWidget: React.FC = () => {
           </SubmitButton>
         </WrappedForm>
       </FormContext>
-      <OrdersPanel>
+      <ExpandableOrdersPanel>
         {/* Toggle panel visibility (arrow) */}
         <OrdersToggler
           type="button"
@@ -1002,11 +1007,11 @@ const TradeWidget: React.FC = () => {
           $isOpen={ordersVisible}
         />
         {/* Actual orders content */}
-        <div className="hideOnMobile">
+        <div className="ordersTogglerContainer">
           <h5>Your orders</h5>
           <OrdersWidget displayOnly="regular" />
         </div>
-      </OrdersPanel>
+      </ExpandableOrdersPanel>
       {/* React Forms DevTool debugger */}
       {process.env.NODE_ENV === 'development' && <DevTool control={methods.control} />}
     </WrappedWidget>

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -158,7 +158,7 @@ const WrappedForm = styled.form`
     }
 
     > i {
-      margin: 0.3rem 0;
+      margin: 0;
       font-style: normal;
       width: 100%;
 

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -43,6 +43,17 @@ const GlobalStyles = createGlobalStyle`
     line-height: revert;
   }
 
+  ::-webkit-scrollbar {
+    width: 6px!important;
+    height: 6px!important;
+  }
+  ::-webkit-scrollbar-thumb {
+      background-color: rgba(0,0,0,.2);
+  }
+  ::-webkit-scrollbar-track {
+      background: hsla(0,0%,100%,.1);
+  }
+
   *, *:before, *:after {
     box-sizing: inherit;
   }


### PR DESCRIPTION
Fixes some general css issues

1. make height relative/percentage for OrdersTable and dependent on entire wrapper, dont give height to both orders table and wrapper
2. fixes width of table when expanded
3. adds scroll to warning when too long (eliminates weird styling if user inputs some enormous number even with `formatSmart`)