### PR TITLE
Sepatate the spinner and Pending label

### DIFF
--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -34,7 +34,8 @@ const PendingLink: React.FC<Pick<Props, 'transactionHash'>> = props => {
   const { transactionHash } = props
   return (
     <>
-      <Spinner size="sm" /> Pending...
+      <Spinner size="sm" />
+      &nbsp;Pending...
       <br />
       {transactionHash && <EtherscanLink identifier={transactionHash} type="tx" label={<small>View status</small>} />}
     </>


### PR DESCRIPTION
Just a tiny detail that bother me while testing and just went for it

Before:
![image](https://user-images.githubusercontent.com/2352112/88086617-ed458080-cb87-11ea-823d-f7af2ec8c565.png)

After:
![image](https://user-images.githubusercontent.com/2352112/88086711-182fd480-cb88-11ea-9cea-89e3ade35993.png)

Before @Velenir says anything, `{' '}` don't work for me, cause prettier plugin turn it into a space, that then is removed when rendering. Old school `&nbsp;` works fine