### PR TITLE
Allow to change the default initial selection of tokens

### DIFF
--- a/config-default.yaml
+++ b/config-default.yaml
@@ -133,3 +133,8 @@ disabledTokens:
     - address: '0x6Fb0855c404E09c47C3fBCA25f08d4E41f9F062f'
     - address: '0xFC4B8ED459e00e5400be803A9BB3954234FD50e3'
   4: [] # Rinkeby
+
+# Initial token selection for the sell token and buy token
+initialTokenSelection:
+  sellToken: DAI
+  receiveToken: USDC

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,9 +89,21 @@ const Settings = React.lazy(() =>
 import { withGlobalContext } from 'hooks/useGlobalState'
 import { rootReducer, INITIAL_STATE } from 'reducers-actions'
 import PrivateRoute from './PrivateRoute'
+import { assertNonNull } from 'utils'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const Router: typeof BrowserRouter & typeof HashRouter = (window as any).IS_IPFS ? HashRouter : BrowserRouter
+
+function getInitialUrl(): string {
+  // Validate tha
+  assertNonNull(CONFIG.initialTokenSelection, 'initialTokenSelection config is required')
+  const { sellToken: initialSellToken, receiveToken: initialReceiveToken } = CONFIG.initialTokenSelection
+  assertNonNull(initialSellToken, 'sellToken is required in the initialTokenSelection config')
+  assertNonNull(initialReceiveToken, 'receiveToken is required in the initialTokenSelection config')
+  return '/trade/' + initialSellToken + '-' + initialReceiveToken + '?sell=0&price=0'
+}
+
+const initialUrl = getInitialUrl()
 
 // App
 const App: React.FC = () => (
@@ -111,7 +123,7 @@ const App: React.FC = () => (
             <Route path="/connect-wallet" exact component={ConnectWallet} />
             <Route path="/trades" exact component={Trades} />
             <Route path="/settings" exact component={Settings} />
-            <Redirect from="/" to="/trade/DAI-USDC?sell=0&price=0" />
+            <Redirect from="/" to={initialUrl} />
             <Route component={NotFound} />
           </Switch>
         </React.Suspense>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,7 +95,6 @@ import { assertNonNull } from 'utils'
 const Router: typeof BrowserRouter & typeof HashRouter = (window as any).IS_IPFS ? HashRouter : BrowserRouter
 
 function getInitialUrl(): string {
-  // Validate tha
   assertNonNull(CONFIG.initialTokenSelection, 'initialTokenSelection config is required')
   const { sellToken: initialSellToken, receiveToken: initialReceiveToken } = CONFIG.initialTokenSelection
   assertNonNull(initialSellToken, 'sellToken is required in the initialTokenSelection config')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { hot } from 'react-hot-loader/root'
 import React from 'react'
 import { BrowserRouter, HashRouter, Route, Switch, Redirect } from 'react-router-dom'
 import Console from './Console'
+import { encodeSymbol } from '@gnosis.pm/dex-js'
 
 // SCSS
 import GlobalStyles from 'styles/global'
@@ -99,7 +100,7 @@ function getInitialUrl(): string {
   const { sellToken: initialSellToken, receiveToken: initialReceiveToken } = CONFIG.initialTokenSelection
   assertNonNull(initialSellToken, 'sellToken is required in the initialTokenSelection config')
   assertNonNull(initialReceiveToken, 'receiveToken is required in the initialTokenSelection config')
-  return '/trade/' + initialSellToken + '-' + initialReceiveToken + '?sell=0&price=0'
+  return '/trade/' + encodeSymbol(initialSellToken) + '-' + encodeSymbol(initialReceiveToken) + '?sell=0&price=0'
 }
 
 const initialUrl = getInitialUrl()

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -425,6 +425,8 @@ interface TokensAdderProps {
   onTokensAdded: (newTokens: TokenDetails[]) => void
 }
 
+const { sellToken: initialSellToken, receiveToken: initialReceiveToken } = CONFIG.initialTokenSelection
+
 const TokensAdder: React.FC<TokensAdderProps> = ({ tokenAddresses, networkId, onTokensAdded }) => {
   const { addTokensToList, modalProps } = useBetterAddTokenModal({ focused: true })
 
@@ -465,7 +467,7 @@ interface ChooseTokenInput {
   tokens: TokenDetails[]
   token: TokenDetails | null
   tokenSymbolFromUrl?: string
-  defaultTokenSymbol: 'DAI' | 'USDC'
+  defaultTokenSymbol: string
 }
 
 const chooseTokenWithFallback = ({
@@ -561,7 +563,7 @@ const TradeWidget: React.FC = () => {
       token: trade.sellToken,
       tokens,
       tokenSymbolFromUrl: sellTokenSymbol,
-      defaultTokenSymbol: 'DAI',
+      defaultTokenSymbol: initialSellToken,
     }),
   )
   const [receiveToken, setReceiveToken] = useState(() =>
@@ -569,7 +571,7 @@ const TradeWidget: React.FC = () => {
       token: trade.buyToken,
       tokens,
       tokenSymbolFromUrl: receiveTokenSymbol,
-      defaultTokenSymbol: 'USDC',
+      defaultTokenSymbol: initialReceiveToken,
     }),
   )
 
@@ -586,7 +588,7 @@ const TradeWidget: React.FC = () => {
           : null,
         tokens: tokenListApi.getTokens(networkIdOrDefault), // get immediate new tokens
         tokenSymbolFromUrl: sellTokenSymbol, // from url params
-        defaultTokenSymbol: 'DAI', // default sellToken
+        defaultTokenSymbol: initialSellToken, // default sellToken
       })
       setSellToken(sellTokenOrFallback)
     }
@@ -598,7 +600,7 @@ const TradeWidget: React.FC = () => {
           : null,
         tokens: tokenListApi.getTokens(networkIdOrDefault),
         tokenSymbolFromUrl: receiveTokenSymbol,
-        defaultTokenSymbol: 'USDC', // default buyToken
+        defaultTokenSymbol: initialReceiveToken, // default buyToken
       })
       setReceiveToken(buyTokenOrFallback)
     }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -4,6 +4,11 @@ import { DexPriceEstimatorParams } from 'api/dexPriceEstimator/DexPriceEstimator
 import { ContractDeploymentBlock } from 'api/exchange/ExchangeApi'
 import { Network } from 'types'
 
+export interface TokenSelection {
+  sellToken: string
+  receiveToken: string
+}
+
 export interface MultiTcrConfig {
   type: 'multi-tcr'
   config: Omit<MultiTcrApiParams, 'web3'>
@@ -61,6 +66,7 @@ export interface Config {
   name: string
   logoPath: string
   templatePath: string
+  initialTokenSelection: TokenSelection
   tcr: MultiTcrConfig | NoTcrConfig
   dexPriceEstimator: DexPriceEstimatorConfig
   theGraphApi: TheGraphApiConfig


### PR DESCRIPTION
Brother PR of #1357, same motivation:

> The app depends on an initial list of tokens in dex-js
> This list is used for an initial warm up of the app, when there's no persisted local storage, and the TCR hasn't been loaded.
> The list of tokens are the initial thing forks change.

In this PR it's been added a new `initialTokenSelection` that allows you to set the default selection in the trade page. By default, we select DAI and USDC as the initial selection for sell token, and receive token.

One fork could, thanks to #1357 change the initial list, and then with this one, could change the initial selection (choosing 2 tokens from his custom list).