### PR TITLE
Fix liquidity orders on rinkeby

### DIFF
--- a/src/components/PoolingWidget/index.tsx
+++ b/src/components/PoolingWidget/index.tsx
@@ -156,7 +156,13 @@ const PoolingInterface: React.FC = () => {
     )
   }, [tokenList])
 
-  const [selectedTokensMap, setSelectedTokensMap] = useSafeState<Map<number, TokenDetails>>(setFullTokenMap(tokens))
+  const [selectedTokensMap, setSelectedTokensMap] = useSafeState<Map<number, TokenDetails>>(() =>
+    setFullTokenMap(tokens),
+  )
+
+  useEffect(() => {
+    setSelectedTokensMap(setFullTokenMap(tokens))
+  }, [setSelectedTokensMap, tokens])
 
   const methods = useForm<PoolingFormData>({
     defaultValues: {


### PR DESCRIPTION
The issue happens because:

1. Page load
2. No connection => default networkId = 1
3. `selectedTokensMap` is filled with tokens from network 1
4. Connection to rinkeby established
5. Tokens updated
6. But `selectedTokensMap` not refilled

This is a quick fix, but let's switch to addresses instead of symbols soonish.
Having addresses in `LIQUIDITY_TOKEN_LIST` and that list differentiating by network would have made this issue more obvious (cause there would not have been a match for wrong address on the right network)

Closes #1235