### PR TITLE
Order book reposition

### DIFF
--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -42,7 +42,7 @@ export const BalancesWidget = styled(CardWidgetWrapper)`
   height: 100%;
 
   > .filterToolsBar {
-    height: 10%;
+    min-height: 5.2rem;
   }
 
   > ${CardTable} {
@@ -54,7 +54,7 @@ export const BalancesWidget = styled(CardWidgetWrapper)`
       font-size: 1.3rem;
 
       > tr:not(.cardRowDrawer) {
-        min-height: 6.3rem;
+        /* min-height: 6.3rem; */
         > td,
         > th {
           justify-content: flex-end;
@@ -63,11 +63,11 @@ export const BalancesWidget = styled(CardWidgetWrapper)`
       }
     }
 
-    > thead {
+    /* > thead {
       > tr:not(.cardRowDrawer) {
         padding: 0.8rem 3rem;
       }
-    }
+    } */
 
     > tbody {
       overflow-y: auto;
@@ -83,9 +83,9 @@ export const BalancesWidget = styled(CardWidgetWrapper)`
 
             > div {
               word-break: break-word;
-              white-space: nowrap;
-              overflow: hidden;
-              text-overflow: ellipsis;
+              /* white-space: nowrap; */
+              /* overflow: hidden;
+              text-overflow: ellipsis; */
 
               > strong {
                 display: flex;
@@ -318,64 +318,64 @@ const BalancesDisplay: React.FC<BalanceDisplayProps> = ({
         {error ? (
           <ErrorMsg title="oops..." message="Something happened while loading the balances" />
         ) : (
-          <CardTable className="balancesOverview" $gap="0 1rem">
-            <thead>
-              <tr>
-                <th>Token</th>
-                <th>Exchange Balance</th>
-                <th>Pending Withdrawals</th>
-                <th>Wallet Balance</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {displayedBalances && displayedBalances.length > 0 ? (
-                displayedBalances.map((tokenBalances) => (
-                  <Row
-                    key={tokenBalances.address}
-                    ethBalance={ethBalance}
-                    tokenBalances={tokenBalances}
-                    onEnableToken={(): Promise<void> => enableToken(tokenBalances.address)}
-                    onSubmitDeposit={(balance, onTxHash): Promise<void> =>
-                      depositToken(balance, tokenBalances.address, onTxHash)
-                    }
-                    onSubmitWithdraw={(balance, onTxHash): Promise<void> => {
-                      return requestWithdrawConfirmation(
-                        balance,
-                        tokenBalances.address,
-                        tokenBalances.claimable,
-                        onTxHash,
-                      )
-                    }}
-                    onClaim={(): Promise<void | React.ReactText> => claimToken(tokenBalances.address)}
-                    claiming={claiming.has(tokenBalances.address)}
-                    withdrawing={withdrawing.has(tokenBalances.address)}
-                    depositing={depositing.has(tokenBalances.address)}
-                    highlighted={highlighted.has(tokenBalances.address)}
-                    enabling={enabling.has(tokenBalances.address)}
-                    enabled={enabled.has(tokenBalances.address)}
-                    immatureClaim={immatureClaim.has(tokenBalances.address)}
-                    {...windowSpecs}
-                  />
-                ))
-              ) : balances.length === 0 && hasTokensToShow ? (
-                <NoTokensMessage>
-                  <td>
-                    All tokens disabled. Enable some in <a onClick={toggleModal}>Manage Tokens</a>
-                  </td>
-                </NoTokensMessage>
-              ) : (
-                (search || hideZeroBalances) && (
+            <CardTable className="balancesOverview" $gap="0 1rem">
+              <thead>
+                <tr>
+                  <th>Token</th>
+                  <th>Exchange Balance</th>
+                  <th>Pending Withdrawals</th>
+                  <th>Wallet Balance</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {displayedBalances && displayedBalances.length > 0 ? (
+                  displayedBalances.map((tokenBalances) => (
+                    <Row
+                      key={tokenBalances.address}
+                      ethBalance={ethBalance}
+                      tokenBalances={tokenBalances}
+                      onEnableToken={(): Promise<void> => enableToken(tokenBalances.address)}
+                      onSubmitDeposit={(balance, onTxHash): Promise<void> =>
+                        depositToken(balance, tokenBalances.address, onTxHash)
+                      }
+                      onSubmitWithdraw={(balance, onTxHash): Promise<void> => {
+                        return requestWithdrawConfirmation(
+                          balance,
+                          tokenBalances.address,
+                          tokenBalances.claimable,
+                          onTxHash,
+                        )
+                      }}
+                      onClaim={(): Promise<void | React.ReactText> => claimToken(tokenBalances.address)}
+                      claiming={claiming.has(tokenBalances.address)}
+                      withdrawing={withdrawing.has(tokenBalances.address)}
+                      depositing={depositing.has(tokenBalances.address)}
+                      highlighted={highlighted.has(tokenBalances.address)}
+                      enabling={enabling.has(tokenBalances.address)}
+                      enabled={enabled.has(tokenBalances.address)}
+                      immatureClaim={immatureClaim.has(tokenBalances.address)}
+                      {...windowSpecs}
+                    />
+                  ))
+                ) : balances.length === 0 && hasTokensToShow ? (
                   <NoTokensMessage>
                     <td>
-                      No enabled tokens match provided filters <a onClick={clearFilters}>clear filters</a>
+                      All tokens disabled. Enable some in <a onClick={toggleModal}>Manage Tokens</a>
                     </td>
                   </NoTokensMessage>
-                )
-              )}
-            </tbody>
-          </CardTable>
-        )}
+                ) : (
+                      (search || hideZeroBalances) && (
+                        <NoTokensMessage>
+                          <td>
+                            No enabled tokens match provided filters <a onClick={clearFilters}>clear filters</a>
+                          </td>
+                        </NoTokensMessage>
+                      )
+                    )}
+              </tbody>
+            </CardTable>
+          )}
         <Modali.Modal {...modalProps} />
       </BalancesWidget>
     </StandaloneCardWrapper>

--- a/src/components/FilterTools.tsx
+++ b/src/components/FilterTools.tsx
@@ -20,14 +20,18 @@ export const BalanceTools = styled.div<{ $css?: string | false }>`
   ${FormMessage} {
     color: var(--color-text-primary);
     background: var(--color-background-validation-warning);
-    font-size: x-small;
+    /* font-size: x-small; */
+    font-size: small;
     margin: 0;
-    position: absolute;
+    /* position: absolute;
     bottom: 0;
-    left: 0;
+    left: 0; */
     width: max-content;
-    padding: 0.1rem 1.6rem 0.1rem 0.5rem;
-    border-radius: 0 1.6rem 0rem 0rem;
+    /* padding: 0.1rem 1.6rem 0.1rem 0.5rem; */
+    padding: 1.3rem 1.6rem;
+    box-sizing: border-box;
+    /* border-radius: 0 1.6rem 0rem 0rem; */
+    border-radius: 0;
   }
 
   // label + search input
@@ -35,8 +39,9 @@ export const BalanceTools = styled.div<{ $css?: string | false }>`
     position: relative;
     display: flex;
     width: 100%;
-    height: 4rem;
-    margin: 1.2rem;
+    height: 100%;
+    /* margin: 1.2rem; */
+    margin: 0;
 
     @media ${MEDIA.mobile} {
       height: 4.6rem;
@@ -55,10 +60,11 @@ export const BalanceTools = styled.div<{ $css?: string | false }>`
     > input {
       margin: 0;
       max-width: 100%;
-      background: var(--color-background-input) url(${searchIcon}) no-repeat left 1.6rem center/1.6rem;
+      background: url(${searchIcon}) no-repeat left 1.6rem center/1.6rem;
       border-radius: 0.6rem 0.6rem 0 0;
       border: 0;
       font-size: 1.4rem;
+      min-height: 5.2rem;
       line-height: 1;
       box-sizing: border-box;
       border-bottom: 0.2rem solid transparent;
@@ -122,22 +128,22 @@ const FilterTools: React.FC<Props> = ({
   showFilter,
   handleSearch,
 }) => (
-  <BalanceTools className={className} $css={customStyles}>
-    <label className="balances-searchTokens">
-      <input
-        placeholder="Search token by Name, Symbol or Address"
-        type="text"
-        value={searchValue}
-        onChange={handleSearch}
-      />
-      {showFilter && (
-        <FormMessage id="filterLabel">
-          Filter: Showing {dataLength} {dataLength === 1 ? 'result' : resultName}
-        </FormMessage>
-      )}
-    </label>
-    <>{children}</>
-  </BalanceTools>
-)
+    <BalanceTools className={className} $css={customStyles}>
+      <label className="balances-searchTokens">
+        <input
+          placeholder="Search token by Name, Symbol or Address"
+          type="text"
+          value={searchValue}
+          onChange={handleSearch}
+        />
+        {showFilter && (
+          <FormMessage id="filterLabel">
+            Filter: Showing {dataLength} {dataLength === 1 ? 'result' : resultName}
+          </FormMessage>
+        )}
+      </label>
+      <>{children}</>
+    </BalanceTools>
+  )
 
 export default FilterTools

--- a/src/components/Layout/Card/Card.tsx
+++ b/src/components/Layout/Card/Card.tsx
@@ -16,7 +16,7 @@ const CardRowDrawer = styled.tr`
   left: 0;
   width: 100%;
   height: 100%;
-  border-radius: 0.6rem;
+  /* border-radius: 0.6rem; */
   background: var(--color-background-modali);
 
   // Inner td wrapper
@@ -25,7 +25,7 @@ const CardRowDrawer = styled.tr`
     z-index: 9999;
     background: var(--color-background-pageWrapper);
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.14);
-    border-radius: var(--border-radius);
+    /* border-radius: var(--border-radius); */
     margin: 0;
     width: 50rem;
     height: 50rem;
@@ -159,8 +159,8 @@ export const FoldableRowWrapper = styled.tr<{ $open?: boolean; $openCSS?: string
       }
 
       ${({ $open = true }): string | false =>
-        !$open &&
-        `
+    !$open &&
+    `
         td:not(.responsiveRow):not(.cardOpener):not(.showResponsive) {
           height: 0;
           padding: 0;
@@ -188,7 +188,7 @@ export const CardTable = styled.table<{
   display: grid;
   flex: 1;
   width: 100%;
-  padding-bottom: 2rem;
+  // padding-bottom: 2rem;
 
   .checked {
     margin: 0;
@@ -269,7 +269,7 @@ export const CardTable = styled.table<{
       th {
         color: inherit;
         line-height: 1.2;
-        height: 4rem;
+        // height: 4rem;
 
         &.sortable {
           cursor: pointer;
@@ -292,7 +292,8 @@ export const CardTable = styled.table<{
     font-weight: var(--font-weight-regular);
     color: var(--color-text-primary);
     
-    letter-spacing: -0.085rem;
+    // letter-spacing: -0.085rem;
+    letter-spacing: 0;
     line-height: 1.2;
 
     tr:not(.cardRowDrawer) {
@@ -330,14 +331,12 @@ export const CardTable = styled.table<{
   ${({ $webCSS }): string | undefined => $webCSS}
 `
 
-export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
+export const CardWidgetWrapper = styled(Widget) <{ $columns?: string }>`
   display: flex;
   flex-flow: column nowrap;
   justify-content: flex-start;
-
   width: 100%;
   margin: 0 auto;
-
   border-radius: 0.6rem;
   font-size: 1.6rem;
   line-height: 1;
@@ -386,8 +385,9 @@ export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
 
       tr:not(.cardRowDrawer) {
         &:last-child {
-          border-bottom: 0.1rem solid rgba(159, 180, 201, 0.5);
-          border-radius: var(--border-radius);
+          /* border-bottom: 0.1rem solid rgba(159, 180, 201, 0.5); */
+          /* border-radius: var(--border-radius); */
+          border-bottom: 0;
         }
 
         td {

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -32,7 +32,7 @@ const Wrapper = styled.footer`
   line-height: 1;
 
   width: 100%;
-  margin: 0 0 4rem 0;
+  margin: 4rem 0;
   padding: 0 2rem;
 
   @media ${MEDIA.mobile} {
@@ -211,8 +211,8 @@ const Footer: React.FC = () => {
         {contractAddress && networkId ? (
           <LinkWrapper type="contract" identifier={contractAddress} networkId={networkId} label={VerifiedText} />
         ) : (
-          ''
-        )}
+            ''
+          )}
       </VerifiedContractLink>
       <SideContentWrapper>
         {/* DARK/LIGHT MODE TOGGLER */}

--- a/src/components/Layout/Header/Header.styled.ts
+++ b/src/components/Layout/Header/Header.styled.ts
@@ -7,26 +7,31 @@ export const HeaderWrapper = styled.header`
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  padding: 0;
+  padding: 0 2.4rem;
+  box-sizing: border-box;
+  
+    @media ${MEDIA.mobile} {
+      padding: 1rem 1.6rem 0;
+      box-sizing: border-box;
+    }
 
   nav {
     display: flex;
     flex-flow: column wrap;
     align-items: center;
     width: 100%;
-
-    @media ${MEDIA.mobile} {
-      padding: 0 1.2rem;
-      box-sizing: border-box;
-    }
   }
 
   ${UserWalletWrapper} {
-    order: 1;
-    margin: 3.2rem 3rem 3.2rem 0;
+    /* order: 1; */
+    margin: 2.4rem 0 3.2rem 3.2rem;
+    order: 2;
+    /* margin: 3.2rem 3rem 3.2rem 0; */
 
     @media ${MEDIA.mobile} {
-      margin: 2rem 1rem 2rem 0;
+      /* margin: 2rem 1rem 2rem 0; */
+      margin: 0;
+      order: 1;
     }
   }
 

--- a/src/components/Layout/Header/Navigation.styled.ts
+++ b/src/components/Layout/Header/Navigation.styled.ts
@@ -4,17 +4,18 @@ import { MEDIA } from 'const'
 export const NavLinksWrapper = styled.div<{ $open?: boolean; $responsive: boolean }>`
   display: flex;
   order: 1;
-  flex: 1 1 100%;
   margin: auto;
   align-items: center;
-  justify-content: center;
+  flex: 1 1 auto;
+  justify-content: flex-start;
 
   @media ${MEDIA.mobile} {
     flex-flow: row wrap;
     background: #dde4ed;
     border-radius: 15rem;
     width: 100%;
-    margin: 0 auto;
+    margin: 2.4rem auto 0;
+    order: 3;
     justify-content: space-between;
   }
 
@@ -26,13 +27,16 @@ export const NavLinksWrapper = styled.div<{ $open?: boolean; $responsive: boolea
     text-decoration: none;
     transition: color 0.2s ease-in-out, background 0.2s ease-in-out;
     font-weight: var(--font-weight-bold);
-    font-size: 2.1rem;
-    padding: 0 4rem;
+    /* font-size: 2.1rem; */
+    /* padding: 0 4rem; */
     border-radius: 15rem;
     letter-spacing: 0;
     text-align: center;
     box-sizing: border-box;
-    height: 5.4rem;
+    /* height: 5.4rem; */
+    height: 4.2rem;
+    font-size: 1.8rem;
+    padding: 0 2.4rem;
     line-height: 1;
     display: flex;
     justify-content: center;
@@ -42,9 +46,8 @@ export const NavLinksWrapper = styled.div<{ $open?: boolean; $responsive: boolea
       color: rgba(78, 106, 133, 0.75);
       margin: 0;
       padding: 0;
-      font-size: 1.3rem;
+      font-size: 1.2rem;
       width: 100%;
-      height: 4rem;
     }
 
     &:hover {
@@ -66,7 +69,8 @@ export const NavLinksWrapper = styled.div<{ $open?: boolean; $responsive: boolea
 export const OrderedNavLinkDiv = styled.span`
   display: flex;
   align-items: center;
-  flex: 1 1 auto;
+  /* flex: 1 1 auto; */
+  flex: 0;
 
   // Hide 'ORDERS' tab on desktop/tablet (until we decide to show it for all devices...)
   &:nth-of-type(3) {
@@ -82,7 +86,8 @@ export const OrderedNavLinkDiv = styled.span`
   }
 
   &:not(:last-of-type) {
-    margin: 0 1.6rem 0 0;
+    /* margin: 0 1.6rem 0 0; */
+    margin: 0;
     @media ${MEDIA.mobile} {
       margin: 0;
     }

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -37,13 +37,20 @@ const TopWrapper = styled.div`
 
   @media ${MEDIA.mobile} {
     justify-content: space-between;
+    flex-flow: row wrap;
   }
 `
 
 const CountDownStyled = styled.div`
   display: flex;
   flex-flow: column;
-  order 2;
+  /* order 2; */
+  order: 1;
+  
+    @media ${MEDIA.mobile} {
+      order: 2;
+      padding: 1.2rem 0 0;
+    }
 
  > div {
   display: flex;
@@ -52,14 +59,14 @@ const CountDownStyled = styled.div`
   color: var(--color-text-primary);
   min-width: 16rem;
   letter-spacing: 0;
-  margin: 0.5rem 0;
+  margin: 0.3rem 0;
   align-items: baseline;
 
-  @media ${MEDIA.mobile} {
+  /* @media ${MEDIA.mobile} {
     flex-flow: row wrap;
     line-height: 1.2;
     width: auto;
-  }
+  } */
 
   > strong {
     color: var(--color-text-active);
@@ -113,18 +120,18 @@ const Header: React.FC<HeaderProps> = ({ navigation: initialState }: HeaderProps
           {CONFIG.name}
         </NavLink> */}
         <TopWrapper>
+          {/* HEADER LINKS */}
+          <NavigationLinks
+            navigation={navigationArray}
+            responsive={isResponsive}
+            handleOpenNav={handleOpenNav}
+            showNav={openNav}
+          />
           {/* USER WALLET */}
           <UserWallet />
           {/* Global Batch Countdown */}
           <BatchCountDown />
         </TopWrapper>
-        {/* HEADER LINKS */}
-        <NavigationLinks
-          navigation={navigationArray}
-          responsive={isResponsive}
-          handleOpenNav={handleOpenNav}
-          showNav={openNav}
-        />
       </nav>
     </HeaderWrapper>
   )

--- a/src/components/Layout/PageWrapper.tsx
+++ b/src/components/Layout/PageWrapper.tsx
@@ -62,7 +62,8 @@ export const StandaloneCardWrapper = styled.div`
   }
 `
 export const PageWrapper = styled.section`
-  height: 71rem;
+  /* height: 71rem; */
+  height: auto;
   min-width: 85rem;
   max-width: 100%;
 

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -15,9 +15,9 @@ import LegalBanner from 'components/LegalBanner'
 export const EllipsisText = styled.div<{ $maxWidth?: string }>`
   font-size: inherit;
   max-width: ${({ $maxWidth = '6ch' }): string => $maxWidth};
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
+  /* text-overflow: ellipsis;
+  overflow: hidden; */
+  /* white-space: nowrap; */
 `
 
 const Wrapper = styled.div`
@@ -27,8 +27,10 @@ const Wrapper = styled.div`
   flex-flow: column wrap;
 
   main {
-    flex: 0 1 auto;
-    margin: 2.4rem auto 5rem;
+    /* flex: 0 1 auto; */
+    /* margin: 2.4rem auto 5rem; */
+    flex: 1 1 auto;
+    margin: 0 2.4rem;
     width: auto;
     display: flex;
     flex-flow: row wrap;

--- a/src/components/OrderBookWidget.tsx
+++ b/src/components/OrderBookWidget.tsx
@@ -218,7 +218,7 @@ function _printOrderBook(pricePoints: PricePointDetails[], baseToken: TokenDetai
     const isBid = pricePoint.type === Offer.Bid
     logDebug(
       `\t${isBid ? 'Bid' : 'Ask'} ${pricePoint.totalVolumeFormatted} ${baseToken.symbol} at ${
-        pricePoint.priceFormatted
+      pricePoint.priceFormatted
       } ${quoteToken.symbol}`,
     )
   })

--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -64,6 +64,7 @@ export const OrdersWrapper = styled(StandaloneCardWrapper)`
                 margin: auto;
               }
             }
+            
           }
         }
       }
@@ -149,12 +150,13 @@ export const OrdersForm = styled.div`
       display: flex;
       flex-flow: row nowrap;
       width: 100%;
-      margin: 0 0 -0.1rem;
+      /* margin: 0 0 -0.1rem; */
+      margin: 0;
       align-items: center;
 
       > button {
         font-weight: var(--font-weight-bold);
-        font-size: 1.5rem;
+        font-size: 1.3rem;
         color: var(--color-text-secondary);
         letter-spacing: 0;
         text-align: center;
@@ -169,8 +171,8 @@ export const OrdersForm = styled.div`
         justify-content: center;
         transition: border 0.2s ease-in-out;
         align-items: center;
-        border-bottom: 0.3rem solid transparent;
-        min-height: 6.4rem;
+        border-bottom: 0.2rem solid transparent;
+        min-height: 5.2rem;
 
         > i {
           height: 1.8rem;
@@ -212,7 +214,7 @@ export const OrdersForm = styled.div`
       }
 
       > button.selected {
-        border-bottom: 0.3rem solid var(--color-text-active);
+        border-bottom: 0.2rem solid var(--color-text-active);
         color: var(--color-text-active);
       }
 

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useCallback, useEffect } from 'react'
+import styled from 'styled-components'
 // eslint-disable-next-line @typescript-eslint/camelcase
 import { unstable_batchedUpdates } from 'react-dom'
 
@@ -33,6 +34,9 @@ import FilterTools from 'components/FilterTools'
 import { useDeleteOrders } from 'components/OrdersWidget/useDeleteOrders'
 import OrderRow from 'components/OrdersWidget/OrderRow'
 import { OrdersWrapper, ButtonWithIcon, OrdersForm } from 'components/OrdersWidget/OrdersWidget.styled'
+
+// Misc
+import { MEDIA } from 'const'
 
 type OrderTabs = 'active' | 'closed' | 'trades'
 type FilteredOrdersStateKeys = Exclude<OrderTabs, 'trades'>
@@ -92,9 +96,9 @@ function filterOrdersByDisplayType(
   return !displayOnly
     ? orders
     : orders.filter(
-        (order) =>
-          (displayOnly === 'liquidity' && order.isUnlimited) || (displayOnly === 'regular' && !order.isUnlimited),
-      )
+      (order) =>
+        (displayOnly === 'liquidity' && order.isUnlimited) || (displayOnly === 'regular' && !order.isUnlimited),
+    )
 }
 
 const OrdersWidget: React.FC<Props> = ({ displayOnly }) => {
@@ -113,10 +117,10 @@ const OrdersWidget: React.FC<Props> = ({ displayOnly }) => {
       !displayOnly
         ? allTrades
         : allTrades.filter(
-            (trade) =>
-              (displayOnly === 'liquidity' && trade.type === 'liquidity') ||
-              (displayOnly === 'regular' && trade.type != 'liquidity'),
-          ),
+          (trade) =>
+            (displayOnly === 'liquidity' && trade.type === 'liquidity') ||
+            (displayOnly === 'regular' && trade.type != 'liquidity'),
+        ),
     [allTrades, displayOnly],
   )
 
@@ -347,43 +351,54 @@ const OrdersWidget: React.FC<Props> = ({ displayOnly }) => {
     classifiedOrders[selectedTab]?.orders?.length > 0 && markedForDeletion.size === displayedOrders.length
   )
 
+  const FilterToolsWrapper = styled.div`
+    display: flex;
+    width: 100%;
+    
+    @media ${MEDIA.mobile} {
+      flex-flow: column wrap;
+    }
+  `
+
   return (
     <OrdersWrapper>
       {!isConnected ? (
         <ConnectWalletBanner />
       ) : (
-        noOrders &&
-        noTrades && (
-          <p className="noOrdersInfo">
-            It appears you haven&apos;t placed any order yet. <br /> Create one!
-          </p>
-        )
-      )}
+          noOrders &&
+          noTrades && (
+            <p className="noOrdersInfo">
+              It appears you haven&apos;t placed any order yet. <br /> Create one!
+            </p>
+          )
+        )}
       {(!noOrders || !noTrades) && networkId && (
         <OrdersForm>
           <form action="submit" onSubmit={onSubmit}>
-            <FilterTools
-              className="widgetFilterTools"
-              resultName={tabSpecificResultName}
-              searchValue={tabSpecficSearch}
-              handleSearch={handleTabSpecificSearch}
-              showFilter={!!tabSpecficSearch}
-              dataLength={tabSpecificDataLength}
-            >
-              {selectedTab !== 'trades' && (
-                <label className="checked">
-                  <small>Cancel All Orders:</small>
-                  <input
-                    type="checkbox"
-                    onChange={toggleSelectAll}
-                    checked={markedForDeletionChecked}
-                    disabled={deleting}
-                  />
-                </label>
-              )}
-            </FilterTools>
-            {/* ORDERS TABS: ACTIVE/TRADES/CLOSED */}
-            <Tabs<OrderTabs> {...tabsProps} />
+            <FilterToolsWrapper>
+              <FilterTools
+                className="widgetFilterTools"
+                resultName={tabSpecificResultName}
+                searchValue={tabSpecficSearch}
+                handleSearch={handleTabSpecificSearch}
+                showFilter={!!tabSpecficSearch}
+                dataLength={tabSpecificDataLength}
+              >
+                {selectedTab !== 'trades' && (
+                  <label className="checked">
+                    <small>Cancel All Orders:</small>
+                    <input
+                      type="checkbox"
+                      onChange={toggleSelectAll}
+                      checked={markedForDeletionChecked}
+                      disabled={deleting}
+                    />
+                  </label>
+                )}
+              </FilterTools>
+              {/* ORDERS TABS: ACTIVE/TRADES/CLOSED */}
+              <Tabs<OrderTabs> {...tabsProps} />
+            </FilterToolsWrapper>
 
             {/* DELETE ORDERS ROW */}
             <div className="deleteContainer" data-disabled={markedForDeletion.size === 0 || deleting}>
@@ -405,7 +420,7 @@ const OrdersWidget: React.FC<Props> = ({ displayOnly }) => {
               <div className="ordersContainer">
                 <CardWidgetWrapper className="widgetCardWrapper">
                   <CardTable
-                    $columns="3.2rem minmax(8.6rem, 0.3fr) repeat(2,1fr) minmax(5.2rem,0.6fr) minmax(8.6rem, 0.3fr)"
+                    $columns="3.2rem minmax(8.6rem,0.3fr) repeat(2,1fr) minmax(5.2rem,0.6fr) minmax(9rem,0.3fr)"
                     $gap="0 0.6rem"
                     $rowSeparation="0"
                   >
@@ -461,10 +476,10 @@ const OrdersWidget: React.FC<Props> = ({ displayOnly }) => {
                 </CardWidgetWrapper>
               </div>
             ) : (
-              <div className="noOrders">
-                <span>You have no {selectedTab} orders</span>
-              </div>
-            )}
+                  <div className="noOrders">
+                    <span>You have no {selectedTab} orders</span>
+                  </div>
+                )}
           </form>
         </OrdersForm>
       )}

--- a/src/components/PoolingWidget/PoolingWidget.styled.ts
+++ b/src/components/PoolingWidget/PoolingWidget.styled.ts
@@ -43,7 +43,8 @@ export const PoolingInterfaceWrapper = styled(WrappedWidget)`
     flex-flow: column nowrap;
     padding: 2rem;
     min-width: 51.4rem;
-    max-width: 75rem;
+    /* max-width: 75rem; */
+    margin: 0 auto;
 
     > h2 {
       margin: 1rem auto 2.4rem;
@@ -60,7 +61,7 @@ export const PoolingInterfaceWrapper = styled(WrappedWidget)`
     > form {
       min-width: 100%;
       max-width: 100%;
-      padding: 2rem 4rem;
+      padding: 2rem 2.4rem;
     }
   }
 

--- a/src/components/PoolingWidget/index.tsx
+++ b/src/components/PoolingWidget/index.tsx
@@ -14,7 +14,7 @@ import { maxAmountsForSpread, resolverFactory, NUMBER_VALIDATION_KEYS } from 'ut
 
 // components
 import OrdersWidget from 'components/OrdersWidget'
-import { ExpandableOrdersPanel, OrdersToggler } from 'components/TradeWidget'
+import { ExpandableOrdersPanel } from 'components/TradeWidget'
 
 // PoolingWidget: subcomponents
 import ProgressBar from 'components/PoolingWidget/ProgressBar'
@@ -147,7 +147,7 @@ const PoolingInterface: React.FC = () => {
   const [txReceipt, setTxReceipt] = useSafeState<Receipt | undefined>(undefined)
   const [txError, setTxError] = useSafeState(undefined)
 
-  const [ordersVisible, setOrdersVisible] = useSafeState(true)
+  const [ordersVisible] = useSafeState(true)
 
   const { networkId, networkIdOrDefault, userAddress } = useWalletConnection()
   // Get all the tokens for the current network
@@ -330,11 +330,11 @@ const PoolingInterface: React.FC = () => {
       </FormContext>
       <ExpandableOrdersPanel>
         {/* Toggle panel visibility (arrow) */}
-        <OrdersToggler
+        {/* <OrdersToggler
           type="button"
           onClick={(): void => setOrdersVisible((ordersVisible) => !ordersVisible)}
           $isOpen={ordersVisible}
-        />
+        /> */}
         {/* Actual orders content */}
         <OrdersWidget displayOnly="liquidity" />
       </ExpandableOrdersPanel>

--- a/src/components/TradeWidget/OrderValidity.tsx
+++ b/src/components/TradeWidget/OrderValidity.tsx
@@ -69,7 +69,8 @@ const Wrapper = styled.div`
       background: transparent;
       align-items: center;
       flex-flow: row wrap;
-      padding: 0 0.8rem;
+      /* padding: 0 0.8rem; */
+      padding: 0 0.8rem 0 0;
 
       > b {
         color: #218dff;
@@ -324,16 +325,16 @@ const OrderValidity: React.FC<Props> = ({
     // undefined validFrom input - set Now
     !validFromInputValue
       ? batchedUpdates(() => {
-          setAsap(true)
-          setValue(validFromInputId, undefined, true)
-        })
+        setAsap(true)
+        setValue(validFromInputId, undefined, true)
+      })
       : setAsap(false)
     // undefined validUntil input - set unlimited
     !validUntilInputValue
       ? batchedUpdates(() => {
-          setUnlimited(true)
-          setValue(validUntilInputId, undefined, true)
-        })
+        setUnlimited(true)
+        setValue(validUntilInputId, undefined, true)
+      })
       : setUnlimited(false)
   }, [setAsap, setUnlimited, setValue, validFromInputValue, validFromInputId, validUntilInputValue, validUntilInputId])
 

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -63,7 +63,8 @@ const Wrapper = styled.div`
     font-size: 1.25rem;
     align-items: center;
     line-height: 1.4;
-    padding: 0 0.8rem;
+    /* padding: 0 0.8rem; */
+    padding: 0;
 
     > div {
       display: flex;

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -87,7 +87,7 @@ export const WrappedWidget = styled(Widget)`
   min-width: 0;
   margin: 0 auto;
   width: auto;
-  flex-flow: row nowrap;
+  flex-flow: column wrap;
   display: flex;
   background: var(--color-background-pageWrapper);
   border-radius: 0.6rem;
@@ -122,12 +122,15 @@ export const WrappedWidget = styled(Widget)`
 const WrappedForm = styled.form`
   display: flex;
   flex-flow: column nowrap;
-  flex: 1 0 42rem;
+  /* flex: 1 0 42rem; */
+  flex: 1 1 auto;
   max-width: 50rem;
-  padding: 1.6rem;
+  width: 100%;
   box-sizing: border-box;
   transition: width 0.2s ease-in-out, opacity 0.2s ease-in-out;
   opacity: 1;
+  padding: 1.6rem 1.6rem 3.2rem;
+  box-sizing: border-box;
 
   .react-select__control:focus-within,
   input[type='checkbox']:focus,
@@ -136,9 +139,10 @@ const WrappedForm = styled.form`
   }
 
   @media ${MEDIA.tablet} {
-    max-width: initial;
+    /* max-width: initial;
     flex: 1 1 50%;
-    padding: 1.6rem 1.6rem 3.2rem;
+    padding: 1.6rem 1.6rem 3.2rem; */
+    max-width: 40rem;
   }
 
   @media ${MEDIA.mobile} {
@@ -243,6 +247,25 @@ const SubmitButton = styled.button`
   }
 `
 
+const TradeParentWrapper = styled.div`
+  display: flex;
+  width: 100%;
+
+  @media ${MEDIA.mobile} {
+    flex-flow: column wrap;
+  }
+`
+
+const OrderBookPlaceholder = styled.div`
+  display: flex;
+  width: 100%;
+  border-left: .1rem solid var(--color-background-banner);
+
+  @media ${MEDIA.mobile} {
+    border: 0;
+  }
+`
+
 export const ExpandableOrdersPanel = styled.div`
   overflow: hidden;
   display: flex;
@@ -251,7 +274,7 @@ export const ExpandableOrdersPanel = styled.div`
   min-width: 50vw;
   max-width: 100%;
   background: var(--color-background) none repeat scroll 0% 0%; // var(--color-background-pageWrapper);
-  border-radius: 0 0.6rem 0.6rem 0;
+  border-radius: 0 0 0.6rem .6rem;
   box-sizing: border-box;
   transition: flex 0.2s ease-in-out;
   align-items: flex-start;
@@ -260,7 +283,6 @@ export const ExpandableOrdersPanel = styled.div`
   @media ${MEDIA.tablet} {
     flex: 1 1 50%;
     min-width: initial;
-    border-radius: 0;
   }
 
   // Connect Wallet banner in the orders panel
@@ -271,8 +293,9 @@ export const ExpandableOrdersPanel = styled.div`
 
   // Orders widget when inside the ExpandableOrdersPanel
   ${OrdersWrapper} {
-    width: calc(100% - 1.6rem);
-    height: 90%;
+    /* width: calc(100% - 1.6rem); */
+    width: 100%;
+    height: auto;
     background: transparent;
     box-shadow: none;
     border-radius: 0;
@@ -288,22 +311,23 @@ export const ExpandableOrdersPanel = styled.div`
     // Search Filter
     .widgetFilterTools {
       > .balances-searchTokens {
-        height: 3.6rem;
-        margin: 0.8rem;
+        /* height: 3.6rem;
+        margin: 0.8rem; */
+        height: 100%;
       }
     }
 
     .widgetCardWrapper {
       thead,
       tbody {
-        font-size: 1.1rem;
+        /* font-size: 1.1rem; */
 
         > tr {
-          padding: 0 1.4rem;
+          /* padding: 0 1.4rem; */
 
-          @media ${MEDIA.mobile} {
+          /* @media ${MEDIA.mobile} {
             padding: 1.4rem;
-          }
+          } */
         }
       }
     }
@@ -341,11 +365,11 @@ export const ExpandableOrdersPanel = styled.div`
       }
     }
 
-    @media ${MEDIA.tablet} {
+    /* @media ${MEDIA.tablet} {
       width: 100%;
       border-radius: 0;
       margin: 2.4rem auto 0;
-    }
+    } */
 
     @media ${MEDIA.mobile} {
       display: none;
@@ -523,8 +547,8 @@ const TradeWidget: React.FC = () => {
     isConnected && balances.length > 0
       ? balances
       : tokenList.length > 0
-      ? tokenList
-      : tokenListApi.getTokens(networkIdOrDefault)
+        ? tokenList
+        : tokenListApi.getTokens(networkIdOrDefault)
 
   // Listen on manual changes to URL search query
   const { sell: encodedSellTokenSymbol, buy: decodeReceiveTokenSymbol } = useParams()
@@ -610,7 +634,8 @@ const TradeWidget: React.FC = () => {
   const [unlimited, setUnlimited] = useState(!defaultValidUntil || !Number(defaultValidUntil))
   const [asap, setAsap] = useState(!defaultValidFrom || !Number(defaultValidFrom))
 
-  const [ordersVisible, setOrdersVisible] = useState(true)
+  // const [ordersVisible, setOrdersVisible] = useState(true)
+  const [ordersVisible] = useState(true)
 
   const methods = useForm<TradeFormData>({
     mode: 'onChange',
@@ -960,100 +985,102 @@ const TradeWidget: React.FC = () => {
       <TokensAdder tokenAddresses={tokenAddressesToAdd} networkId={networkIdOrDefault} onTokensAdded={onTokensAdded} />
       {/* Toggle Class 'expanded' on WrappedWidget on click of the <ExpandableOrdersPanel> <button> */}
       <FormContext {...methods}>
-        <WrappedForm onSubmit={onConfirm} autoComplete="off" noValidate>
-          {sameToken && <WarningLabel>Tokens cannot be the same!</WarningLabel>}
-          <TokenRow
-            autoFocus
-            selectedToken={sellToken}
-            tokens={tokens}
-            balance={sellTokenBalance}
-            selectLabel="Sell"
-            onSelectChange={onSelectChangeSellToken}
-            inputId={sellInputId}
-            isDisabled={isSubmitting}
-            validateMaxAmount
-            tabIndex={1}
-            readOnly={false}
-            userConnected={!!(userAddress && networkId)}
-          />
-          <IconWrapper onClick={swapTokens}>
-            <SwitcherSVG />
-          </IconWrapper>
-          <TokenRow
-            selectedToken={receiveTokenBalance}
-            tokens={tokens}
-            balance={receiveTokenBalance}
-            selectLabel="Receive at least"
-            onSelectChange={onSelectChangeReceiveToken}
-            inputId={receiveInputId}
-            isDisabled={isSubmitting}
-            tabIndex={1}
-            readOnly
-          />
-          <Price
-            priceInputId={priceInputId}
-            priceInverseInputId={priceInverseInputId}
-            sellToken={sellToken}
-            receiveToken={receiveToken}
-            tabIndex={1}
-            swapPrices={swapPrices}
-            priceShown={priceShown}
-          />
-          <PriceEstimations
-            networkId={networkIdOrDefault}
-            baseToken={receiveToken}
-            quoteToken={sellToken}
-            amount={debouncedSellValue}
-            isPriceInverted={priceShown === 'INVERSE'}
-            priceInputId={priceInputId}
-            priceInverseInputId={priceInverseInputId}
-            swapPrices={swapPrices}
-          />
-          <OrderValidity
-            validFromInputId={validFromId}
-            validUntilInputId={validUntilId}
-            isDisabled={isSubmitting}
-            isAsap={asap}
-            isUnlimited={unlimited}
-            setAsap={setAsap}
-            setUnlimited={setUnlimited}
-            tabIndex={1}
-          />
-          <p>This order might be partially filled.</p>
-          <ButtonWrapper
-            onConfirm={onConfirm}
-            message={(): React.ReactNode => (
-              <ConfirmationModalWrapper>
-                <TxMessage networkId={networkIdOrDefault} sellToken={sellToken} receiveToken={receiveToken} />
-              </ConfirmationModalWrapper>
-            )}
-          >
-            <SubmitButton
-              data-text="This order might be partially filled."
-              type="submit"
-              disabled={isSubmitting}
+        <TradeParentWrapper>
+          <WrappedForm onSubmit={onConfirm} autoComplete="off" noValidate>
+            {sameToken && <WarningLabel>Tokens cannot be the same!</WarningLabel>}
+            <TokenRow
+              autoFocus
+              selectedToken={sellToken}
+              tokens={tokens}
+              balance={sellTokenBalance}
+              selectLabel="Sell"
+              onSelectChange={onSelectChangeSellToken}
+              inputId={sellInputId}
+              isDisabled={isSubmitting}
+              validateMaxAmount
               tabIndex={1}
-              onClick={(e): void => {
-                // don't show Submit Confirm modal for invalid form
-                if (!formState.isValid) e.stopPropagation()
-              }}
+              readOnly={false}
+              userConnected={!!(userAddress && networkId)}
+            />
+            <IconWrapper onClick={swapTokens}>
+              <SwitcherSVG />
+            </IconWrapper>
+            <TokenRow
+              selectedToken={receiveTokenBalance}
+              tokens={tokens}
+              balance={receiveTokenBalance}
+              selectLabel="Receive at least"
+              onSelectChange={onSelectChangeReceiveToken}
+              inputId={receiveInputId}
+              isDisabled={isSubmitting}
+              tabIndex={1}
+              readOnly
+            />
+            <Price
+              priceInputId={priceInputId}
+              priceInverseInputId={priceInverseInputId}
+              sellToken={sellToken}
+              receiveToken={receiveToken}
+              tabIndex={1}
+              swapPrices={swapPrices}
+              priceShown={priceShown}
+            />
+            <PriceEstimations
+              networkId={networkIdOrDefault}
+              baseToken={receiveToken}
+              quoteToken={sellToken}
+              amount={debouncedSellValue}
+              isPriceInverted={priceShown === 'INVERSE'}
+              priceInputId={priceInputId}
+              priceInverseInputId={priceInverseInputId}
+              swapPrices={swapPrices}
+            />
+            <OrderValidity
+              validFromInputId={validFromId}
+              validUntilInputId={validUntilId}
+              isDisabled={isSubmitting}
+              isAsap={asap}
+              isUnlimited={unlimited}
+              setAsap={setAsap}
+              setUnlimited={setUnlimited}
+              tabIndex={1}
+            />
+            <p>This order might be partially filled.</p>
+            <ButtonWrapper
+              onConfirm={onConfirm}
+              message={(): React.ReactNode => (
+                <ConfirmationModalWrapper>
+                  <TxMessage networkId={networkIdOrDefault} sellToken={sellToken} receiveToken={receiveToken} />
+                </ConfirmationModalWrapper>
+              )}
             >
-              {isSubmitting && <Spinner size="lg" spin={isSubmitting} />}{' '}
-              {sameToken ? 'Please select different tokens' : 'Submit limit order'}
-            </SubmitButton>
-          </ButtonWrapper>
-        </WrappedForm>
+              <SubmitButton
+                data-text="This order might be partially filled."
+                type="submit"
+                disabled={isSubmitting}
+                tabIndex={1}
+                onClick={(e): void => {
+                  // don't show Submit Confirm modal for invalid form
+                  if (!formState.isValid) e.stopPropagation()
+                }}
+              >
+                {isSubmitting && <Spinner size="lg" spin={isSubmitting} />}{' '}
+                {sameToken ? 'Please select different tokens' : 'Submit limit order'}
+              </SubmitButton>
+            </ButtonWrapper>
+          </WrappedForm>
+          <OrderBookPlaceholder>-Add the order book component here -</OrderBookPlaceholder>
+        </TradeParentWrapper>
       </FormContext>
       <ExpandableOrdersPanel>
         {/* Toggle panel visibility (arrow) */}
-        <OrdersToggler
+        {/* <OrdersToggler
           type="button"
           onClick={(): void => setOrdersVisible((ordersVisible) => !ordersVisible)}
           $isOpen={ordersVisible}
-        />
+        /> */}
         {/* Actual orders content */}
         <div className="innerWidgetContainer">
-          <h5>Your orders</h5>
           <OrdersWidget displayOnly="regular" />
         </div>
       </ExpandableOrdersPanel>

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -227,20 +227,20 @@ export const TradesWidget: React.FC = () => {
   return !isConnected ? (
     <ConnectWalletBanner />
   ) : (
-    <StandaloneCardWrapper>
-      <OverflowContainer>
-        <FilterTools
-          className="widgetFilterTools"
-          resultName="trades"
-          searchValue={search}
-          handleSearch={handleSearch}
-          showFilter={!!search}
-          dataLength={filteredData.length}
-        />
-        <InnerTradesWidget trades={filteredData} />
-      </OverflowContainer>
-    </StandaloneCardWrapper>
-  )
+      <StandaloneCardWrapper>
+        <OverflowContainer>
+          <FilterTools
+            className="widgetFilterTools"
+            resultName="trades"
+            searchValue={search}
+            handleSearch={handleSearch}
+            showFilter={!!search}
+            dataLength={filteredData.length}
+          />
+          <InnerTradesWidget trades={filteredData} />
+        </OverflowContainer>
+      </StandaloneCardWrapper>
+    )
 }
 
 export default TradesWidget

--- a/src/components/UserWallet/UserWallet.styled.ts
+++ b/src/components/UserWallet/UserWallet.styled.ts
@@ -84,7 +84,7 @@ export const LogInOutButton = styled.div`
 
 export const UserAddress = styled.div`
   font-weight: var(--font-weight-bold);
-  font-size: 1.6rem;
+  font-size: 1.5rem;
   color: var(--color-text-primary);
   letter-spacing: 0;
 
@@ -159,7 +159,7 @@ export const CopyDiv = styled.div`
 export const UserWalletSlideWrapper = styled.div`
   position: absolute;
   background: inherit;
-  left: 0;
+  right: 0;
   background: var(--color-background-pageWrapper);
   width: 19.8rem;
   display: flex;
@@ -169,7 +169,7 @@ export const UserWalletSlideWrapper = styled.div`
   z-index: 10;
   flex-flow: column wrap;
   top: 100%;
-  margin: 1rem 0 0;
+  margin: 2rem 0 0;
   box-shadow: var(--box-shadow-wrapper);
 
   @media ${MEDIA.mobile} {
@@ -228,6 +228,7 @@ export const WalletName = styled.div`
   position: absolute;
   top: 100%;
   font-size: 1rem;
+  font-weight: lighter;
 `
 
 export const MonospaceAddress = styled.div`

--- a/src/hooks/useManageTokens.tsx
+++ b/src/hooks/useManageTokens.tsx
@@ -27,8 +27,8 @@ const OptionWrapper = styled.div`
   min-height: 5.6rem;
   transition: background 0.2s ease-in-out;
   cursor: pointer;
-
-  flex: 50% 0 0;
+  flex: 1 1 50%;
+  align-self: normal;
 
   :hover {
     background: rgba(33, 141, 255, 0.1);
@@ -235,8 +235,8 @@ const ManageTokensContainer: React.FC = () => {
             />
           </SearchItemWrapper>
         ) : (
-          <TokenList tokens={filteredTokens} disabledTokens={tokensDisabledState} onToggleToken={toggleTokenState} />
-        )}
+            <TokenList tokens={filteredTokens} disabledTokens={tokensDisabledState} onToggleToken={toggleTokenState} />
+          )}
       </TokenListWrapper>
       <Modali.Modal {...modalProps} />
     </div>


### PR DESCRIPTION

# Done
- Re-organised the layout to have the orders panel below. 
- Reserved a container on the top right to showcase the order book.

<img width="369" alt="Screenshot 2020-08-28 at 11 59 23" src="https://user-images.githubusercontent.com/31534717/91549033-98cfb680-e926-11ea-9278-a3b7b2c77f34.png">
<img width="1436" alt="Screenshot 2020-08-28 at 12 02 13" src="https://user-images.githubusercontent.com/31534717/91549023-95d4c600-e926-11ea-88d6-c6d5eced3f2f.png">

# Need help integrating:
- Adding the actual order book component. Basically the current order book as shown in the modal, but without the pair selector (given that's already present in the order form on the left). Right now I simply added a placeholder container component.
- For mobile I would suggest for this iteration to keep the 'View order book' button and hide the upfront container we show on desktop. This means that on desktop we won't show the 'View order book' button and show the order book container instead.
- For a next iteration we can add footer tabs for this like this example (@anxolin):
![image (1)](https://user-images.githubusercontent.com/31534717/91549422-34f9bd80-e927-11ea-810b-19cddcfe6314.png)

