### PR TITLE
Preventing submission when either sell/buy amount is 0

### DIFF
--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -21,7 +21,15 @@ import { MEDIA, PRICE_ESTIMATION_DEBOUNCE_TIME } from 'const'
 import { TokenDetails, Network } from 'types'
 
 // utils
-import { getToken, parseAmount, parseBigNumber, dateToBatchId, resolverFactory, formatTimeToFromBatch } from 'utils'
+import {
+  getToken,
+  parseAmount,
+  parseBigNumber,
+  dateToBatchId,
+  resolverFactory,
+  formatTimeToFromBatch,
+  logDebug,
+} from 'utils'
 
 // api
 import { PendingTxObj } from 'api/exchange/ExchangeApi'
@@ -862,7 +870,23 @@ const TradeWidget: React.FC = () => {
     const cachedSellToken = getToken('symbol', sellToken.symbol, tokens)
 
     // Do not let potential null values through
-    if (!buyAmount || !sellAmount || !cachedBuyToken || !cachedSellToken || !networkId) return
+    if (
+      !buyAmount ||
+      buyAmount.isZero() ||
+      !sellAmount ||
+      sellAmount.isZero() ||
+      !cachedBuyToken ||
+      !cachedSellToken ||
+      !networkId
+    ) {
+      logDebug(
+        `Preventing null values on submit: 
+        buyAmount:${buyAmount}, sellAmount:${sellAmount}, 
+        cachedBuyToken:${cachedBuyToken}, cachedSellToken${cachedSellToken}, 
+        networkId:${networkId}`,
+      )
+      return
+    }
     const orderParams = {
       price,
       validFrom: validFromAsBatch,


### PR DESCRIPTION
Closes #1225

Simple fix, prevents submission when either value is 0.
We had the check in place for `falsy` values, but since amount is a BN, we also need to check whether it's zero.

Does not address the slowness to fill in buyAmount.

Printing debug log entry when a null value is detected:
![screenshot_2020-07-14_13-11-24](https://user-images.githubusercontent.com/43217/87471600-7a5e6780-c5d3-11ea-8521-4974e12494ea.png)

## Steps to reproduce
1. Fill in a sell amount
2. Click on suggested price
3. Very quickly, click on submit or hit enter.

Before: the wallet is prompted to sign the tx, before the `Receive at least` (buyAmount) is filled
After: no tx is sent, debug log message is printed.
