### PR TITLE
[HiddenOrderbook] Allow to fetch historic books by batchId

### DIFF
--- a/src/api/dexPriceEstimator/DexPriceEstimatorApi.ts
+++ b/src/api/dexPriceEstimator/DexPriceEstimatorApi.ts
@@ -21,6 +21,7 @@ interface OrderBookParams {
   baseTokenId: number
   quoteTokenId: number
   hops?: number
+  batchId?: number
 }
 
 /**
@@ -120,13 +121,17 @@ export class DexPriceEstimatorApiImpl implements DexPriceEstimatorApi {
   }
 
   public getOrderBookUrl(params: OrderBookParams): string {
-    const { networkId, baseTokenId, quoteTokenId, hops = ORDER_BOOK_HOPS_DEFAULT } = params
+    const { networkId, baseTokenId, quoteTokenId, hops = ORDER_BOOK_HOPS_DEFAULT, batchId } = params
     assert(hops >= 0, 'Hops should be positive')
     assert(hops <= ORDER_BOOK_HOPS_MAX, 'Hops should be not be greater than ' + ORDER_BOOK_HOPS_MAX)
 
     const baseUrl = this._getBaseUrl(networkId)
 
-    return `${baseUrl}markets/${baseTokenId}-${quoteTokenId}?atoms=true&hops=${hops}`
+    let url = `${baseUrl}markets/${baseTokenId}-${quoteTokenId}?atoms=true&hops=${hops}`
+    if (batchId) {
+      url += `&batchId=${batchId}`
+    }
+    return url
   }
 
   public async getOrderBookData(params: OrderBookParams): Promise<OrderBookData> {

--- a/src/components/OrderBookWidget.tsx
+++ b/src/components/OrderBookWidget.tsx
@@ -206,7 +206,7 @@ const OrderBookWidget: React.FC<OrderBookProps> = (props) => {
     }
 
     fetchApiData()
-  }, [baseToken, quoteToken, networkId, hops, setApiData, setError])
+  }, [baseToken, quoteToken, networkId, hops, batchId, setApiData, setError])
 
   if (error) return <OrderBookWrapper>{error.message}</OrderBookWrapper>
 

--- a/src/components/OrderBookWidget.tsx
+++ b/src/components/OrderBookWidget.tsx
@@ -169,10 +169,11 @@ export const processRawApiData = ({ data, baseToken, quoteToken }: ProcessRawDat
 
 interface OrderBookProps extends Omit<OrderBookChartProps, 'data'> {
   hops?: number
+  batchId?: number
 }
 
 const OrderBookWidget: React.FC<OrderBookProps> = (props) => {
-  const { baseToken, quoteToken, networkId, hops } = props
+  const { baseToken, quoteToken, networkId, hops, batchId } = props
   const [apiData, setApiData] = useSafeState<PricePointDetails[]>([])
   const [error, setError] = useSafeState<Error | null>(null)
 
@@ -192,6 +193,7 @@ const OrderBookWidget: React.FC<OrderBookProps> = (props) => {
           quoteTokenId: quoteToken.id,
           hops,
           networkId,
+          batchId,
         })
 
         const processedData = processRawApiData({ data: rawData, baseToken, quoteToken })

--- a/src/pages/OrderBook.tsx
+++ b/src/pages/OrderBook.tsx
@@ -85,7 +85,7 @@ const OrderBook: React.FC = () => {
   const [baseToken, setBaseToken] = useSafeState<TokenDetails | null>(null)
   const [quoteToken, setQuoteToken] = useSafeState<TokenDetails | null>(null)
   const [hops, setHops] = useSafeState(ORDER_BOOK_HOPS_DEFAULT.toString())
-  const [batchId, setBatchId] = useSafeState<number | undefined>(undefined)
+  const [batchId, setBatchId] = useSafeState<number | undefined>('')
 
   const tokensLoaded = tokenList.length !== 0
   useEffect(() => {

--- a/src/pages/OrderBook.tsx
+++ b/src/pages/OrderBook.tsx
@@ -64,6 +64,7 @@ const OrderBookWrapper = styled.div`
 
     input {
       padding: 0 1rem;
+      max-width: 8em;
     }
 
     label {
@@ -135,7 +136,8 @@ const OrderBook: React.FC = () => {
             <label>BatchId</label>
             <Input
               value={batchId}
-              type="string"
+              type="number"
+              min="0"
               onChange={(e: ChangeEvent<HTMLInputElement>): void => {
                 const batchIdValue = e.target.value
                 if (batchIdValue && !isNaN(Number(batchIdValue))) {

--- a/src/pages/OrderBook.tsx
+++ b/src/pages/OrderBook.tsx
@@ -14,6 +14,7 @@ import InputBox from 'components/InputBox'
 const OrderBookPage = styled(ContentPage)`
   padding: 2.4rem 0rem;
   min-height: initial;
+  max-width: initial;
 `
 
 const OrderBookWrapper = styled.div`

--- a/src/pages/OrderBook.tsx
+++ b/src/pages/OrderBook.tsx
@@ -83,6 +83,7 @@ const OrderBook: React.FC = () => {
   const [baseToken, setBaseToken] = useSafeState<TokenDetails | null>(null)
   const [quoteToken, setQuoteToken] = useSafeState<TokenDetails | null>(null)
   const [hops, setHops] = useSafeState(ORDER_BOOK_HOPS_DEFAULT.toString())
+  const [batchId, setBatchId] = useSafeState<number | undefined>(undefined)
 
   const tokensLoaded = tokenList.length !== 0
   useEffect(() => {
@@ -128,9 +129,32 @@ const OrderBook: React.FC = () => {
             />
           </InputBox>
         </span>
+        <span>
+          <InputBox>
+            <label>BatchId</label>
+            <Input
+              value={batchId}
+              type="string"
+              onChange={(e: ChangeEvent<HTMLInputElement>): void => {
+                const batchIdValue = e.target.value
+                if (batchIdValue && !isNaN(Number(batchIdValue))) {
+                  setBatchId(Number(batchIdValue))
+                } else {
+                  setBatchId(undefined)
+                }
+              }}
+            />
+          </InputBox>
+        </span>
       </OrderBookWrapper>
 
-      <OrderBookWidget baseToken={baseToken} quoteToken={quoteToken} networkId={networkIdOrDefault} hops={+hops} />
+      <OrderBookWidget
+        baseToken={baseToken}
+        quoteToken={quoteToken}
+        networkId={networkIdOrDefault}
+        hops={+hops}
+        batchId={batchId}
+      />
     </OrderBookPage>
   )
 }


### PR DESCRIPTION
Convenience feature to see the orderbook at arbitrary points in the past. This only applies to the hidden orderbook page under http://localhost:8080/book

I'd really appreciate some styling help how to align this text box a bit nicer.

### Test Plan

<img width="930" alt="Screen Shot 2020-08-26 at 11 55 32" src="https://user-images.githubusercontent.com/1200333/91290029-65a8ee00-e793-11ea-9780-ecca7f1c3889.png">


Also making sure that we can still load the normal orderbook at the most recent batch.