### PR TITLE
Removing duplicated `Market` row for responsive orders

### DIFF
--- a/src/components/OrdersWidget/OrderRow.styled.ts
+++ b/src/components/OrdersWidget/OrderRow.styled.ts
@@ -60,14 +60,3 @@ export const OrderRowWrapper = styled(FoldableRowWrapper)<{ $color?: string }>`
     }
   }
 `
-
-export const ResponsiveTitleRow = styled.td`
-  // force first
-  order: -1;
-
-  > div:first-of-type {
-    display: flex;
-    justify-content: center;
-    align-items: items;
-  }
-`

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -27,7 +27,7 @@ import {
 
 import { DetailedAuctionElement } from 'api/exchange/ExchangeApi'
 
-import { OrderRowWrapper, ResponsiveTitleRow } from 'components/OrdersWidget/OrderRow.styled'
+import { OrderRowWrapper } from 'components/OrdersWidget/OrderRow.styled'
 import { displayTokenSymbolOrLink } from 'utils/display'
 
 const PendingLink: React.FC<Pick<Props, 'transactionHash'>> = props => {
@@ -318,11 +318,6 @@ const OrderRow: React.FC<Props> = props => {
           isPendingOrder={isPendingOrder}
           transactionHash={transactionHash}
         />
-        <ResponsiveTitleRow className="responsiveRow" data-label="Market">
-          <div>
-            {displayTokenSymbolOrLink(buyToken)}/{displayTokenSymbolOrLink(sellToken)}
-          </div>
-        </ResponsiveTitleRow>
       </OrderRowWrapper>
     )
   )


### PR DESCRIPTION
Part of #1236 

Before:
![screenshot_2020-07-17_12-54-29](https://user-images.githubusercontent.com/43217/87825751-8bee7c00-c82c-11ea-820f-b4aa1fa89521.png)

After:
![screenshot_2020-07-17_12-55-10](https://user-images.githubusercontent.com/43217/87825799-a1fc3c80-c82c-11ea-813b-ebc24af6c557.png)

