### PR TITLE
Invert orders initial sort by date

### DIFF
--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -193,6 +193,7 @@ const OrdersWidget: React.FC<Props> = ({ displayOnly }) => {
     displayedOrders,
     DEFAULT_ORDERS_SORTABLE_TOPIC,
     compareFnFactory,
+    'desc',
   )
 
   // Why 2 useDataFilter instead of concatenating pending + current?

--- a/src/hooks/useSortByTopic.ts
+++ b/src/hooks/useSortByTopic.ts
@@ -12,9 +12,13 @@ function useSortByTopic<T, K extends string>(
   data: T[],
   defaultTopic: K,
   compareFnFactory: CustomSortComparator<T, K>,
+  initialSort?: 'asc' | 'desc',
 ): { sortedData: T[]; sortTopic: SortTopic<K>; setSortTopic: React.Dispatch<React.SetStateAction<SortTopic<K>>> } {
   // true == 'asc' && false == 'dsc'
-  const [sortTopic, setSortTopic] = useSafeState<SortTopic<K>>({ topic: defaultTopic, asc: true })
+  const [sortTopic, setSortTopic] = useSafeState<SortTopic<K>>({
+    topic: defaultTopic,
+    asc: !initialSort || initialSort === 'asc',
+  })
   const [sortedData, setSortedData] = useSafeState<T[]>(data)
 
   const { asc, topic } = sortTopic


### PR DESCRIPTION
Now:
![screenshot_2020-07-23_10-04-03](https://user-images.githubusercontent.com/43217/88316091-1e2ece00-cccc-11ea-882c-a5de5683b9ec.png)
