### PR TITLE
Low volume warning

### DIFF
--- a/src/api/gasStation.ts
+++ b/src/api/gasStation.ts
@@ -5,7 +5,9 @@ const GAS_STATIONS = {
   4: 'https://safe-relay.staging.gnosisdev.com/api/v1/gas-station/',
 }
 
-const GAS_PRICE_LEVEL: Exclude<keyof GasStationResponse, 'lastUpdate'> = 'standard'
+export type GasPriceLevel = Exclude<keyof GasStationResponse, 'lastUpdate'>
+
+const GAS_PRICE_LEVEL: GasPriceLevel = 'standard'
 
 let cacheKey = ''
 let cachedGasPrice: string
@@ -26,7 +28,9 @@ interface GasStationResponse {
   fastest: string
 }
 
-const fetchGasPriceFactory = (walletApi: WalletApi) => async (): Promise<string | undefined> => {
+const fetchGasPriceFactory = (walletApi: WalletApi) => async (
+  gasPriceLevel: GasPriceLevel = GAS_PRICE_LEVEL,
+): Promise<string | undefined> => {
   const { blockchainState } = walletApi
 
   if (!blockchainState) return undefined
@@ -47,7 +51,7 @@ const fetchGasPriceFactory = (walletApi: WalletApi) => async (): Promise<string 
     const response = await fetch(gasStationURL)
     const json: GasStationResponse = await response.json()
 
-    const gasPrice = json[GAS_PRICE_LEVEL]
+    const gasPrice = json[gasPriceLevel]
     if (gasPrice) {
       cacheKey = key
       cachedGasPrice = gasPrice

--- a/src/api/wallet/WalletApi.ts
+++ b/src/api/wallet/WalletApi.ts
@@ -13,7 +13,7 @@ import { logDebug, toBN, txDataEncoder, generateWCOptions } from 'utils'
 import { subscribeToWeb3Event } from './subscriptionHelpers'
 import { getMatchingScreenSize, subscribeToScreenSizeChange } from 'utils/mediaQueries'
 import { composeProvider } from './composeProvider'
-import fetchGasPriceFactory from 'api/gasStation'
+import fetchGasPriceFactory, { GasPriceLevel } from 'api/gasStation'
 import { earmarkTxData } from 'api/earmark'
 import { Provider, isMetamaskProvider, isWalletConnectProvider, ProviderRpcError } from './providerUtils'
 
@@ -53,7 +53,7 @@ export interface WalletApi {
   getProviderInfo(): ProviderInfo
   blockchainState: BlockchainUpdatePrompt
   userPrintAsync: Promise<string>
-  getGasPrice(): Promise<number | null>
+  getGasPrice(gasPriceLevel?: GasPriceLevel): Promise<number | null>
 }
 
 export interface WalletInfo {
@@ -462,10 +462,10 @@ export class WalletApiImpl implements WalletApi {
     await this._notifyListeners()
   }
 
-  public async getGasPrice(): Promise<number | null> {
+  public async getGasPrice(gasPriceLevel?: GasPriceLevel): Promise<number | null> {
     // this never errors
     // returns undefined if unable to fetch
-    let gasPrice = await this._fetchGasPrice()
+    let gasPrice = await this._fetchGasPrice(gasPriceLevel)
 
     if (gasPrice) return +gasPrice
     try {

--- a/src/api/wallet/WalletApiMock.ts
+++ b/src/api/wallet/WalletApiMock.ts
@@ -58,6 +58,10 @@ export class WalletApiMock implements WalletApi {
     return this.connect()
   }
 
+  public async getGasPrice(): Promise<null> {
+    return null
+  }
+
   public async getAddress(): Promise<string> {
     assert(this._connected, 'The wallet is not connected')
 

--- a/src/components/TradeWidget/TxMessage.tsx
+++ b/src/components/TradeWidget/TxMessage.tsx
@@ -66,8 +66,10 @@ const useLowVolumeAmount = ({ sellToken, sellTokenAmount, networkId }: LowVolume
       priceEstimation === null ||
       wethPriceInOwl === null ||
       gasPrice === null
-    )
+    ) {
       return { isLoading: true }
+    }
+
     logDebug('priceEstimation of', sellToken.symbol, 'in OWL', priceEstimation.toString(10))
     logDebug('WETH price in OWL', wethPriceInOwl.toString(10))
 

--- a/src/components/TradeWidget/TxMessage.tsx
+++ b/src/components/TradeWidget/TxMessage.tsx
@@ -127,7 +127,7 @@ export const TxMessage: React.FC<TxMessageProps> = ({ sellToken, receiveToken, n
       {!isLoading && isLowVolume && (
         <Warning>
           <span>
-            This is a small order. Please keep in mind that solvers might not include your order if it does not generate
+            This is a low volume order. Please keep in mind that solvers might not include your order if it does not generate
             enough fee to pay their running costs. Learn more [here]
           </span>
           <img className="alert" src={alertIcon} />

--- a/src/components/TradeWidget/TxMessage.tsx
+++ b/src/components/TradeWidget/TxMessage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { formatTimeInHours } from 'utils'
+import { formatTimeInHours, logDebug } from 'utils'
 import { useFormContext } from 'react-hook-form'
 import { TokenDetails } from 'types'
 import styled from 'styled-components'
@@ -68,8 +68,8 @@ const useLowVolumeAmount = ({ sellToken, sellTokenAmount, networkId }: LowVolume
       gasPrice === null
     )
       return { isLoading: true }
-    console.log('priceEstimation of', sellToken.symbol, 'in OWL', priceEstimation.toString(10))
-    console.log('WETH price in OWL', wethPriceInOwl.toString(10))
+    logDebug('priceEstimation of', sellToken.symbol, 'in OWL', priceEstimation.toString(10))
+    logDebug('WETH price in OWL', wethPriceInOwl.toString(10))
 
     const minTradableAmountInOwl = calcMinTradableAmountInOwl({ gasPrice, ethPriceInOwl: wethPriceInOwl })
 
@@ -78,7 +78,7 @@ const useLowVolumeAmount = ({ sellToken, sellTokenAmount, networkId }: LowVolume
 
     const difference = isLowVolume ? minTradableAmountPerToken.minus(sellTokenAmount) : ZERO_BIG_NUMBER
 
-    console.log('{ isLowVolume, difference, minAmount, gasPrice }', {
+    logDebug({
       isLowVolume,
       difference: difference.toString(10),
       minAmount: minTradableAmountPerToken.toString(10),
@@ -127,8 +127,8 @@ export const TxMessage: React.FC<TxMessageProps> = ({ sellToken, receiveToken, n
       {!isLoading && isLowVolume && (
         <Warning>
           <span>
-            This is a low volume order. Please keep in mind that solvers might not include your order if it does not generate
-            enough fee to pay their running costs. Learn more [here]
+            This is a low volume order. Please keep in mind that solvers might not include your order if it does not
+            generate enough fee to pay their running costs. Learn more [here]
           </span>
           <img className="alert" src={alertIcon} />
         </Warning>

--- a/src/components/TradeWidget/TxMessage.tsx
+++ b/src/components/TradeWidget/TxMessage.tsx
@@ -11,6 +11,7 @@ import { ZERO_BIG_NUMBER } from 'const'
 
 import alertIcon from 'assets/img/alert.svg'
 import { useGasPrice } from 'hooks/useGasPrice'
+import { DEFAULT_GAS_PRICE, calcMinTradableAmountInOwl } from 'utils/minFee'
 
 interface TxMessageProps {
   sellToken: TokenDetails
@@ -34,21 +35,6 @@ const Warning = styled.p`
   }
 `
 
-const DEFAULT_GASP_RICE = 40e9 // 40 Gwei
-const ETH_PRICE_IN_OWL = 240 * 1000
-const SUBSIDIZE_FACTOR = 10
-
-const SETTLEMENT_FACTOR = 1.5
-const FEE_FACTOR = 1000
-
-const calcMinTradableAmountInOwl = (gasPrice: number): BigNumber => {
-  //                            trade tx gasLimit
-  const MIN_ECONOMICAL_VIABLE_FEE_IN_OWL = 120000 * gasPrice * ETH_PRICE_IN_OWL
-
-  const MIN_FEE = MIN_ECONOMICAL_VIABLE_FEE_IN_OWL / SUBSIDIZE_FACTOR
-  return new BigNumber(MIN_FEE * FEE_FACTOR * SETTLEMENT_FACTOR)
-}
-
 interface LowVolumeParams {
   sellToken: TokenDetails
   networkId: number
@@ -69,7 +55,7 @@ const useLowVolumeAmount = ({ sellToken, sellTokenAmount, networkId }: LowVolume
     networkId,
   })
 
-  const gasPrice = useGasPrice(DEFAULT_GASP_RICE)
+  const gasPrice = useGasPrice(DEFAULT_GAS_PRICE)
 
   return useMemo(() => {
     if (isPriceLoading || priceEstimation === null || gasPrice === null) return { isLoading: true }

--- a/src/components/TradeWidget/TxMessage.tsx
+++ b/src/components/TradeWidget/TxMessage.tsx
@@ -57,7 +57,7 @@ const useLowVolumeAmount = ({ sellToken, sellTokenAmount, networkId }: LowVolume
 
   const { priceEstimation: wethPriceInOwl, isPriceLoading: isWETHPriceLoading } = useWETHPriceInOwl(networkId)
 
-  const gasPrice = useGasPrice(DEFAULT_GAS_PRICE)
+  const gasPrice = useGasPrice({ defaultGasPrice: DEFAULT_GAS_PRICE, gasPriceLevel: 'fast' })
 
   return useMemo(() => {
     if (

--- a/src/components/TradeWidget/TxMessage.tsx
+++ b/src/components/TradeWidget/TxMessage.tsx
@@ -1,21 +1,84 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { formatTimeInHours } from 'utils'
 import { useFormContext } from 'react-hook-form'
 import { TokenDetails } from 'types'
 import styled from 'styled-components'
 import { TradeFormData } from '.'
 import { displayTokenSymbolOrLink } from 'utils/display'
+import { usePriceEstimationInOwl } from 'hooks/usePriceEstimation'
+import BigNumber from 'bignumber.js'
+import { ZERO_BIG_NUMBER } from 'const'
+
+import alertIcon from 'assets/img/alert.svg'
 
 interface TxMessageProps {
   sellToken: TokenDetails
   receiveToken: TokenDetails
+  networkId: number
 }
 
 const TxMessageWrapper = styled.div`
   padding: 1em;
 `
 
-export const TxMessage: React.FC<TxMessageProps> = ({ sellToken, receiveToken }) => {
+const Warning = styled.p`
+  background: beige;
+  padding: 0.5em;
+  box-shadow: inset 0 0 7px 3px #cc262647;
+  border-radius: 0.3em;
+  display: flex;
+
+  .alert {
+    min-width: 2.5em;
+  }
+`
+
+const MIN_ECONOMICAL_VIABLE_FEE_IN_OWL = 1.2
+const SUBSIDIZE_FACTOR = 10
+const MIN_FEE = MIN_ECONOMICAL_VIABLE_FEE_IN_OWL / SUBSIDIZE_FACTOR
+const SETTLEMENT_FACTOR = 1.5
+const FEE_FACTOR = 1000
+const MIN_TRADABLE_AMOUNT_IN_OWL = new BigNumber(MIN_FEE * FEE_FACTOR * SETTLEMENT_FACTOR)
+
+interface LowVolumeParams {
+  sellToken: TokenDetails
+  networkId: number
+  sellTokenAmount: string
+}
+
+interface LowVolumeResult {
+  isLoading: boolean
+  isLowVolume?: boolean
+  difference?: BigNumber
+  minAmount?: BigNumber
+}
+
+const useLowVolumeAmount = ({ sellToken, sellTokenAmount, networkId }: LowVolumeParams): LowVolumeResult => {
+  const { priceEstimation, isPriceLoading } = usePriceEstimationInOwl({
+    tokenId: sellToken.id,
+    tokenDecimals: sellToken.decimals,
+    networkId,
+  })
+
+  return useMemo(() => {
+    if (isPriceLoading || priceEstimation === null) return { isLoading: true }
+    console.log('priceEstimation of', sellToken.symbol, 'in OWL', priceEstimation.toString(10))
+
+    const minTradableAmountPerToken = MIN_TRADABLE_AMOUNT_IN_OWL.dividedBy(priceEstimation)
+    const isLowVolume = minTradableAmountPerToken.isGreaterThan(sellTokenAmount)
+
+    const difference = isLowVolume ? minTradableAmountPerToken.minus(sellTokenAmount) : ZERO_BIG_NUMBER
+
+    console.log('{ isLowVolume, difference, minAmount }', {
+      isLowVolume,
+      difference: difference.toString(10),
+      minAmount: minTradableAmountPerToken.toString(10),
+    })
+    return { isLowVolume, difference, isLoading: false, minAmount: minTradableAmountPerToken }
+  }, [isPriceLoading, priceEstimation, sellToken.symbol, sellTokenAmount])
+}
+
+export const TxMessage: React.FC<TxMessageProps> = ({ sellToken, receiveToken, networkId }) => {
   const { getValues } = useFormContext<TradeFormData>()
   const {
     price,
@@ -27,6 +90,8 @@ export const TxMessage: React.FC<TxMessageProps> = ({ sellToken, receiveToken })
   } = getValues()
   const displaySellToken = displayTokenSymbolOrLink(sellToken)
   const displayReceiveToken = displayTokenSymbolOrLink(receiveToken)
+
+  const { isLoading, isLowVolume } = useLowVolumeAmount({ sellToken, networkId, sellTokenAmount })
 
   return (
     <TxMessageWrapper>
@@ -49,6 +114,15 @@ export const TxMessage: React.FC<TxMessageProps> = ({ sellToken, receiveToken })
         Your order starts {formatTimeInHours(validFrom || 0, 'now')}{' '}
         {validUntil && `and will expire ${formatTimeInHours(validUntil, 'Never')}`}
       </p>
+      {!isLoading && isLowVolume && (
+        <Warning>
+          <span>
+            This is a small order. Please keep in mind that solvers might not include your order if it does not generate
+            enough fee to pay their running costs. Learn more [here]
+          </span>
+          <img className="alert" src={alertIcon} />
+        </Warning>
+      )}
     </TxMessageWrapper>
   )
 }

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -999,7 +999,9 @@ const TradeWidget: React.FC = () => {
           <p>This order might be partially filled.</p>
           <ButtonWrapper
             onConfirm={onConfirm}
-            message={(): React.ReactNode => <TxMessage sellToken={sellToken} receiveToken={receiveToken} />}
+            message={(): React.ReactNode => (
+              <TxMessage networkId={networkIdOrDefault} sellToken={sellToken} receiveToken={receiveToken} />
+            )}
           >
             <SubmitButton
               data-text="This order might be partially filled."

--- a/src/hooks/useGasPrice.ts
+++ b/src/hooks/useGasPrice.ts
@@ -1,16 +1,22 @@
 import { useEffect } from 'react'
 import useSafeState from './useSafeState'
 import { walletApi } from 'api'
+import { GasPriceLevel } from 'api/gasStation'
 
-export const useGasPrice = (defaultGasPrice: number | null = null): number | null => {
+interface GasPriceParams {
+  gasPriceLevel?: GasPriceLevel
+  defaultGasPrice?: number | null
+}
+
+export const useGasPrice = ({ defaultGasPrice = null, gasPriceLevel }: GasPriceParams = {}): number | null => {
   const [gasPrice, setGasPrice] = useSafeState<number | null>(null)
   useEffect(() => {
     async function getGasPrice(): Promise<void> {
-      const gasPrice = (await walletApi.getGasPrice()) || defaultGasPrice
+      const gasPrice = (await walletApi.getGasPrice(gasPriceLevel)) || defaultGasPrice
       setGasPrice(gasPrice)
     }
     getGasPrice()
-  }, [setGasPrice, defaultGasPrice])
+  }, [setGasPrice, defaultGasPrice, gasPriceLevel])
 
   return gasPrice
 }

--- a/src/hooks/useGasPrice.ts
+++ b/src/hooks/useGasPrice.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import useSafeState from './useSafeState'
+import { walletApi } from 'api'
+
+export const useGasPrice = (defaultGasPrice: number | null = null): number | null => {
+  const [gasPrice, setGasPrice] = useSafeState<number | null>(null)
+  useEffect(() => {
+    async function getGasPrice(): Promise<void> {
+      const gasPrice = (await walletApi.getGasPrice()) || defaultGasPrice
+      setGasPrice(gasPrice)
+    }
+    getGasPrice()
+  }, [setGasPrice, defaultGasPrice])
+
+  return gasPrice
+}

--- a/src/hooks/usePriceEstimation.ts
+++ b/src/hooks/usePriceEstimation.ts
@@ -137,3 +137,18 @@ export function usePriceEstimationInOwl(params: PriceInOwlParams): Result {
 
   return usePriceEstimationWithSlippage(getPriceParams)
 }
+
+const WETHestimationInOWLDefaults = {
+  ...estimationInOwlDefaults,
+  quoteTokenId: 1,
+  quoteTokenDecimals: 18,
+}
+
+export function useWETHPriceInOwl(networkId: number): Result {
+  const getPriceParams: SlippageParams = {
+    ...WETHestimationInOWLDefaults,
+    networkId,
+  }
+
+  return usePriceEstimationWithSlippage(getPriceParams)
+}

--- a/src/hooks/usePriceEstimation.ts
+++ b/src/hooks/usePriceEstimation.ts
@@ -112,3 +112,28 @@ export function usePriceEstimationWithSlippage(params: SlippageParams): Result {
 
   return { priceEstimation, isPriceLoading }
 }
+
+interface PriceInOwlParams {
+  networkId: number
+  tokenId: number
+  tokenDecimals?: number
+}
+
+const estimationInOwlDefaults = {
+  baseTokenId: 0,
+  baseTokenDecimals: 18,
+  amount: '',
+}
+
+export function usePriceEstimationInOwl(params: PriceInOwlParams): Result {
+  const { networkId, tokenId: quoteTokenId, tokenDecimals: quoteTokenDecimals } = params
+
+  const getPriceParams: SlippageParams = {
+    ...estimationInOwlDefaults,
+    networkId,
+    quoteTokenId,
+    quoteTokenDecimals,
+  }
+
+  return usePriceEstimationWithSlippage(getPriceParams)
+}

--- a/src/utils/minFee.ts
+++ b/src/utils/minFee.ts
@@ -1,0 +1,19 @@
+import { BigNumber } from 'bignumber.js'
+
+export const DEFAULT_GAS_PRICE = 40e9 // 40 Gwei
+export const ETH_PRICE_IN_OWL = 240 * 1000
+export const SUBSIDIZE_FACTOR = 10
+
+// account for a 20% change in the time it takes to mine the tx, and start the batch
+export const BUFFER_MULTIPLIER = 1.2
+
+export const SETTLEMENT_FACTOR = 1.5
+export const FEE_FACTOR = 1000
+export const TRADE_TX_GASLIMIT = 120000
+
+export const calcMinTradableAmountInOwl = (gasPrice: number): BigNumber => {
+  const MIN_ECONOMICAL_VIABLE_FEE_IN_OWL = TRADE_TX_GASLIMIT * gasPrice * ETH_PRICE_IN_OWL
+
+  const MIN_FEE = (BUFFER_MULTIPLIER * MIN_ECONOMICAL_VIABLE_FEE_IN_OWL) / SUBSIDIZE_FACTOR
+  return new BigNumber(MIN_FEE * FEE_FACTOR * SETTLEMENT_FACTOR)
+}

--- a/src/utils/minFee.ts
+++ b/src/utils/minFee.ts
@@ -22,11 +22,11 @@ export const calcMinTradableAmountInOwl = ({
   gasPrice,
   ethPriceInOwl,
 }: CalcMinTradableAmountInOwlParams): BigNumber => {
-  const minEconocmicalViableFeeInOwl = ethPriceInOwl
+  const minEconomicalViableFeeInOwl = ethPriceInOwl
     .multipliedBy(TRADE_TX_GASLIMIT * gasPrice)
     .dividedBy(OWL_DECIMAL_UNITS)
-  logDebug('MIN_ECONOMICAL_VIABLE_FEE_IN_OWL', minEconocmicalViableFeeInOwl.toString(10))
+  logDebug('MIN_ECONOMICAL_VIABLE_FEE_IN_OWL', minEconomicalViableFeeInOwl.toString(10))
 
-  const minFee = minEconocmicalViableFeeInOwl.multipliedBy(BUFFER_MULTIPLIER).dividedBy(SUBSIDIZE_FACTOR)
+  const minFee = minEconomicalViableFeeInOwl.multipliedBy(BUFFER_MULTIPLIER).dividedBy(SUBSIDIZE_FACTOR)
   return minFee.multipliedBy(FEE_FACTOR * SETTLEMENT_FACTOR)
 }

--- a/src/utils/minFee.ts
+++ b/src/utils/minFee.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from 'bignumber.js'
+import { logDebug } from './miscellaneous'
 
 export const DEFAULT_GAS_PRICE = 40e9 // 40 Gwei
 export const SUBSIDIZE_FACTOR = 10
@@ -24,7 +25,7 @@ export const calcMinTradableAmountInOwl = ({
   const minEconocmicalViableFeeInOwl = ethPriceInOwl
     .multipliedBy(TRADE_TX_GASLIMIT * gasPrice)
     .dividedBy(OWL_DECIMAL_UNITS)
-  console.log('MIN_ECONOMICAL_VIABLE_FEE_IN_OWL', minEconocmicalViableFeeInOwl.toString(10))
+  logDebug('MIN_ECONOMICAL_VIABLE_FEE_IN_OWL', minEconocmicalViableFeeInOwl.toString(10))
 
   const minFee = minEconocmicalViableFeeInOwl.multipliedBy(BUFFER_MULTIPLIER).dividedBy(SUBSIDIZE_FACTOR)
   return minFee.multipliedBy(FEE_FACTOR * SETTLEMENT_FACTOR)

--- a/src/utils/minFee.ts
+++ b/src/utils/minFee.ts
@@ -21,11 +21,11 @@ export const calcMinTradableAmountInOwl = ({
   gasPrice,
   ethPriceInOwl,
 }: CalcMinTradableAmountInOwlParams): BigNumber => {
-  const MIN_ECONOMICAL_VIABLE_FEE_IN_OWL = ethPriceInOwl
+  const minEconocmicalViableFeeInOwl = ethPriceInOwl
     .multipliedBy(TRADE_TX_GASLIMIT * gasPrice)
     .dividedBy(OWL_DECIMAL_UNITS)
-  console.log('MIN_ECONOMICAL_VIABLE_FEE_IN_OWL', MIN_ECONOMICAL_VIABLE_FEE_IN_OWL.toString(10))
+  console.log('MIN_ECONOMICAL_VIABLE_FEE_IN_OWL', minEconocmicalViableFeeInOwl.toString(10))
 
-  const MIN_FEE = MIN_ECONOMICAL_VIABLE_FEE_IN_OWL.multipliedBy(BUFFER_MULTIPLIER).dividedBy(SUBSIDIZE_FACTOR)
-  return MIN_FEE.multipliedBy(FEE_FACTOR * SETTLEMENT_FACTOR)
+  const minFee = minEconocmicalViableFeeInOwl.multipliedBy(BUFFER_MULTIPLIER).dividedBy(SUBSIDIZE_FACTOR)
+  return minFee.multipliedBy(FEE_FACTOR * SETTLEMENT_FACTOR)
 }

--- a/src/utils/minFee.ts
+++ b/src/utils/minFee.ts
@@ -1,7 +1,6 @@
 import { BigNumber } from 'bignumber.js'
 
 export const DEFAULT_GAS_PRICE = 40e9 // 40 Gwei
-export const ETH_PRICE_IN_OWL = 240 * 1000
 export const SUBSIDIZE_FACTOR = 10
 
 // account for a 20% change in the time it takes to mine the tx, and start the batch
@@ -11,9 +10,22 @@ export const SETTLEMENT_FACTOR = 1.5
 export const FEE_FACTOR = 1000
 export const TRADE_TX_GASLIMIT = 120000
 
-export const calcMinTradableAmountInOwl = (gasPrice: number): BigNumber => {
-  const MIN_ECONOMICAL_VIABLE_FEE_IN_OWL = TRADE_TX_GASLIMIT * gasPrice * ETH_PRICE_IN_OWL
+const OWL_DECIMAL_UNITS = 1e18
 
-  const MIN_FEE = (BUFFER_MULTIPLIER * MIN_ECONOMICAL_VIABLE_FEE_IN_OWL) / SUBSIDIZE_FACTOR
-  return new BigNumber(MIN_FEE * FEE_FACTOR * SETTLEMENT_FACTOR)
+interface CalcMinTradableAmountInOwlParams {
+  gasPrice: number
+  ethPriceInOwl: BigNumber
+}
+
+export const calcMinTradableAmountInOwl = ({
+  gasPrice,
+  ethPriceInOwl,
+}: CalcMinTradableAmountInOwlParams): BigNumber => {
+  const MIN_ECONOMICAL_VIABLE_FEE_IN_OWL = ethPriceInOwl
+    .multipliedBy(TRADE_TX_GASLIMIT * gasPrice)
+    .dividedBy(OWL_DECIMAL_UNITS)
+  console.log('MIN_ECONOMICAL_VIABLE_FEE_IN_OWL', MIN_ECONOMICAL_VIABLE_FEE_IN_OWL.toString(10))
+
+  const MIN_FEE = MIN_ECONOMICAL_VIABLE_FEE_IN_OWL.multipliedBy(BUFFER_MULTIPLIER).dividedBy(SUBSIDIZE_FACTOR)
+  return MIN_FEE.multipliedBy(FEE_FACTOR * SETTLEMENT_FACTOR)
 }


### PR DESCRIPTION

Ignore styling, check logic only
Additionally, what would be the best way to get `MIN_ECONOMICAL_VIABLE_FEE_IN_OWL`:
1. as a fixed value

2. or calculate like in #1227
2.1. get ETH price In OWL from [market endpoint](https://github.com/gnosis/dex-services/tree/master/price-estimator#estimated-buy-amount)
2.2. => min economical viable fee = (120k gas)(40GWEI)(Etherprice in owl)=(120000 * 40 * 10**9 * 240 *1000) =1.2 OWL

Will the solver be run with `--min-avg-fee-per-order` as start-time flag (so a fixed fee), or will the fee be dynamic? @josojo 

![localhost_8080_trade_WETH-USDC_sell=0 5 price=1 01361 from= expires=](https://user-images.githubusercontent.com/5121491/88938907-91b57a00-d28e-11ea-84a9-f01f83f1b02b.png)
