### PR TITLE
Allow to connect from non-localhost

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "node": "12"
   },
   "scripts": {
-    "start": "NODE_ENV=development webpack-dev-server --mode development --hot",
-    "start:browserstack": "yarn start --host 0.0.0.0 --disable-host-check",
+    "start": "NODE_ENV=development webpack-dev-server --mode development --hot --host 0.0.0.0 --disable-host-check",
     "mock": "MOCK=true yarn start",
     "build": "rimraf ./dist && NODE_ENV=production webpack --mode production",
     "lint": "eslint src --ext .ts,.tsx,.js",


### PR DESCRIPTION
Simplifies the `package.json` so we don't have a script just for browserstack.
Also this way we can access the dev server from localhost or from our local network. This is convenient for access from our mobile using WIFI

Additionally, makes it coherent with storybook, which we already allowed:
![image](https://user-images.githubusercontent.com/2352112/92499827-9e69ae00-f1fc-11ea-8cd8-6e7dda2d27c0.png)

