### PR TITLE
yarn build NODE_ENV production sets PRICE_ESTIMATION_URL to production

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -178,7 +178,7 @@ module.exports = ({ stats = false } = {}) => ({
       MOCK_WEB3: process.env.MOCK || 'false',
       // AUTOCONNECT: only applies for mock implementation
       AUTOCONNECT: 'true',
-      PRICE_ESTIMATOR_URL: process.env.PRICE_ESTIMATOR_URL || 'develop',
+      PRICE_ESTIMATOR_URL: process.env.PRICE_ESTIMATOR_URL || (isProduction && 'production') || 'develop',
       APP_ID: null,
       INFURA_ID: null,
       WALLET_CONNECT_BRIDGE: null,


### PR DESCRIPTION
```js
{
// ...
PRICE_ESTIMATOR_URL: process.env.PRICE_ESTIMATOR_URL || (isProduction && 'production') || 'develop',
// ...
}
```

Checks if `NODE_ENV=production` and sets `PRICE_ESTIMATOR_URL` accordingly

Tested it via `yarn build` then running `serve dist` and checking the URL in network - was `production`
Tested it via 1 time `yarn build:dev` aka `NODE_ENV=development <rest_of_build_script>` and the URL was `develop`