### PR TITLE
Fix warning when priceEsimaion = 0

### DIFF
--- a/src/components/TradeWidget/TxMessage.tsx
+++ b/src/components/TradeWidget/TxMessage.tsx
@@ -158,6 +158,13 @@ const useLowVolumeAmount = ({ sellToken, sellTokenAmount, networkId }: LowVolume
   const gasPrice = useGasPrice({ defaultGasPrice: DEFAULT_GAS_PRICE, gasPriceLevel: 'fast' })
 
   return useMemo(() => {
+    if (priceEstimation !== null && priceEstimation.isZero()) {
+      // no price data for token
+      logDebug('No priceEstimation data for', sellToken.symbol, 'in OWL')
+
+      return { isLoading: false, isLowVolume: false }
+    }
+
     if (
       isPriceLoading ||
       isWETHPriceLoading ||


### PR DESCRIPTION
An edge case when `priceEstimation = 0 --> minTradableAmount  = Infinity` for a token, happens when that token has not been traded yet. 

![localhost_8080_trade_DAI-SUSHI_sell=3 price=2 12896 from= expires=](https://user-images.githubusercontent.com/5121491/91942659-f76caa00-ed03-11ea-9d95-8d9fc9c080d3.png)