### PR TITLE
Trades page styling

### DIFF
--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -37,7 +37,7 @@ interface WithdrawState {
   tokenAddress: string
 }
 
-const BalancesWidget = styled(CardWidgetWrapper)`
+export const BalancesWidget = styled(CardWidgetWrapper)`
   background: var(--color-background-pageWrapper);
   height: 100%;
 

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -7,11 +7,12 @@ import styled from 'styled-components'
 import { formatPrice, formatAmount, invertPrice, formatAmountFull } from '@gnosis.pm/dex-js'
 
 import FilterTools from 'components/FilterTools'
-import { CardTable, CardWidgetWrapper } from 'components/Layout/Card'
+import { CardTable } from 'components/Layout/Card'
 import { ConnectWalletBanner } from 'components/ConnectWalletBanner'
 import { FileDownloaderLink } from 'components/FileDownloaderLink'
 import { StandaloneCardWrapper } from 'components/Layout/PageWrapper'
 import { TradeRow } from 'components/TradesWidget/TradeRow'
+import { BalancesWidget } from 'components/DepositWidget'
 
 import { useWalletConnection } from 'hooks/useWalletConnection'
 import { useTrades } from 'hooks/useTrades'
@@ -21,9 +22,31 @@ import { Trade } from 'api/exchange/ExchangeApi'
 
 import { toCsv, CsvColumns } from 'utils/csv'
 import { filterTradesFn } from 'utils/filter'
-
 import { getNetworkFromId, isTradeSettled, isTradeReverted, divideBN } from 'utils'
 import { symbolOrAddress } from 'utils/display'
+
+const OverflowContainer = styled(BalancesWidget)`
+  > ${CardTable} {
+    > thead > tr:not(.cardRowDrawer) {
+      padding: 0.8rem 2rem 0.8rem 1.6rem;
+    }
+
+    > thead,
+    > tbody {
+      font-size: 1.3rem;
+
+      > tr:not(.cardRowDrawer) {
+        min-height: 4rem;
+        text-align: left;
+        > td,
+        > th {
+          justify-content: flex-start;
+          text-align: left;
+        }
+      }
+    }
+  }
+`
 
 const CsvButtonContainer = styled.div`
   display: flex;
@@ -210,7 +233,7 @@ export const TradesWidget: React.FC = () => {
     <ConnectWalletBanner />
   ) : (
     <StandaloneCardWrapper>
-      <CardWidgetWrapper>
+      <OverflowContainer>
         <FilterTools
           className="widgetFilterTools"
           resultName="trades"
@@ -220,7 +243,7 @@ export const TradesWidget: React.FC = () => {
           dataLength={filteredData.length}
         />
         <InnerTradesWidget trades={filteredData} />
-      </CardWidgetWrapper>
+      </OverflowContainer>
     </StandaloneCardWrapper>
   )
 }

--- a/src/pages/Trades.tsx
+++ b/src/pages/Trades.tsx
@@ -1,1 +1,11 @@
-export { default } from 'components/TradesWidget'
+import React from 'react'
+import TradesPage from 'components/TradesWidget'
+import { PageWrapper } from 'components/Layout/PageWrapper'
+
+const Trades: React.FC = () => (
+  <PageWrapper>
+    <TradesPage />
+  </PageWrapper>
+)
+
+export default Trades


### PR DESCRIPTION
Forgot to wrap TradesPage in the overflow wrapper... fixes that

## Before:
![Screenshot from 2020-07-20 18-55-36](https://user-images.githubusercontent.com/21335563/87964513-a3db2f80-caba-11ea-832a-8198ffdd89fc.png)

## After:
![Screenshot from 2020-07-20 18-55-41](https://user-images.githubusercontent.com/21335563/87964521-a6d62000-caba-11ea-9330-070749eb9dd1.png)
