### PR TITLE
Allow to specify an initial list of tokens in the config

### DIFF
--- a/config-default.yaml
+++ b/config-default.yaml
@@ -133,3 +133,137 @@ disabledTokens:
     - address: '0x6Fb0855c404E09c47C3fBCA25f08d4E41f9F062f'
     - address: '0xFC4B8ED459e00e5400be803A9BB3954234FD50e3'
   4: [] # Rinkeby
+
+# Initial Token List
+#   List of token loaded by default
+#   This list is used while the app loads the TCR (if the TCR setting is used)
+initialTokenList:
+  - name: Wrapped Ether
+    symbol: WETH
+    decimals: 18
+    addressByNetwork:
+      '1': '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
+      '4': '0xc778417E063141139Fce010982780140Aa0cD5Ab'
+
+  - id: 2
+    name: Tether USD
+    symbol: USDT
+    decimals: 6
+    addressByNetwork:
+      '1': '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+      '4': '0xa9881E6459CA05d7D7C95374463928369cD7a90C'
+
+  - id: 3
+    name: TrueUSD
+    symbol: TUSD
+    decimals: 18
+    addressByNetwork:
+      '1': '0x0000000000085d4780B73119b644AE5ecd22b376'
+      '4': '0x0000000000085d4780B73119b644AE5ecd22b376'
+
+  - id: 4
+    name: USD Coin
+    symbol: USDC
+    decimals: 6
+    addressByNetwork:
+      '1': '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+      '4': '0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b'
+
+  - id: 5
+    name: Paxos Standard
+    symbol: PAX
+    decimals: 18
+    addressByNetwork:
+      '1': '0x8E870D67F660D95d5be530380D0eC0bd388289E1'
+      '4': '0xBD6A9921504fae42EaD2024F43305A8ED3890F6f'
+
+  - id: 6
+    name: Gemini dollar
+    symbol: GUSD
+    decimals: 2
+    addressByNetwork:
+      '1': '0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd'
+      '4': '0x784B46A4331f5c7C495F296AE700652265ab2fC6'
+
+  - id: 7
+    name: DAI Stablecoin
+    symbol: DAI
+    decimals: 18
+    addressByNetwork:
+      '1': '0x6B175474E89094C44Da98b954EedeAC495271d0F'
+      '4': '0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa'
+
+  - id: 8
+    name: Synth sETH
+    symbol: sETH
+    decimals: 18
+    addressByNetwork:
+      '1': '0x5e74C9036fb86BD7eCdcb084a0673EFc32eA31cb'
+      '4': '0x0647b2c7a2a818276154b0fc79557f512b165bc1'
+
+  - id: 9
+    name: Synth sUSD
+    symbol: sUSD
+    decimals: 18
+    addressByNetwork:
+      '1': '0x57Ab1E02fEE23774580C119740129eAC7081e9D3'
+      '4': '0x1b642a124cdfa1e5835276a6ddaa6cfc4b35d52c'
+
+  - id: 10
+    name: Synth sBTC
+    symbol: sBTC
+    decimals: 18
+    addressByNetwork:
+      '1': '0xfE18be6b3Bd88A2D2A7f928d00292E7a9963CfC6'
+
+  - id: 11
+    name: Wrapped BTC
+    symbol: WBTC
+    decimals: 8
+    addressByNetwork:
+      '1': '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'
+
+  - id: 13
+    name: Compound Dai
+    symbol: cDAI
+    decimals: 8
+    addressByNetwork:
+      '1': '0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643'
+
+  - id: 15
+    name: Synthetix Network
+    symbol: SNX
+    decimals: 18
+    addressByNetwork:
+      '1': '0xC011A72400E58ecD99Ee497CF89E3775d4bd732F'
+      '4': '0x322A3346bf24363f451164d96A5b5cd5A7F4c337'
+
+  - id: 16
+    name: Chai
+    symbol: CHAI
+    decimals: 18
+    addressByNetwork:
+      '1': '0x06AF07097C9Eeb7fD685c692751D5C66dB49c215'
+
+  - id: 18
+    name: Gnosis Token
+    symbol: GNO
+    decimals: 18
+    addressByNetwork:
+      '1': '0x6810e776880C02933D47DB1b9fc05908e5386b96'
+      '4': '0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c'
+
+  - id: 19
+    name: Panvala pan
+    symbol: PAN
+    decimals: 18
+    addressByNetwork:
+      '1': '0xD56daC73A4d6766464b38ec6D91eB45Ce7457c44'
+
+  - id: 0
+    name: OWL
+    symbol: OWL
+    decimals: 18
+    addressByNetwork:
+      '1': '0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4'
+      '4': '0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D'

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -32,8 +32,6 @@ import {
 } from '../../test/data'
 import Web3 from 'web3'
 import { ETH_NODE_URL } from 'const'
-import { tokenList as initialTokenList } from '@gnosis.pm/dex-js'
-
 // TODO connect to mainnet if we need AUTOCONNECT at all
 export const getDefaultProvider = (): string | null => (process.env.NODE_ENV === 'test' ? null : ETH_NODE_URL)
 
@@ -123,7 +121,7 @@ function createTokenListApi(): TokenList {
   if (process.env.MOCK_TOKEN_LIST === 'true') {
     tokenListApi = new TokenListApiMock(tokenList)
   } else {
-    tokenListApi = new TokenListApiImpl({ networkIds, initialTokenList })
+    tokenListApi = new TokenListApiImpl({ networkIds, initialTokenList: CONFIG.initialTokenList })
   }
 
   window['tokenListApi'] = tokenListApi // register for convenience

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -32,6 +32,7 @@ import {
 } from '../../test/data'
 import Web3 from 'web3'
 import { ETH_NODE_URL } from 'const'
+import { tokenList as initialTokenList } from '@gnosis.pm/dex-js'
 
 // TODO connect to mainnet if we need AUTOCONNECT at all
 export const getDefaultProvider = (): string | null => (process.env.NODE_ENV === 'test' ? null : ETH_NODE_URL)
@@ -122,7 +123,7 @@ function createTokenListApi(): TokenList {
   if (process.env.MOCK_TOKEN_LIST === 'true') {
     tokenListApi = new TokenListApiMock(tokenList)
   } else {
-    tokenListApi = new TokenListApiImpl({ networkIds })
+    tokenListApi = new TokenListApiImpl({ networkIds, initialTokenList })
   }
 
   window['tokenListApi'] = tokenListApi // register for convenience

--- a/src/api/tokenList/TokenListApi.ts
+++ b/src/api/tokenList/TokenListApi.ts
@@ -2,6 +2,7 @@ import { TokenDetails } from 'types'
 import { getTokensByNetwork } from './tokenList'
 import { logDebug } from 'utils'
 import GenericSubscriptions, { SubscriptionsInterface } from './Subscriptions'
+import { TokenDetailsConfig } from '@gnosis.pm/dex-js'
 import { DISABLED_TOKEN_MAPS } from 'const'
 
 const addOverrideToDisabledTokens = (networkId: number) => (token: TokenDetails): TokenDetails => {
@@ -29,6 +30,7 @@ export interface TokenList extends SubscriptionsInterface<TokenDetails[]> {
 
 export interface TokenListApiParams {
   networkIds: number[]
+  initialTokenList: TokenDetailsConfig[]
 }
 
 export interface AddTokenParams {
@@ -62,7 +64,7 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
   private _tokensByNetwork: { [networkId: number]: TokenDetails[] }
   private _tokenAddressNetworkSet: Set<string>
 
-  public constructor({ networkIds }: TokenListApiParams) {
+  public constructor({ networkIds, initialTokenList }: TokenListApiParams) {
     super()
 
     // Init the tokens by network
@@ -76,7 +78,7 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
         this.loadTokenList(networkId, 'service'),
         this.loadTokenList(networkId, 'user'),
         // then default list
-        getTokensByNetwork(networkId),
+        getTokensByNetwork(networkId, initialTokenList),
       )
       this._tokensByNetwork[networkId] = TokenListApiImpl.extendTokensInList(
         tokenList,

--- a/src/api/tokenList/tokenList.ts
+++ b/src/api/tokenList/tokenList.ts
@@ -2,9 +2,9 @@ import { TokenDetails, Network } from 'types'
 import { DEFAULT_PRECISION } from 'const'
 
 import { getImageUrl } from 'utils'
-import { tokenList } from '@gnosis.pm/dex-js'
+import { TokenDetailsConfig } from '@gnosis.pm/dex-js'
 
-export function getTokensByNetwork(networkId: number): TokenDetails[] {
+export function getTokensByNetwork(networkId: number, tokenList: TokenDetailsConfig[]): TokenDetails[] {
   // Return token details
   const tokenDetails: TokenDetails[] = tokenList.reduce((acc: TokenDetails[], token) => {
     const address = token.addressByNetwork[networkId]
@@ -22,5 +22,3 @@ export function getTokensByNetwork(networkId: number): TokenDetails[] {
 
   return tokenDetails
 }
-
-export default tokenList

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,6 +3,7 @@ import { MultiTcrApiParams } from 'api/tcr/MultiTcrApi'
 import { DexPriceEstimatorParams } from 'api/dexPriceEstimator/DexPriceEstimatorApi'
 import { ContractDeploymentBlock } from 'api/exchange/ExchangeApi'
 import { Network } from 'types'
+import { TokenDetailsConfig } from '@gnosis.pm/dex-js'
 
 export interface MultiTcrConfig {
   type: 'multi-tcr'
@@ -61,6 +62,7 @@ export interface Config {
   name: string
   logoPath: string
   templatePath: string
+  initialTokenList: TokenDetailsConfig[]
   tcr: MultiTcrConfig | NoTcrConfig
   dexPriceEstimator: DexPriceEstimatorConfig
   theGraphApi: TheGraphApiConfig

--- a/test/api/ExchangeApi/TokenListApiMock.test.ts
+++ b/test/api/ExchangeApi/TokenListApiMock.test.ts
@@ -4,6 +4,7 @@ import TokenListApiMock from 'api/tokenList/TokenListApiMock'
 import { TokenListApiImpl, TokenList } from 'api/tokenList/TokenListApi'
 import { tokenList as testTokenList } from '../../data'
 import SubscriptionBase from 'api/tokenList/Subscriptions'
+import { tokenList as initialTokenList } from '@gnosis.pm/dex-js'
 
 class GenericSubscriptions<T> extends SubscriptionBase<T> {
   // expose triggerSubscriptions for testing
@@ -17,7 +18,7 @@ let instanceReal: TokenList
 
 beforeEach(() => {
   instanceMock = new TokenListApiMock(testTokenList)
-  instanceReal = new TokenListApiImpl({ networkIds: [Network.Mainnet, Network.Rinkeby] })
+  instanceReal = new TokenListApiImpl({ networkIds: [Network.Mainnet, Network.Rinkeby], initialTokenList })
 })
 
 const NEW_TOKEN = {


### PR DESCRIPTION
The app depends on an initial list of tokens in dex-js

This list is used for an initial warm up of the app, when there's no persisted local storage, and the TCR hasn't been loaded.
The list of tokens are the initial thing forks change.

Judging from other projects, they end up being super creative on how to hack this list into the app.
This PR tries to make it easier for them to add a custom list. So:
- adds `initialTokenList` config params, with this list
- Makes `getTokensByNetwork` in tokenList api to not depend on dex-js anymore. It just receives the list by parameter
- Modifies tokenList API to receive the list in the constructor
- Now the initialization of the APIs, load the list from the config, and inject it to the API