### PR TITLE
Decreasing the amount of token required to consider token enabled

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -35,7 +35,7 @@ export const ORDER_FILLED_FACTOR = new BN(10000) // 0.01%
 
 export const BATCH_SUBMISSION_CLOSE_TIME = 4 // in minutes
 
-export const MINIMUM_ALLOWANCE_DECIMALS = 12
+export const MINIMUM_ALLOWANCE_DECIMALS = 10
 
 export const APP_NAME = 'fuse'
 


### PR DESCRIPTION
Closes #1229 

This issue as been previously addressed on https://github.com/gnosis/dex-react/pull/1147 when a token used uint128 for allowance.

This time, the token uses uint96.

This change reduces the minimum amount required to consider a token enabled.

Using the COMP token as example, that has 18 decimal places, the user now will have to deposit over 29 billion COMP before an allowance refresh is required:
![screenshot_2020-07-15_14-42-05](https://user-images.githubusercontent.com/43217/87602307-9cc3b400-c6ab-11ea-9ec9-da4b90c01fb9.png)

To test, add COMP token (`0xc00e94Cb662C3520282E6f5717214004A7f26888`) to your mainnet wallet and enabled it.

On latest mesa.eth.link after refresh the page, the enable button will be shown again.
On this PR, it won't.
