### PR TITLE
Fix wrong Fills number

### DIFF
--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -7,7 +7,7 @@ import { faTrashAlt, faChevronDown, faChevronUp } from '@fortawesome/free-solid-
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 // Const and utils
-import { isOrderActive, isPendingOrderActive } from 'utils'
+import { isOrderActive, isPendingOrderActive, isTradeSettled, isTradeReverted } from 'utils'
 import { DEFAULT_ORDERS_SORTABLE_TOPIC } from 'const'
 import { filterTradesFn, filterOrdersFn } from 'utils/filter'
 
@@ -307,12 +307,17 @@ const OrdersWidget: React.FC<Props> = ({ displayOnly }) => {
     [deleteOrders, forceOrdersRefresh, markedForDeletion, selectedTab, setClassifiedOrders],
   )
 
+  const settledAndNotRevertedTrades = useMemo(
+    () => trades.filter(trade => trade && isTradeSettled(trade) && !isTradeReverted(trade)),
+    [trades],
+  )
+
   const {
     filteredData: filteredTrades,
     search: tradesSearch,
     handlers: { handleSearch: handleTradesSearch },
   } = useDataFilter<Trade>({
-    data: trades,
+    data: settledAndNotRevertedTrades,
     filterFnFactory: filterTradesFn,
   })
 
@@ -390,7 +395,7 @@ const OrdersWidget: React.FC<Props> = ({ displayOnly }) => {
                 <ShowOrdersButton
                   type="fills"
                   isActive={selectedTab === 'fills'}
-                  count={trades.length}
+                  count={settledAndNotRevertedTrades.length}
                   onClick={setSelectedTabFactory('fills')}
                 />
                 <ShowOrdersButton

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -22,7 +22,7 @@ import { Trade } from 'api/exchange/ExchangeApi'
 import { toCsv, CsvColumns } from 'utils/csv'
 import { filterTradesFn } from 'utils/filter'
 
-import { getNetworkFromId, isTradeSettled, isTradeReverted, divideBN } from 'utils'
+import { getNetworkFromId, divideBN } from 'utils'
 import { symbolOrAddress } from 'utils/display'
 
 const CsvButtonContainer = styled.div`
@@ -129,18 +129,13 @@ export const InnerTradesWidget: React.FC<InnerTradesWidgetProps> = props => {
 
   const { networkId, userAddress } = useWalletConnection()
 
-  const filteredTrades = useMemo(
-    () => trades.filter(trade => trade && isTradeSettled(trade) && !isTradeReverted(trade)),
-    [trades],
-  )
-
   const generateCsv = useCallback(
     () =>
       toCsv({
-        data: filteredTrades,
+        data: trades,
         transformer: csvTransformer,
       }),
-    [filteredTrades],
+    [trades],
   )
 
   const filename = useMemo(
@@ -185,7 +180,7 @@ export const InnerTradesWidget: React.FC<InnerTradesWidgetProps> = props => {
         </tr>
       </thead>
       <tbody>
-        {filteredTrades.map(trade => (
+        {trades.map(trade => (
           <TradeRow key={trade.id} trade={trade} networkId={networkId} />
         ))}
       </tbody>


### PR DESCRIPTION
Fills tab was displaying `trades.length` before filtering unsettled and reverted trades.

![localhost_8080_trade_DAI-USDC_sell=0 price=0 from= expires= (1)](https://user-images.githubusercontent.com/5121491/87923160-bb4bf580-ca85-11ea-9fdd-87f56c58767e.png)
