### PR TITLE
fix error label if edge-case where tokens are the same

### DIFF
--- a/src/components/Layout/PageWrapper.tsx
+++ b/src/components/Layout/PageWrapper.tsx
@@ -62,7 +62,7 @@ export const StandaloneCardWrapper = styled.div`
   }
 `
 export const PageWrapper = styled.section`
-  height: 71rem;
+  height: 73rem;
   min-width: 85rem;
   max-width: 100%;
 

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -209,14 +209,13 @@ const IconWrapper = styled.a`
   }
 `
 
-const WarningLabel = styled.code`
-  background: var(--color-error);
-  border-radius: var(--border-radius);
-  font-weight: bolder;
-  margin: 0 auto 0.9375rem;
-  padding: 6;
-  text-align: center;
-  width: 75%;
+const WarningLabel = styled(FormMessage)`
+  &&&&& {
+    color: ghostwhite;
+    background: var(--color-button-danger);
+    justify-content: center;
+    font-weight: bolder;
+  }
 `
 
 const SubmitButton = styled.button`
@@ -963,7 +962,12 @@ const TradeWidget: React.FC = () => {
       {/* Toggle Class 'expanded' on WrappedWidget on click of the <ExpandableOrdersPanel> <button> */}
       <FormContext {...methods}>
         <WrappedForm onSubmit={onConfirm} autoComplete="off" noValidate>
-          {sameToken && <WarningLabel>Tokens cannot be the same!</WarningLabel>}
+          {sameToken && (
+            <>
+              <WarningLabel className="warning">Tokens cannot be the same! </WarningLabel>
+              <br />
+            </>
+          )}
           <TokenRow
             autoFocus
             selectedToken={sellToken}
@@ -1033,7 +1037,7 @@ const TradeWidget: React.FC = () => {
             <SubmitButton
               data-text="This order might be partially filled."
               type="submit"
-              disabled={isSubmitting}
+              disabled={isSubmitting || sameToken}
               tabIndex={1}
               onClick={(e): void => {
                 // don't show Submit Confirm modal for invalid form
@@ -1041,7 +1045,7 @@ const TradeWidget: React.FC = () => {
               }}
             >
               {isSubmitting && <Spinner size="lg" spin={isSubmitting} />}{' '}
-              {sameToken ? 'Please select different tokens' : 'Submit limit order'}
+              {sameToken ? 'Select different tokens' : 'Submit limit order'}
             </SubmitButton>
           </ButtonWrapper>
         </WrappedForm>


### PR DESCRIPTION
We have this weird edge case where if the user puts in an unknown token address/name or whatever the URL grabbing code defaults to market DAI/USDC - this allows users to potentially have the same market e.g DAI/DAI or USDC/USDC and we have an error code to deal

error message looked awful, fixes that

this is more of a pave over of a bigger problem but it looks better at least and users are blocked from doing anything until they change to a compatible token pair

![Screenshot from 2020-09-01 17-11-08](https://user-images.githubusercontent.com/21335563/91869713-7fa46e00-ec76-11ea-87a8-d31a2ba341dc.png)
