### PR TITLE
Token for price estimator is fixed, even when showing inverted price

### DIFF
--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -159,7 +159,7 @@ const OnchainOrderbookPriceEstimation: React.FC<OnchainOrderbookPriceEstimationP
         <HighlightedText>Onchain orderbook price</HighlightedText> <HelpTooltip tooltip={OnchainOrderbookTooltip} /> for
         selling{' '}
         <strong>
-          {+amount || '1'} {displayQtName}
+          {+amount || '1'} {displayTokenSymbolOrLink(quoteToken)}
         </strong>
         :
       </span>


### PR DESCRIPTION
Small fix, this got changed during a refactor.

To be merged onto #1234 

Before:
![screenshot_2020-07-17_13-45-30](https://user-images.githubusercontent.com/43217/87829314-abd56e00-c833-11ea-8061-8b9035a4bb05.png)
![screenshot_2020-07-17_13-45-16](https://user-images.githubusercontent.com/43217/87829315-ad069b00-c833-11ea-8b05-2708d11c7b61.png)

After:
![screenshot_2020-07-17_13-46-48](https://user-images.githubusercontent.com/43217/87829426-ec34ec00-c833-11ea-9090-110574e03330.png)
![screenshot_2020-07-17_13-46-37](https://user-images.githubusercontent.com/43217/87829428-eccd8280-c833-11ea-849a-b15c450637f1.png)

