### PR TITLE
Updated liquidity success message

### DIFF
--- a/src/components/PoolingWidget/AddFunding.tsx
+++ b/src/components/PoolingWidget/AddFunding.tsx
@@ -37,11 +37,7 @@ const AddFunding: React.FC<AddFundingProps> = ({ txIdentifier, txReceipt }) => (
     </HighlightDiv>
     <p>
       <strong>Great</strong> - your liquidity provision is being created right now. Your standing orders will be visible
-      on the{' '}
-      <strong>
-        <Link to="orders">Orders page</Link>
-      </strong>{' '}
-      where you can also cancel these at any time.
+      on this very page, where you can also cancel them at any time.
     </p>
     <p>
       <strong>What now?</strong>


### PR DESCRIPTION
Liquidity orders now are displayed on `/liquidity` page

Before:
![screenshot_2020-07-21_08-28-21](https://user-images.githubusercontent.com/43217/88074570-6fa05700-cb2c-11ea-9b75-ea369913c49a.png)

After:
![screenshot_2020-07-21_08-30-26](https://user-images.githubusercontent.com/43217/88074579-729b4780-cb2c-11ea-945c-7c23ab87f58f.png)
