### PR TITLE
Do not show liquidity trades on orders page

### DIFF
--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -4,7 +4,7 @@ import { PageWrapper } from 'components/Layout/PageWrapper'
 
 const Orders: React.FC = () => (
   <PageWrapper>
-    <OrdersWidget />
+    <OrdersWidget displayOnly="regular" />
   </PageWrapper>
 )
 


### PR DESCRIPTION
Mobile `Fills` tab shows all trades, regular and liquidity.
That's because on responsive mode we show `/orders` page directly.

This change enables the filter for the `/orders` page equal to the one used on `/trade` page.