### PR TITLE
Fix CONFIG.initialTokenList

### DIFF
--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.json"
+}

--- a/config-default.yaml
+++ b/config-default.yaml
@@ -143,7 +143,8 @@ initialTokenSelection:
 #   List of token loaded by default
 #   This list is used while the app loads the TCR (if the TCR setting is used)
 initialTokenList:
-  - name: Wrapped Ether
+  - id: 1
+    name: Wrapped Ether
     symbol: WETH
     decimals: 18
     addressByNetwork:

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -121,4 +121,27 @@ describe('Test config defaults', () => {
     if (disabledOnMainnet.length) expect(disabledOnMainnet).toEqual(disabledTokensArray)
     if (disabledOnRinkeby.length) expect(disabledOnRinkeby).toEqual(disabledTokensArray)
   })
+
+  it('initialTokenSelection', () => {
+    expect(CONFIG.initialTokenSelection).toEqual(
+      expect.objectContaining({
+        sellToken: expect.any(String),
+        receiveToken: expect.any(String),
+      }),
+    )
+  })
+
+  it('initialTokenList', () => {
+    CONFIG.initialTokenList.map((token) =>
+      expect(token).toEqual(
+        expect.objectContaining({
+          id: expect.any(Number),
+          name: expect.any(String),
+          symbol: expect.any(String),
+          decimals: expect.any(Number),
+          addressByNetwork: expect.any(Object),
+        }),
+      ),
+    )
+  })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,5 @@
     "paths": {
       "*": ["custom/*", "src/*"]
     }
-  },
-  "include": ["src/**/*", ".storybook/**/*"]
+  }
 }


### PR DESCRIPTION
- Fixed `CONFIG.initialTokenList`
- Added tests
- 
- Added a separate `tsconfig` for `./.storybook` because putting `includes: [**]` into main `tsconfig` would require explicit mention of all folders to traverse. For example `tests`. Without `includes` all required folders were already included, but not `.storybook`. As I understand by default all folders in the rootdir are included bit not those that start with `.` Better to have one-for-all `tsconfig` at root, and one for the specific case of `.storybook`