### PR TITLE
Order book reposition (supersede #1352)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,10 +72,10 @@ const FAQ = React.lazy(() =>
     'pages/FAQ'
   ),
 )
-const OrderBook = React.lazy(() =>
+const OrderBookPage = React.lazy(() =>
   import(
     /* webpackChunkName: "OrderBook_chunk"*/
-    'pages/OrderBook'
+    'pages/OrderBookPage'
   ),
 )
 const Settings = React.lazy(() =>
@@ -107,7 +107,7 @@ const App: React.FC = () => (
             <PrivateRoute path="/wallet" exact component={Wallet} />
             <Route path="/about" exact component={About} />
             <Route path="/faq" exact component={FAQ} />
-            <Route path="/book" exact component={OrderBook} />
+            <Route path="/book" exact component={OrderBookPage} />
             <Route path="/connect-wallet" exact component={ConnectWallet} />
             <Route path="/trades" exact component={Trades} />
             <Route path="/settings" exact component={Settings} />

--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -42,7 +42,7 @@ export const BalancesWidget = styled(CardWidgetWrapper)`
   height: 100%;
 
   > .filterToolsBar {
-    height: 10%;
+    min-height: 5.2rem;
   }
 
   > ${CardTable} {
@@ -54,7 +54,7 @@ export const BalancesWidget = styled(CardWidgetWrapper)`
       font-size: 1.3rem;
 
       > tr:not(.cardRowDrawer) {
-        min-height: 6.3rem;
+        /* min-height: 6.3rem; */
         > td,
         > th {
           justify-content: flex-end;
@@ -63,11 +63,11 @@ export const BalancesWidget = styled(CardWidgetWrapper)`
       }
     }
 
-    > thead {
+    /* > thead {
       > tr:not(.cardRowDrawer) {
         padding: 0.8rem 3rem;
       }
-    }
+    } */
 
     > tbody {
       overflow-y: auto;
@@ -83,9 +83,9 @@ export const BalancesWidget = styled(CardWidgetWrapper)`
 
             > div {
               word-break: break-word;
-              white-space: nowrap;
-              overflow: hidden;
-              text-overflow: ellipsis;
+              /* white-space: nowrap; */
+              /* overflow: hidden;
+              text-overflow: ellipsis; */
 
               > strong {
                 display: flex;

--- a/src/components/FilterTools.tsx
+++ b/src/components/FilterTools.tsx
@@ -20,14 +20,18 @@ export const BalanceTools = styled.div<{ $css?: string | false }>`
   ${FormMessage} {
     color: var(--color-text-primary);
     background: var(--color-background-validation-warning);
-    font-size: x-small;
+    /* font-size: x-small; */
+    font-size: small;
     margin: 0;
-    position: absolute;
+    /* position: absolute;
     bottom: 0;
-    left: 0;
+    left: 0; */
     width: max-content;
-    padding: 0.1rem 1.6rem 0.1rem 0.5rem;
-    border-radius: 0 1.6rem 0rem 0rem;
+    /* padding: 0.1rem 1.6rem 0.1rem 0.5rem; */
+    padding: 1.3rem 1.6rem;
+    box-sizing: border-box;
+    /* border-radius: 0 1.6rem 0rem 0rem; */
+    border-radius: 0;
   }
 
   // label + search input
@@ -35,8 +39,9 @@ export const BalanceTools = styled.div<{ $css?: string | false }>`
     position: relative;
     display: flex;
     width: 100%;
-    height: 4rem;
-    margin: 1.2rem;
+    height: 100%;
+    /* margin: 1.2rem; */
+    margin: 0;
 
     @media ${MEDIA.mobile} {
       height: 4.6rem;
@@ -55,10 +60,11 @@ export const BalanceTools = styled.div<{ $css?: string | false }>`
     > input {
       margin: 0;
       max-width: 100%;
-      background: var(--color-background-input) url(${searchIcon}) no-repeat left 1.6rem center/1.6rem;
+      background: url(${searchIcon}) no-repeat left 1.6rem center/1.6rem;
       border-radius: 0.6rem 0.6rem 0 0;
       border: 0;
       font-size: 1.4rem;
+      min-height: 5.2rem;
       line-height: 1;
       box-sizing: border-box;
       border-bottom: 0.2rem solid transparent;

--- a/src/components/Layout/Card/Card.tsx
+++ b/src/components/Layout/Card/Card.tsx
@@ -16,7 +16,7 @@ const CardRowDrawer = styled.tr`
   left: 0;
   width: 100%;
   height: 100%;
-  border-radius: 0.6rem;
+  /* border-radius: 0.6rem; */
   background: var(--color-background-modali);
 
   // Inner td wrapper
@@ -25,7 +25,7 @@ const CardRowDrawer = styled.tr`
     z-index: 9999;
     background: var(--color-background-pageWrapper);
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.14);
-    border-radius: var(--border-radius);
+    /* border-radius: var(--border-radius); */
     margin: 0;
     width: 50rem;
     height: 50rem;
@@ -188,7 +188,7 @@ export const CardTable = styled.table<{
   display: grid;
   flex: 1;
   width: 100%;
-  padding-bottom: 2rem;
+  // padding-bottom: 2rem;
 
   .checked {
     margin: 0;
@@ -269,7 +269,7 @@ export const CardTable = styled.table<{
       th {
         color: inherit;
         line-height: 1.2;
-        height: 4rem;
+        // height: 4rem;
 
         &.sortable {
           cursor: pointer;
@@ -292,7 +292,8 @@ export const CardTable = styled.table<{
     font-weight: var(--font-weight-regular);
     color: var(--color-text-primary);
     
-    letter-spacing: -0.085rem;
+    // letter-spacing: -0.085rem;
+    letter-spacing: 0;
     line-height: 1.2;
 
     tr:not(.cardRowDrawer) {
@@ -334,10 +335,8 @@ export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
   display: flex;
   flex-flow: column nowrap;
   justify-content: flex-start;
-
   width: 100%;
   margin: 0 auto;
-
   border-radius: 0.6rem;
   font-size: 1.6rem;
   line-height: 1;
@@ -386,8 +385,9 @@ export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
 
       tr:not(.cardRowDrawer) {
         &:last-child {
-          border-bottom: 0.1rem solid rgba(159, 180, 201, 0.5);
-          border-radius: var(--border-radius);
+          /* border-bottom: 0.1rem solid rgba(159, 180, 201, 0.5); */
+          /* border-radius: var(--border-radius); */
+          border-bottom: 0;
         }
 
         td {

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -32,7 +32,7 @@ const Wrapper = styled.footer`
   line-height: 1;
 
   width: 100%;
-  margin: 0 0 4rem 0;
+  margin: 4rem 0;
   padding: 0 2rem;
 
   @media ${MEDIA.mobile} {

--- a/src/components/Layout/Header/Header.styled.ts
+++ b/src/components/Layout/Header/Header.styled.ts
@@ -7,27 +7,31 @@ export const HeaderWrapper = styled.header`
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  padding: 0;
+  padding: 0 2.4rem;
+  box-sizing: border-box;
+
+  @media ${MEDIA.mobile} {
+    padding: 1rem 1.6rem 0;
+    box-sizing: border-box;
+  }
 
   nav {
     display: flex;
     flex-flow: column wrap;
     align-items: center;
     width: 100%;
-
-    @media ${MEDIA.mobile} {
-      padding: 0 1.2rem;
-      box-sizing: border-box;
-    }
   }
 
   ${UserWalletWrapper} {
-    order: 1;
-    margin: 3.2rem 3rem 3.2rem 0;
-    width: auto;
+    /* order: 1; */
+    margin: 2.4rem 0 3.2rem 3.2rem;
+    order: 2;
+    /* margin: 3.2rem 3rem 3.2rem 0; */
 
     @media ${MEDIA.mobile} {
-      margin: 2rem 1rem 2rem 0;
+      /* margin: 2rem 1rem 2rem 0; */
+      margin: 0;
+      order: 1;
     }
   }
 

--- a/src/components/Layout/Header/Navigation.styled.ts
+++ b/src/components/Layout/Header/Navigation.styled.ts
@@ -4,17 +4,18 @@ import { MEDIA } from 'const'
 export const NavLinksWrapper = styled.div<{ $open?: boolean; $responsive: boolean }>`
   display: flex;
   order: 1;
-  flex: 1 1 100%;
   margin: auto;
   align-items: center;
-  justify-content: center;
+  flex: 1 1 auto;
+  justify-content: flex-start;
 
   @media ${MEDIA.mobile} {
     flex-flow: row wrap;
     background: #dde4ed;
     border-radius: 15rem;
     width: 100%;
-    margin: 0 auto;
+    margin: 2.4rem auto 0;
+    order: 3;
     justify-content: space-between;
   }
 
@@ -26,13 +27,16 @@ export const NavLinksWrapper = styled.div<{ $open?: boolean; $responsive: boolea
     text-decoration: none;
     transition: color 0.2s ease-in-out, background 0.2s ease-in-out;
     font-weight: var(--font-weight-bold);
-    font-size: 2.1rem;
-    padding: 0 4rem;
+    /* font-size: 2.1rem; */
+    /* padding: 0 4rem; */
     border-radius: 15rem;
     letter-spacing: 0;
     text-align: center;
     box-sizing: border-box;
-    height: 5.4rem;
+    /* height: 5.4rem; */
+    height: 4.2rem;
+    font-size: 1.8rem;
+    padding: 0 2.4rem;
     line-height: 1;
     display: flex;
     justify-content: center;
@@ -42,9 +46,8 @@ export const NavLinksWrapper = styled.div<{ $open?: boolean; $responsive: boolea
       color: rgba(78, 106, 133, 0.75);
       margin: 0;
       padding: 0;
-      font-size: 1.3rem;
+      font-size: 1.2rem;
       width: 100%;
-      height: 4rem;
     }
 
     &:hover {
@@ -66,7 +69,8 @@ export const NavLinksWrapper = styled.div<{ $open?: boolean; $responsive: boolea
 export const OrderedNavLinkDiv = styled.span`
   display: flex;
   align-items: center;
-  flex: 1 1 auto;
+  /* flex: 1 1 auto; */
+  flex: 0;
 
   // Hide 'ORDERS' tab on desktop/tablet (until we decide to show it for all devices...)
   &:nth-of-type(3) {
@@ -82,7 +86,8 @@ export const OrderedNavLinkDiv = styled.span`
   }
 
   &:not(:last-of-type) {
-    margin: 0 1.6rem 0 0;
+    /* margin: 0 1.6rem 0 0; */
+    margin: 0;
     @media ${MEDIA.mobile} {
       margin: 0;
     }

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -37,14 +37,20 @@ const TopWrapper = styled.div`
 
   @media ${MEDIA.mobile} {
     justify-content: space-between;
+    flex-flow: row wrap;
   }
 `
 
 const CountDownStyled = styled.div`
   display: flex;
   flex-flow: column;
-  order 2;
-  min-width: 15rem;
+  /* order 2; */
+  order: 1;
+  
+    @media ${MEDIA.mobile} {
+      order: 2;
+      padding: 1.2rem 0 0;
+    }
 
  > div {
   display: flex;
@@ -53,14 +59,14 @@ const CountDownStyled = styled.div`
   color: var(--color-text-primary);
   min-width: 16rem;
   letter-spacing: 0;
-  margin: 0.5rem 0;
+  margin: 0.3rem 0;
   align-items: baseline;
 
-  @media ${MEDIA.mobile} {
+  /* @media ${MEDIA.mobile} {
     flex-flow: row wrap;
     line-height: 1.2;
     width: auto;
-  }
+  } */
 
   > strong {
     color: var(--color-text-active);
@@ -114,18 +120,18 @@ const Header: React.FC<HeaderProps> = ({ navigation: initialState }: HeaderProps
           {CONFIG.name}
         </NavLink> */}
         <TopWrapper>
+          {/* HEADER LINKS */}
+          <NavigationLinks
+            navigation={navigationArray}
+            responsive={isResponsive}
+            handleOpenNav={handleOpenNav}
+            showNav={openNav}
+          />
           {/* USER WALLET */}
           <UserWallet />
           {/* Global Batch Countdown */}
           <BatchCountDown />
         </TopWrapper>
-        {/* HEADER LINKS */}
-        <NavigationLinks
-          navigation={navigationArray}
-          responsive={isResponsive}
-          handleOpenNav={handleOpenNav}
-          showNav={openNav}
-        />
       </nav>
     </HeaderWrapper>
   )

--- a/src/components/Layout/PageWrapper.tsx
+++ b/src/components/Layout/PageWrapper.tsx
@@ -62,7 +62,8 @@ export const StandaloneCardWrapper = styled.div`
   }
 `
 export const PageWrapper = styled.section`
-  height: 71rem;
+  /* height: 71rem; */
+  height: auto;
   min-width: 85rem;
   max-width: 100%;
 

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -15,9 +15,9 @@ import LegalBanner from 'components/LegalBanner'
 export const EllipsisText = styled.div<{ $maxWidth?: string }>`
   font-size: inherit;
   max-width: ${({ $maxWidth = '6ch' }): string => $maxWidth};
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
+  /* text-overflow: ellipsis;
+  overflow: hidden; */
+  /* white-space: nowrap; */
 `
 
 const Wrapper = styled.div`
@@ -27,8 +27,10 @@ const Wrapper = styled.div`
   flex-flow: column wrap;
 
   main {
-    flex: 0 1 auto;
-    margin: 2.4rem auto 5rem;
+    /* flex: 0 1 auto; */
+    /* margin: 2.4rem auto 5rem; */
+    flex: 1 1 auto;
+    margin: 0 2.4rem;
     width: auto;
     display: flex;
     flex-flow: row wrap;

--- a/src/components/OrderBook.tsx
+++ b/src/components/OrderBook.tsx
@@ -18,7 +18,7 @@ import { DEFAULT_PRECISION } from '@gnosis.pm/dex-js'
 
 const SMALL_VOLUME_THRESHOLD = 0.01
 
-interface OrderBookProps {
+export interface OrderBookProps {
   baseToken: TokenDetails
   quoteToken: TokenDetails
   networkId: number
@@ -304,7 +304,7 @@ const draw = (
   return chart
 }
 
-const OrderBookWidget: React.FC<OrderBookProps> = (props) => {
+export const OrderBook: React.FC<OrderBookProps> = (props) => {
   const { baseToken, quoteToken, networkId, hops } = props
   const mountPoint = useRef<HTMLDivElement>(null)
 
@@ -323,4 +323,4 @@ const OrderBookWidget: React.FC<OrderBookProps> = (props) => {
   )
 }
 
-export default OrderBookWidget
+export default OrderBook

--- a/src/components/OrderBookBtn.tsx
+++ b/src/components/OrderBookBtn.tsx
@@ -13,7 +13,7 @@ import { safeTokenName, getNetworkFromId } from '@gnosis.pm/dex-js'
 
 // components
 import { DEFAULT_MODAL_OPTIONS, ModalBodyWrapper } from 'components/Modal'
-import OrderBookWidget from 'components/OrderBookWidget'
+import OrderBook from 'components/OrderBook'
 import TokenSelector from 'components/TokenSelector'
 
 // hooks
@@ -167,7 +167,7 @@ export const OrderBookBtn: React.FC<OrderBookBtnProps> = (props: OrderBookBtnPro
             }
           />
         </span>
-        <OrderBookWidget baseToken={baseToken} quoteToken={quoteToken} networkId={networkId} />
+        <OrderBook baseToken={baseToken} quoteToken={quoteToken} networkId={networkId} />
       </ModalWrapper>
     ),
     buttons: [

--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -149,12 +149,13 @@ export const OrdersForm = styled.div`
       display: flex;
       flex-flow: row nowrap;
       width: 100%;
-      margin: 0 0 -0.1rem;
+      /* margin: 0 0 -0.1rem; */
+      margin: 0;
       align-items: center;
 
       > button {
         font-weight: var(--font-weight-bold);
-        font-size: 1.5rem;
+        font-size: 1.3rem;
         color: var(--color-text-secondary);
         letter-spacing: 0;
         text-align: center;
@@ -169,8 +170,8 @@ export const OrdersForm = styled.div`
         justify-content: center;
         transition: border 0.2s ease-in-out;
         align-items: center;
-        border-bottom: 0.3rem solid transparent;
-        min-height: 6.4rem;
+        border-bottom: 0.2rem solid transparent;
+        min-height: 5.2rem;
 
         > i {
           height: 1.8rem;
@@ -212,7 +213,7 @@ export const OrdersForm = styled.div`
       }
 
       > button.selected {
-        border-bottom: 0.3rem solid var(--color-text-active);
+        border-bottom: 0.2rem solid var(--color-text-active);
         color: var(--color-text-active);
       }
 

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useCallback, useEffect } from 'react'
+import styled from 'styled-components'
 // eslint-disable-next-line @typescript-eslint/camelcase
 import { unstable_batchedUpdates } from 'react-dom'
 
@@ -33,6 +34,9 @@ import FilterTools from 'components/FilterTools'
 import { useDeleteOrders } from 'components/OrdersWidget/useDeleteOrders'
 import OrderRow from 'components/OrdersWidget/OrderRow'
 import { OrdersWrapper, ButtonWithIcon, OrdersForm } from 'components/OrdersWidget/OrdersWidget.styled'
+
+// Misc
+import { MEDIA } from 'const'
 
 type OrderTabs = 'active' | 'closed' | 'trades'
 type FilteredOrdersStateKeys = Exclude<OrderTabs, 'trades'>
@@ -347,6 +351,15 @@ const OrdersWidget: React.FC<Props> = ({ displayOnly }) => {
     classifiedOrders[selectedTab]?.orders?.length > 0 && markedForDeletion.size === displayedOrders.length
   )
 
+  const FilterToolsWrapper = styled.div`
+    display: flex;
+    width: 100%;
+
+    @media ${MEDIA.mobile} {
+      flex-flow: column wrap;
+    }
+  `
+
   return (
     <OrdersWrapper>
       {!isConnected ? (
@@ -362,28 +375,30 @@ const OrdersWidget: React.FC<Props> = ({ displayOnly }) => {
       {(!noOrders || !noTrades) && networkId && (
         <OrdersForm>
           <form action="submit" onSubmit={onSubmit}>
-            <FilterTools
-              className="widgetFilterTools"
-              resultName={tabSpecificResultName}
-              searchValue={tabSpecficSearch}
-              handleSearch={handleTabSpecificSearch}
-              showFilter={!!tabSpecficSearch}
-              dataLength={tabSpecificDataLength}
-            >
-              {selectedTab !== 'trades' && (
-                <label className="checked">
-                  <small>Cancel All Orders:</small>
-                  <input
-                    type="checkbox"
-                    onChange={toggleSelectAll}
-                    checked={markedForDeletionChecked}
-                    disabled={deleting}
-                  />
-                </label>
-              )}
-            </FilterTools>
-            {/* ORDERS TABS: ACTIVE/TRADES/CLOSED */}
-            <Tabs<OrderTabs> {...tabsProps} />
+            <FilterToolsWrapper>
+              <FilterTools
+                className="widgetFilterTools"
+                resultName={tabSpecificResultName}
+                searchValue={tabSpecficSearch}
+                handleSearch={handleTabSpecificSearch}
+                showFilter={!!tabSpecficSearch}
+                dataLength={tabSpecificDataLength}
+              >
+                {selectedTab !== 'trades' && (
+                  <label className="checked">
+                    <small>Cancel All Orders:</small>
+                    <input
+                      type="checkbox"
+                      onChange={toggleSelectAll}
+                      checked={markedForDeletionChecked}
+                      disabled={deleting}
+                    />
+                  </label>
+                )}
+              </FilterTools>
+              {/* ORDERS TABS: ACTIVE/TRADES/CLOSED */}
+              <Tabs<OrderTabs> {...tabsProps} />
+            </FilterToolsWrapper>
 
             {/* DELETE ORDERS ROW */}
             <div className="deleteContainer" data-disabled={markedForDeletion.size === 0 || deleting}>
@@ -405,7 +420,7 @@ const OrdersWidget: React.FC<Props> = ({ displayOnly }) => {
               <div className="ordersContainer">
                 <CardWidgetWrapper className="widgetCardWrapper">
                   <CardTable
-                    $columns="3.2rem minmax(8.6rem, 0.3fr) repeat(2,1fr) minmax(5.2rem,0.6fr) minmax(8.6rem, 0.3fr)"
+                    $columns="3.2rem minmax(8.6rem,0.3fr) repeat(2,1fr) minmax(5.2rem,0.6fr) minmax(9rem,0.3fr)"
                     $gap="0 0.6rem"
                     $rowSeparation="0"
                   >

--- a/src/components/PoolingWidget/PoolingWidget.styled.ts
+++ b/src/components/PoolingWidget/PoolingWidget.styled.ts
@@ -43,7 +43,8 @@ export const PoolingInterfaceWrapper = styled(WrappedWidget)`
     flex-flow: column nowrap;
     padding: 2rem;
     min-width: 51.4rem;
-    max-width: 75rem;
+    /* max-width: 75rem; */
+    margin: 0 auto;
 
     > h2 {
       margin: 1rem auto 2.4rem;
@@ -60,7 +61,7 @@ export const PoolingInterfaceWrapper = styled(WrappedWidget)`
     > form {
       min-width: 100%;
       max-width: 100%;
-      padding: 2rem 4rem;
+      padding: 2rem 2.4rem;
     }
   }
 

--- a/src/components/PoolingWidget/index.tsx
+++ b/src/components/PoolingWidget/index.tsx
@@ -14,7 +14,7 @@ import { maxAmountsForSpread, resolverFactory, NUMBER_VALIDATION_KEYS } from 'ut
 
 // components
 import OrdersWidget from 'components/OrdersWidget'
-import { ExpandableOrdersPanel, OrdersToggler } from 'components/TradeWidget'
+import { ExpandableOrdersPanel } from 'components/TradeWidget'
 
 // PoolingWidget: subcomponents
 import ProgressBar from 'components/PoolingWidget/ProgressBar'
@@ -147,7 +147,7 @@ const PoolingInterface: React.FC = () => {
   const [txReceipt, setTxReceipt] = useSafeState<Receipt | undefined>(undefined)
   const [txError, setTxError] = useSafeState(undefined)
 
-  const [ordersVisible, setOrdersVisible] = useSafeState(true)
+  const [ordersVisible] = useSafeState(true)
 
   const { networkId, networkIdOrDefault, userAddress } = useWalletConnection()
   // Get all the tokens for the current network
@@ -330,11 +330,11 @@ const PoolingInterface: React.FC = () => {
       </FormContext>
       <ExpandableOrdersPanel>
         {/* Toggle panel visibility (arrow) */}
-        <OrdersToggler
+        {/* <OrdersToggler
           type="button"
           onClick={(): void => setOrdersVisible((ordersVisible) => !ordersVisible)}
           $isOpen={ordersVisible}
-        />
+        /> */}
         {/* Actual orders content */}
         <OrdersWidget displayOnly="liquidity" />
       </ExpandableOrdersPanel>

--- a/src/components/TradeWidget/OrderValidity.tsx
+++ b/src/components/TradeWidget/OrderValidity.tsx
@@ -69,7 +69,8 @@ const Wrapper = styled.div`
       background: transparent;
       align-items: center;
       flex-flow: row wrap;
-      padding: 0 0.8rem;
+      /* padding: 0 0.8rem; */
+      padding: 0 0.8rem 0 0;
 
       > b {
         color: #218dff;

--- a/src/components/TradeWidget/Price.tsx
+++ b/src/components/TradeWidget/Price.tsx
@@ -8,9 +8,6 @@ import { TokenDetails } from 'types'
 import { parseBigNumber } from 'utils'
 import { DEFAULT_PRECISION, MEDIA } from 'const'
 
-// Components
-import { OrderBookBtn } from 'components/OrderBookBtn'
-
 // TradeWidget: subcomponents
 import { TradeFormData } from 'components/TradeWidget'
 import FormMessage, { FormInputError } from 'components/TradeWidget/FormMessage'
@@ -224,9 +221,7 @@ const Price: React.FC<Props> = ({
 
   return (
     <Wrapper>
-      <strong>
-        Limit Price <OrderBookBtn baseToken={receiveToken} quoteToken={sellToken} />
-      </strong>
+      <strong>Limit Price</strong>
       {/* using display: none to hide to avoid hook-form reregister */}
       <PriceInputBox hidden={priceShown !== 'DIRECT'}>
         <label>

--- a/src/components/TradeWidget/PriceEstimations.tsx
+++ b/src/components/TradeWidget/PriceEstimations.tsx
@@ -63,7 +63,8 @@ const Wrapper = styled.div`
     font-size: 1.25rem;
     align-items: center;
     line-height: 1.4;
-    padding: 0 0.8rem;
+    /* padding: 0 0.8rem; */
+    padding: 0;
 
     > div {
       display: flex;

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -42,6 +42,7 @@ import { OrdersWrapper } from 'components/OrdersWidget/OrdersWidget.styled'
 import { TxNotification } from 'components/TxNotification'
 import { Wrapper } from 'components/ConnectWalletBanner'
 import { Spinner } from 'components/Spinner'
+import { OrderBook } from 'components/OrderBook'
 
 // TradeWidget: subcomponents
 import TokenRow from 'components/TradeWidget/TokenRow'
@@ -256,7 +257,7 @@ const TradeParentWrapper = styled.div`
   }
 `
 
-const OrderBookPlaceholder = styled.div`
+const OrderBookWrapper = styled.div`
   display: flex;
   width: 100%;
   border-left: 0.1rem solid var(--color-background-banner);
@@ -1069,7 +1070,9 @@ const TradeWidget: React.FC = () => {
               </SubmitButton>
             </ButtonWrapper>
           </WrappedForm>
-          <OrderBookPlaceholder>-Add the order book component here -</OrderBookPlaceholder>
+          <OrderBookWrapper>
+            <OrderBook baseToken={receiveToken} quoteToken={sellToken} networkId={networkIdOrDefault} />
+          </OrderBookWrapper>
         </TradeParentWrapper>
       </FormContext>
       <ExpandableOrdersPanel>

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -87,7 +87,7 @@ export const WrappedWidget = styled(Widget)`
   min-width: 0;
   margin: 0 auto;
   width: auto;
-  flex-flow: row nowrap;
+  flex-flow: column wrap;
   display: flex;
   background: var(--color-background-pageWrapper);
   border-radius: 0.6rem;
@@ -122,12 +122,15 @@ export const WrappedWidget = styled(Widget)`
 const WrappedForm = styled.form`
   display: flex;
   flex-flow: column nowrap;
-  flex: 1 0 42rem;
+  /* flex: 1 0 42rem; */
+  flex: 1 1 auto;
   max-width: 50rem;
-  padding: 1.6rem;
+  width: 100%;
   box-sizing: border-box;
   transition: width 0.2s ease-in-out, opacity 0.2s ease-in-out;
   opacity: 1;
+  padding: 1.6rem 1.6rem 3.2rem;
+  box-sizing: border-box;
 
   .react-select__control:focus-within,
   input[type='checkbox']:focus,
@@ -136,9 +139,10 @@ const WrappedForm = styled.form`
   }
 
   @media ${MEDIA.tablet} {
-    max-width: initial;
+    /* max-width: initial;
     flex: 1 1 50%;
-    padding: 1.6rem 1.6rem 3.2rem;
+    padding: 1.6rem 1.6rem 3.2rem; */
+    max-width: 40rem;
   }
 
   @media ${MEDIA.mobile} {
@@ -243,6 +247,25 @@ const SubmitButton = styled.button`
   }
 `
 
+const TradeParentWrapper = styled.div`
+  display: flex;
+  width: 100%;
+
+  @media ${MEDIA.mobile} {
+    flex-flow: column wrap;
+  }
+`
+
+const OrderBookPlaceholder = styled.div`
+  display: flex;
+  width: 100%;
+  border-left: 0.1rem solid var(--color-background-banner);
+
+  @media ${MEDIA.mobile} {
+    border: 0;
+  }
+`
+
 export const ExpandableOrdersPanel = styled.div`
   overflow: hidden;
   display: flex;
@@ -251,7 +274,7 @@ export const ExpandableOrdersPanel = styled.div`
   min-width: 50vw;
   max-width: 100%;
   background: var(--color-background) none repeat scroll 0% 0%; // var(--color-background-pageWrapper);
-  border-radius: 0 0.6rem 0.6rem 0;
+  border-radius: 0 0 0.6rem .6rem;
   box-sizing: border-box;
   transition: flex 0.2s ease-in-out;
   align-items: flex-start;
@@ -260,7 +283,6 @@ export const ExpandableOrdersPanel = styled.div`
   @media ${MEDIA.tablet} {
     flex: 1 1 50%;
     min-width: initial;
-    border-radius: 0;
   }
 
   // Connect Wallet banner in the orders panel
@@ -271,8 +293,9 @@ export const ExpandableOrdersPanel = styled.div`
 
   // Orders widget when inside the ExpandableOrdersPanel
   ${OrdersWrapper} {
-    width: calc(100% - 1.6rem);
-    height: 90%;
+    /* width: calc(100% - 1.6rem); */
+    width: 100%;
+    height: auto;
     background: transparent;
     box-shadow: none;
     border-radius: 0;
@@ -288,22 +311,23 @@ export const ExpandableOrdersPanel = styled.div`
     // Search Filter
     .widgetFilterTools {
       > .balances-searchTokens {
-        height: 3.6rem;
-        margin: 0.8rem;
+        /* height: 3.6rem;
+        margin: 0.8rem; */
+        height: 100%;
       }
     }
 
     .widgetCardWrapper {
       thead,
       tbody {
-        font-size: 1.1rem;
+        /* font-size: 1.1rem; */
 
         > tr {
-          padding: 0 1.4rem;
+          /* padding: 0 1.4rem; */
 
-          @media ${MEDIA.mobile} {
+          /* @media ${MEDIA.mobile} {
             padding: 1.4rem;
-          }
+          } */
         }
       }
     }
@@ -341,11 +365,11 @@ export const ExpandableOrdersPanel = styled.div`
       }
     }
 
-    @media ${MEDIA.tablet} {
+    /* @media ${MEDIA.tablet} {
       width: 100%;
       border-radius: 0;
       margin: 2.4rem auto 0;
-    }
+    } */
 
     @media ${MEDIA.mobile} {
       display: none;
@@ -610,7 +634,8 @@ const TradeWidget: React.FC = () => {
   const [unlimited, setUnlimited] = useState(!defaultValidUntil || !Number(defaultValidUntil))
   const [asap, setAsap] = useState(!defaultValidFrom || !Number(defaultValidFrom))
 
-  const [ordersVisible, setOrdersVisible] = useState(true)
+  // const [ordersVisible, setOrdersVisible] = useState(true)
+  const [ordersVisible] = useState(true)
 
   const methods = useForm<TradeFormData>({
     mode: 'onChange',
@@ -960,100 +985,102 @@ const TradeWidget: React.FC = () => {
       <TokensAdder tokenAddresses={tokenAddressesToAdd} networkId={networkIdOrDefault} onTokensAdded={onTokensAdded} />
       {/* Toggle Class 'expanded' on WrappedWidget on click of the <ExpandableOrdersPanel> <button> */}
       <FormContext {...methods}>
-        <WrappedForm onSubmit={onConfirm} autoComplete="off" noValidate>
-          {sameToken && <WarningLabel>Tokens cannot be the same!</WarningLabel>}
-          <TokenRow
-            autoFocus
-            selectedToken={sellToken}
-            tokens={tokens}
-            balance={sellTokenBalance}
-            selectLabel="Sell"
-            onSelectChange={onSelectChangeSellToken}
-            inputId={sellInputId}
-            isDisabled={isSubmitting}
-            validateMaxAmount
-            tabIndex={1}
-            readOnly={false}
-            userConnected={!!(userAddress && networkId)}
-          />
-          <IconWrapper onClick={swapTokens}>
-            <SwitcherSVG />
-          </IconWrapper>
-          <TokenRow
-            selectedToken={receiveTokenBalance}
-            tokens={tokens}
-            balance={receiveTokenBalance}
-            selectLabel="Receive at least"
-            onSelectChange={onSelectChangeReceiveToken}
-            inputId={receiveInputId}
-            isDisabled={isSubmitting}
-            tabIndex={1}
-            readOnly
-          />
-          <Price
-            priceInputId={priceInputId}
-            priceInverseInputId={priceInverseInputId}
-            sellToken={sellToken}
-            receiveToken={receiveToken}
-            tabIndex={1}
-            swapPrices={swapPrices}
-            priceShown={priceShown}
-          />
-          <PriceEstimations
-            networkId={networkIdOrDefault}
-            baseToken={receiveToken}
-            quoteToken={sellToken}
-            amount={debouncedSellValue}
-            isPriceInverted={priceShown === 'INVERSE'}
-            priceInputId={priceInputId}
-            priceInverseInputId={priceInverseInputId}
-            swapPrices={swapPrices}
-          />
-          <OrderValidity
-            validFromInputId={validFromId}
-            validUntilInputId={validUntilId}
-            isDisabled={isSubmitting}
-            isAsap={asap}
-            isUnlimited={unlimited}
-            setAsap={setAsap}
-            setUnlimited={setUnlimited}
-            tabIndex={1}
-          />
-          <p>This order might be partially filled.</p>
-          <ButtonWrapper
-            onConfirm={onConfirm}
-            message={(): React.ReactNode => (
-              <ConfirmationModalWrapper>
-                <TxMessage networkId={networkIdOrDefault} sellToken={sellToken} receiveToken={receiveToken} />
-              </ConfirmationModalWrapper>
-            )}
-          >
-            <SubmitButton
-              data-text="This order might be partially filled."
-              type="submit"
-              disabled={isSubmitting}
+        <TradeParentWrapper>
+          <WrappedForm onSubmit={onConfirm} autoComplete="off" noValidate>
+            {sameToken && <WarningLabel>Tokens cannot be the same!</WarningLabel>}
+            <TokenRow
+              autoFocus
+              selectedToken={sellToken}
+              tokens={tokens}
+              balance={sellTokenBalance}
+              selectLabel="Sell"
+              onSelectChange={onSelectChangeSellToken}
+              inputId={sellInputId}
+              isDisabled={isSubmitting}
+              validateMaxAmount
               tabIndex={1}
-              onClick={(e): void => {
-                // don't show Submit Confirm modal for invalid form
-                if (!formState.isValid) e.stopPropagation()
-              }}
+              readOnly={false}
+              userConnected={!!(userAddress && networkId)}
+            />
+            <IconWrapper onClick={swapTokens}>
+              <SwitcherSVG />
+            </IconWrapper>
+            <TokenRow
+              selectedToken={receiveTokenBalance}
+              tokens={tokens}
+              balance={receiveTokenBalance}
+              selectLabel="Receive at least"
+              onSelectChange={onSelectChangeReceiveToken}
+              inputId={receiveInputId}
+              isDisabled={isSubmitting}
+              tabIndex={1}
+              readOnly
+            />
+            <Price
+              priceInputId={priceInputId}
+              priceInverseInputId={priceInverseInputId}
+              sellToken={sellToken}
+              receiveToken={receiveToken}
+              tabIndex={1}
+              swapPrices={swapPrices}
+              priceShown={priceShown}
+            />
+            <PriceEstimations
+              networkId={networkIdOrDefault}
+              baseToken={receiveToken}
+              quoteToken={sellToken}
+              amount={debouncedSellValue}
+              isPriceInverted={priceShown === 'INVERSE'}
+              priceInputId={priceInputId}
+              priceInverseInputId={priceInverseInputId}
+              swapPrices={swapPrices}
+            />
+            <OrderValidity
+              validFromInputId={validFromId}
+              validUntilInputId={validUntilId}
+              isDisabled={isSubmitting}
+              isAsap={asap}
+              isUnlimited={unlimited}
+              setAsap={setAsap}
+              setUnlimited={setUnlimited}
+              tabIndex={1}
+            />
+            <p>This order might be partially filled.</p>
+            <ButtonWrapper
+              onConfirm={onConfirm}
+              message={(): React.ReactNode => (
+                <ConfirmationModalWrapper>
+                  <TxMessage networkId={networkIdOrDefault} sellToken={sellToken} receiveToken={receiveToken} />
+                </ConfirmationModalWrapper>
+              )}
             >
-              {isSubmitting && <Spinner size="lg" spin={isSubmitting} />}{' '}
-              {sameToken ? 'Please select different tokens' : 'Submit limit order'}
-            </SubmitButton>
-          </ButtonWrapper>
-        </WrappedForm>
+              <SubmitButton
+                data-text="This order might be partially filled."
+                type="submit"
+                disabled={isSubmitting}
+                tabIndex={1}
+                onClick={(e): void => {
+                  // don't show Submit Confirm modal for invalid form
+                  if (!formState.isValid) e.stopPropagation()
+                }}
+              >
+                {isSubmitting && <Spinner size="lg" spin={isSubmitting} />}{' '}
+                {sameToken ? 'Please select different tokens' : 'Submit limit order'}
+              </SubmitButton>
+            </ButtonWrapper>
+          </WrappedForm>
+          <OrderBookPlaceholder>-Add the order book component here -</OrderBookPlaceholder>
+        </TradeParentWrapper>
       </FormContext>
       <ExpandableOrdersPanel>
         {/* Toggle panel visibility (arrow) */}
-        <OrdersToggler
+        {/* <OrdersToggler
           type="button"
           onClick={(): void => setOrdersVisible((ordersVisible) => !ordersVisible)}
           $isOpen={ordersVisible}
-        />
+        /> */}
         {/* Actual orders content */}
         <div className="innerWidgetContainer">
-          <h5>Your orders</h5>
           <OrdersWidget displayOnly="regular" />
         </div>
       </ExpandableOrdersPanel>

--- a/src/components/UserWallet/UserWallet.styled.ts
+++ b/src/components/UserWallet/UserWallet.styled.ts
@@ -121,7 +121,7 @@ export const ConnectWallet = styled.div`
 
 export const UserAddress = styled.div`
   font-weight: var(--font-weight-bold);
-  font-size: 1.6rem;
+  font-size: 1.5rem;
   color: var(--color-text-primary);
   letter-spacing: 0;
 
@@ -196,7 +196,7 @@ export const CopyDiv = styled.div`
 export const UserWalletSlideWrapper = styled.div`
   position: absolute;
   background: inherit;
-  left: 0;
+  right: 0;
   background: var(--color-background-pageWrapper);
   width: 31rem;
   display: flex;
@@ -205,8 +205,8 @@ export const UserWalletSlideWrapper = styled.div`
   box-sizing: border-box;
   z-index: 10;
   flex-flow: column wrap;
-  top: calc(100% + 0.7rem);
-  margin: 1rem 0 0;
+  top: 100%;
+  margin: 2rem 0 0;
   box-shadow: var(--box-shadow-wrapper);
 
   @media ${MEDIA.mobile} {
@@ -267,6 +267,7 @@ export const WalletName = styled.div`
   position: absolute;
   top: 100%;
   font-size: 1rem;
+  font-weight: lighter;
 `
 
 export const MonospaceAddress = styled.div`

--- a/src/hooks/useManageTokens.tsx
+++ b/src/hooks/useManageTokens.tsx
@@ -27,8 +27,8 @@ const OptionWrapper = styled.div`
   min-height: 5.6rem;
   transition: background 0.2s ease-in-out;
   cursor: pointer;
-
-  flex: 50% 0 0;
+  flex: 1 1 50%;
+  align-self: normal;
 
   :hover {
     background: rgba(33, 141, 255, 0.1);

--- a/src/pages/OrderBookPage.tsx
+++ b/src/pages/OrderBookPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, ChangeEvent } from 'react'
 import { ContentPage } from 'components/Layout/PageWrapper'
-import OrderBookWidget from 'components/OrderBookWidget'
+import { OrderBook } from 'components/OrderBook'
 import TokenSelector from 'components/TokenSelector'
 import { useTokenList } from 'hooks/useTokenList'
 import { useWalletConnection } from 'hooks/useWalletConnection'
@@ -11,7 +11,7 @@ import { Input } from 'components/Input'
 import { MEDIA, ORDER_BOOK_HOPS_DEFAULT, ORDER_BOOK_HOPS_MAX } from 'const'
 import InputBox from 'components/InputBox'
 
-const OrderBookPage = styled(ContentPage)`
+const OrderBookPageWrapper = styled(ContentPage)`
   padding: 2.4rem 0rem;
   min-height: initial;
 `
@@ -76,7 +76,7 @@ const OrderBookWrapper = styled.div`
   }
 `
 
-const OrderBook: React.FC = () => {
+export const OrderBookPage: React.FC = () => {
   const { networkIdOrDefault } = useWalletConnection()
   // get all tokens
   const tokenList = useTokenList({ networkId: networkIdOrDefault })
@@ -102,7 +102,7 @@ const OrderBook: React.FC = () => {
   }
 
   return (
-    <OrderBookPage>
+    <OrderBookPageWrapper>
       <OrderBookWrapper>
         <h1>Order book</h1>
         <span>
@@ -130,9 +130,9 @@ const OrderBook: React.FC = () => {
         </span>
       </OrderBookWrapper>
 
-      <OrderBookWidget baseToken={baseToken} quoteToken={quoteToken} networkId={networkIdOrDefault} hops={+hops} />
-    </OrderBookPage>
+      <OrderBook baseToken={baseToken} quoteToken={quoteToken} networkId={networkIdOrDefault} hops={+hops} />
+    </OrderBookPageWrapper>
   )
 }
 
-export default OrderBook
+export default OrderBookPage


### PR DESCRIPTION
Supersede #1352, 
* It didn't start from develop (was having some 1.3 changes that shouldn't be in this PR --> it would squash them later causing conflicts)
* Bad formatting: breaking some linting rules. Applied autofix from eslint


# Done
- Re-organised the layout to have the orders panel below. 
- Reserved a container on the top right to showcase the order book.

<img width="369" alt="Screenshot 2020-08-28 at 11 59 23" src="https://user-images.githubusercontent.com/31534717/91549033-98cfb680-e926-11ea-9278-a3b7b2c77f34.png">
<img width="1436" alt="Screenshot 2020-08-28 at 12 02 13" src="https://user-images.githubusercontent.com/31534717/91549023-95d4c600-e926-11ea-88d6-c6d5eced3f2f.png">

# Need help integrating:
- Adding the actual order book component. Basically the current order book as shown in the modal, but without the pair selector (given that's already present in the order form on the left). Right now I simply added a placeholder container component.
- For mobile I would suggest for this iteration to keep the 'View order book' button and hide the upfront container we show on desktop. This means that on desktop we won't show the 'View order book' button and show the order book container instead.
- For a next iteration we can add footer tabs for this like this example (@anxolin):
![image (1)](https://user-images.githubusercontent.com/31534717/91549422-34f9bd80-e927-11ea-810b-19cddcfe6314.png)

