### PR TITLE
Fix EnvironmentPlugin warning

### DIFF
--- a/src/utils/flagCodes.ts
+++ b/src/utils/flagCodes.ts
@@ -15,7 +15,6 @@ const SENTINEL =
   Number(CONFIG.appId)
     .toString(16)
     .padStart(2, '0')
-console.log('SENTINEL', SENTINEL)
 
 if (!/^[0-9a-f]+$/.test(SENTINEL)) {
   throw new Error(`SENTINEL isn't valid. Expected lowercase hex value, got ${SENTINEL}`)

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -179,11 +179,11 @@ module.exports = ({ stats = false } = {}) => ({
       // AUTOCONNECT: only applies for mock implementation
       AUTOCONNECT: 'true',
       PRICE_ESTIMATOR_URL: process.env.PRICE_ESTIMATOR_URL || 'develop',
-      APP_ID: process.env.APP_ID,
-      INFURA_ID: process.env.INFURA_ID,
-      WALLET_CONNECT_BRIDGE: process.env.WALLET_CONNECT_BRIDGE,
-      ETH_NODE_URL: process.env.ETH_NODE_URL,
-      LIQUIDITY_TOKEN_LIST: process.env.LIQUIDITY_TOKEN_LIST,
+      APP_ID: null,
+      INFURA_ID: null,
+      WALLET_CONNECT_BRIDGE: null,
+      ETH_NODE_URL: null,
+      LIQUIDITY_TOKEN_LIST: null,
     }),
     new ForkTsCheckerWebpackPlugin({ silent: stats }),
     // define inside one plugin instance


### PR DESCRIPTION

![screenshot_2020-08-04_12-58-43](https://user-images.githubusercontent.com/5121491/89505682-ac2dad00-d7d2-11ea-99a3-cbba9d18dfd5.png)


Setting env variables by default to `null` as per [EnvPlugin docs](https://webpack.js.org/plugins/environment-plugin/#usage-with-default-values:~:text=To%20specify%20an%20unset%20default%20value%2C%20use%20null%20instead%20of%20undefined)
Though it doesn't make them _unset_ in the end, semantically fits