### PR TITLE
Add an 'empty' price point so that all bid prices are included in graph

### DIFF
--- a/src/components/OrderBookWidget.tsx
+++ b/src/components/OrderBookWidget.tsx
@@ -156,6 +156,10 @@ const processData = (
   // Filter tiny orders
   pricePoints = pricePoints.filter(pricePoint => pricePoint.volume.gt(SMALL_VOLUME_THRESHOLD))
 
+  if (isBid && pricePoints.length > 0) {
+    pricePoints.push({ price: ZERO_BIG_NUMBER, volume: ZERO_BIG_NUMBER })
+  }
+
   // Convert the price points that can be represented in the graph (PricePointDetails)
   const { points } = pricePoints.reduce(
     (acc, pricePoint, index) => {


### PR DESCRIPTION
This draft PR is just to illustrate a bandaid solution to the issue described in #1307 by adding an empty bid price point to make sure the last pricepoint (i.e. worst bid order) get correctly displayed. I don't know if this has a real impact for the front-end since the worst bids are generally very bad and unimportant.

Also, I imagine that when using a linear orderbook such as in #1196 that this will no longer become an issue.