### PR TITLE
hotfix/1.1.1

### DIFF
--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -5,6 +5,7 @@ import BN from 'bn.js'
 
 // Utils, const, types
 import { logDebug, getToken } from 'utils'
+import { checkTokenAgainstSearch } from 'utils/filter'
 import { ZERO, MEDIA } from 'const'
 import { TokenBalanceDetails } from 'types'
 
@@ -182,14 +183,10 @@ interface BalanceDisplayProps extends TokenLocalState {
   ): Promise<void>
 }
 
-const customFilterFnFactory = (searchTxt: string) => ({ symbol, name, address }: TokenBalanceDetails): boolean => {
+const customFilterFnFactory = (searchTxt: string) => (token: TokenBalanceDetails): boolean => {
   if (searchTxt === '') return true
 
-  return (
-    symbol?.toLowerCase().includes(searchTxt) ||
-    name?.toLowerCase().includes(searchTxt) ||
-    address.toLowerCase().includes(searchTxt)
-  )
+  return checkTokenAgainstSearch(token, searchTxt)
 }
 
 const customHideZeroFilterFn = ({

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -21,10 +21,9 @@ const filterTradesAndOrdersFnFactory = <
 
   const market =
     sellToken && buyToken && computeMarketProp({ sellToken, buyToken, inverseMarket: includeInverseMarket })
-
+  console.debug(id, rest)
   return (
-    !!id.includes(searchTxt) ||
-    (rest.orderId && !!rest.orderId.includes(searchTxt)) ||
+    (rest.orderId ? !!rest.orderId.includes(searchTxt) : !!id.includes(searchTxt)) ||
     (market && !!market.includes(searchTxt)) ||
     checkTokenAgainstSearch(buyToken, searchTxt) ||
     checkTokenAgainstSearch(sellToken, searchTxt)

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -3,12 +3,12 @@ import { DetailedAuctionElement, Trade } from 'api/exchange/ExchangeApi'
 import { computeMarketProp } from './display'
 import { web3 } from 'api'
 
-export function checkTokenAgainstSearch(token: TokenDetails | null, searchText: string): boolean {
+export function checkTokenAgainstSearch(token: TokenDetails | null, searchText: string, isAddress?: boolean): boolean {
   if (!token) return false
   return (
     token?.symbol?.toLowerCase().includes(searchText) ||
     token?.name?.toLowerCase().includes(searchText) ||
-    (web3.utils.isAddress(searchText) && token?.address.toLowerCase().includes(searchText))
+    (!!isAddress && token?.address.toLowerCase().includes(searchText))
   )
 }
 
@@ -19,14 +19,15 @@ const filterTradesAndOrdersFnFactory = <
 ) => (searchTxt: string) => ({ id, buyToken, sellToken, ...rest }: T): boolean | null => {
   if (searchTxt === '') return null
 
+  const searchIsAddress = web3.utils.isAddress(searchTxt)
   const market =
     sellToken && buyToken && computeMarketProp({ sellToken, buyToken, inverseMarket: includeInverseMarket })
-  console.debug(id, rest)
+
   return (
     (rest.orderId ? !!rest.orderId.includes(searchTxt) : !!id.includes(searchTxt)) ||
     (market && !!market.includes(searchTxt)) ||
-    checkTokenAgainstSearch(buyToken, searchTxt) ||
-    checkTokenAgainstSearch(sellToken, searchTxt)
+    checkTokenAgainstSearch(buyToken, searchTxt, searchIsAddress) ||
+    checkTokenAgainstSearch(sellToken, searchTxt, searchIsAddress)
   )
 }
 

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -1,13 +1,14 @@
 import { TokenDetails } from 'types'
 import { DetailedAuctionElement, Trade } from 'api/exchange/ExchangeApi'
 import { computeMarketProp } from './display'
+import { web3 } from 'api'
 
 export function checkTokenAgainstSearch(token: TokenDetails | null, searchText: string): boolean {
   if (!token) return false
   return (
     token?.symbol?.toLowerCase().includes(searchText) ||
     token?.name?.toLowerCase().includes(searchText) ||
-    token?.address.toLowerCase().includes(searchText)
+    (web3.utils.isAddress(searchText) && token?.address.toLowerCase().includes(searchText))
   )
 }
 

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -12,10 +12,10 @@ export function checkTokenAgainstSearch(token: TokenDetails | null, searchText: 
 }
 
 const filterTradesAndOrdersFnFactory = <
-  T extends { id: string; buyToken: TokenDetails | null; sellToken: TokenDetails | null }
+  T extends { id: string; buyToken: TokenDetails | null; sellToken: TokenDetails | null; orderId?: string }
 >(
   includeInverseMarket?: boolean,
-) => (searchTxt: string) => ({ id, buyToken, sellToken }: T): boolean | null => {
+) => (searchTxt: string) => ({ id, buyToken, sellToken, ...rest }: T): boolean | null => {
   if (searchTxt === '') return null
 
   const market =
@@ -23,6 +23,7 @@ const filterTradesAndOrdersFnFactory = <
 
   return (
     !!id.includes(searchTxt) ||
+    (rest.orderId && !!rest.orderId.includes(searchTxt)) ||
     (market && !!market.includes(searchTxt)) ||
     checkTokenAgainstSearch(buyToken, searchTxt) ||
     checkTokenAgainstSearch(sellToken, searchTxt)


### PR DESCRIPTION
Filtering for `orderId` in `Trades` tab/page was wrong - fixed

1. will still occassionally pick up wrong trades when `orderId` coincidentally is also found inside a token address, for example