### PR TITLE
fix travis yml price estimation setting logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ before_install:
     $TRAVIS_BRANCH = master || \
     $TRAVIS_BRANCH = release/* || \
     $TRAVIS_BRANCH = hotfix/* || \
-    $TRAVIS_TAG != "" ]] && \
-    echo "production" || echo "develop")
+    $TRAVIS_TAG != "" ]] && echo "production" || echo "develop")
 before_deploy:
   # zip ./dist folder if tag IS present
   - if [[ $TRAVIS_TAG != "" && $IPFS_HASH = "" ]]; then

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -178,7 +178,7 @@ module.exports = ({ stats = false } = {}) => ({
       MOCK_WEB3: process.env.MOCK || 'false',
       // AUTOCONNECT: only applies for mock implementation
       AUTOCONNECT: 'true',
-      PRICE_ESTIMATOR_URL: process.env.PRICE_ESTIMATOR_URL || 'develop',
+      PRICE_ESTIMATOR_URL: process.env.PRICE_ESTIMATOR_URL || (isProduction && 'production') || 'develop',
       APP_ID: null,
       INFURA_ID: null,
       WALLET_CONNECT_BRIDGE: null,


### PR DESCRIPTION
Travis was returning:
```bash
$TRAVIS_BRANCH = hotfix/* || \ $TRAVIS_TAG != "" ]] && \ echo "production" || echo "develop")
No command ' echo' found, did you mean:
 Command 'echo' from package 'coreutils' (main)
 Command 'aecho' from package 'netatalk' (universe)
 echo: command not found
```
due to the `\` before echo

Changed to:
```bash
$TRAVIS_TAG != "" ]] && echo "production" || echo "develop")
```

Seems fixed:
### This PR
![image](https://user-images.githubusercontent.com/21335563/90123542-4a83ba80-dd5f-11ea-8200-639d0dfdb9cc.png)

### PR 1310 (some random one before this)
![image](https://user-images.githubusercontent.com/21335563/90123649-743ce180-dd5f-11ea-992e-182689263167.png)
