### PR TITLE
DexPriceEstimator["getBestAsk"] + useBestAsk() hook

### DIFF
--- a/src/api/dexPriceEstimator/DexPriceEstimatorApi.ts
+++ b/src/api/dexPriceEstimator/DexPriceEstimatorApi.ts
@@ -131,7 +131,7 @@ export class DexPriceEstimatorApiImpl implements DexPriceEstimatorApi {
     } = params
 
     // Query format: markets/7-1/estimated-best-ask-price?unit=baseunits&roundingBuffer=enabled
-    const queryString = `markets/${baseTokenId}-${quoteTokenId}/estimated-best-ask-price?unit=baseunits&roundingBuffer=enabled`
+    const queryString = `markets/${baseTokenId}-${quoteTokenId}/estimated-best-ask-price`
 
     try {
       const response = await this.query<number>(networkId, queryString)

--- a/src/api/dexPriceEstimator/DexPriceEstimatorApi.ts
+++ b/src/api/dexPriceEstimator/DexPriceEstimatorApi.ts
@@ -4,6 +4,7 @@ import { ORDER_BOOK_HOPS_DEFAULT, ORDER_BOOK_HOPS_MAX } from 'const'
 
 export interface DexPriceEstimatorApi {
   getPrice(params: GetPriceParams): Promise<BigNumber | null>
+  getBestAsk(params: GetBestAskParams): Promise<BigNumber | null>
   getOrderBookUrl(params: OrderBookParams): string
   getOrderBookData(params: OrderBookParams): Promise<OrderBookData>
 }
@@ -15,6 +16,8 @@ interface GetPriceParams {
   amountInUnits?: BigNumber | string
   inWei?: boolean
 }
+
+type GetBestAskParams = Omit<GetPriceParams, 'amountInUnits' | 'inWei'>
 
 interface OrderBookParams {
   networkId: number
@@ -116,6 +119,32 @@ export class DexPriceEstimatorApiImpl implements DexPriceEstimatorApi {
       console.error(e)
       throw new Error(
         `Failed to query price for baseToken id ${baseTokenId} quoteToken id ${quoteTokenId}: ${e.message}`,
+      )
+    }
+  }
+
+  public async getBestAsk(params: GetBestAskParams): Promise<BigNumber | null> {
+    const {
+      networkId,
+      baseToken: { id: baseTokenId },
+      quoteToken: { id: quoteTokenId },
+    } = params
+
+    // Query format: markets/7-1/estimated-best-ask-price?unit=baseunits&roundingBuffer=enabled
+    const queryString = `markets/${baseTokenId}-${quoteTokenId}/estimated-best-ask-price?unit=baseunits&roundingBuffer=enabled`
+
+    try {
+      const response = await this.query<number>(networkId, queryString)
+
+      if (response === null) {
+        return response
+      }
+
+      return new BigNumber(response)
+    } catch (e) {
+      console.error(e)
+      throw new Error(
+        `Failed to query best ask for baseToken id ${baseTokenId} quoteToken id ${quoteTokenId}: ${e.message}`,
       )
     }
   }

--- a/src/api/dexPriceEstimator/DexPriceEstimatorApiProxy.ts
+++ b/src/api/dexPriceEstimator/DexPriceEstimatorApiProxy.ts
@@ -10,6 +10,9 @@ export class DexPriceEstimatorApiProxy extends DexPriceEstimatorApiImpl {
 
     this.cache = new CacheMixin()
 
-    this.cache.injectCache<DexPriceEstimatorApi>(this, [{ method: 'getPrice', ttl: PRICES_CACHE_TIME }])
+    this.cache.injectCache<DexPriceEstimatorApi>(this, [
+      { method: 'getPrice', ttl: PRICES_CACHE_TIME },
+      { method: 'getBestAsk', ttl: PRICES_CACHE_TIME },
+    ])
   }
 }

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -270,7 +270,6 @@ const TradeWidget: React.FC = () => {
         tokenSymbolFromUrl: sellTokenSymbol, // from url params
         defaultTokenSymbol: initialSellToken, // default sellToken
       })
-      console.debug('SELL TOKEN::', sellTokenOrFallback)
       setSellToken(sellTokenOrFallback)
     }
 

--- a/src/components/trade/LimitOrder/LimitOrder.tsx
+++ b/src/components/trade/LimitOrder/LimitOrder.tsx
@@ -98,6 +98,7 @@ export const LimitOrder: React.FC<Props> = (props: Props) => {
               // Market
               baseToken={receiveToken}
               quoteToken={sellToken}
+              sellToken={sellToken}
               isPriceInverted={isPriceInverted}
               wasPriorityAdjusted={false}
               // Amount

--- a/src/components/trade/PriceSuggestions/PriceSuggestions.stories.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestions.stories.tsx
@@ -17,6 +17,7 @@ export default {
 const defaultProps = {
   baseToken: GNO,
   quoteToken: DAI,
+  sellToken: DAI,
   fillPrice: new BigNumber('55.13245672'),
   fillPriceLoading: false,
   bestAskPrice: new BigNumber('51.153236'),

--- a/src/hooks/useBestAsk.tsx
+++ b/src/hooks/useBestAsk.tsx
@@ -1,0 +1,60 @@
+import { useEffect } from 'react'
+import BigNumber from 'bignumber.js'
+import useSafeState from './useSafeState'
+import { dexPriceEstimatorApi } from 'api'
+
+interface BestAskParams {
+  networkId: number
+  baseTokenId: number
+  quoteTokenId: number
+}
+
+interface HookReturn {
+  bestAskPrice: BigNumber | null
+  bestAskPriceLoading: boolean
+}
+
+function useBestAsk(params: BestAskParams): HookReturn {
+  const [bestAskPrice, setBestAskPrice] = useSafeState<BigNumber | null>(null)
+  const [bestAskPriceLoading, setBestAskPriceLoading] = useSafeState<boolean>(false)
+  const { networkId, baseTokenId, quoteTokenId } = params
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function estimateBestAsk(): Promise<void> {
+      setBestAskPriceLoading(true)
+
+      try {
+        const getBestAskParams = {
+          networkId,
+          baseToken: { id: baseTokenId },
+          quoteToken: { id: quoteTokenId },
+        }
+
+        const bestAsk = await dexPriceEstimatorApi.getBestAsk(getBestAskParams)
+
+        if (!cancelled) {
+          setBestAskPrice(bestAsk)
+        }
+      } catch (e) {
+        console.error(`[useBestAsk] Error getting bestAsk price for tokens ${baseTokenId} and ${quoteTokenId}`, e)
+      } finally {
+        setBestAskPriceLoading(false)
+      }
+    }
+
+    estimateBestAsk()
+
+    return (): void => {
+      cancelled = true
+    }
+  }, [baseTokenId, networkId, quoteTokenId, setBestAskPrice, setBestAskPriceLoading])
+
+  return {
+    bestAskPrice,
+    bestAskPriceLoading,
+  }
+}
+
+export default useBestAsk

--- a/src/hooks/useBestAsk.tsx
+++ b/src/hooks/useBestAsk.tsx
@@ -11,12 +11,12 @@ interface BestAskParams {
 
 interface HookReturn {
   bestAskPrice: BigNumber | null
-  bestAskPriceLoading: boolean
+  isBestAskLoading: boolean
 }
 
 function useBestAsk(params: BestAskParams): HookReturn {
   const [bestAskPrice, setBestAskPrice] = useSafeState<BigNumber | null>(null)
-  const [bestAskPriceLoading, setBestAskPriceLoading] = useSafeState<boolean>(false)
+  const [isBestAskLoading, setBestAskPriceLoading] = useSafeState<boolean>(false)
   const { networkId, baseTokenId, quoteTokenId } = params
 
   useEffect(() => {
@@ -53,7 +53,7 @@ function useBestAsk(params: BestAskParams): HookReturn {
 
   return {
     bestAskPrice,
-    bestAskPriceLoading,
+    isBestAskLoading,
   }
 }
 

--- a/src/hooks/useTokenList.ts
+++ b/src/hooks/useTokenList.ts
@@ -38,7 +38,6 @@ export function mapPrioritiesToTokenList({
 }): TokenDetails[] {
   if (!networkId) return tokenList
   const stablecoinMap = getNetworkCorrectStableCoinList(networkId, quoteTokenPrioritiesList)
-  console.debug('stablecoinMap', stablecoinMap)
   // no networkId or map is empty as network id returns no tokens
   if (!stablecoinMap?.size) return tokenList
 


### PR DESCRIPTION
Waterfalls into #1273 

Adds `getBestAsk` to `DexPriceEstimatorAPI` and cache

Adds `useBestAsk` hook similar to `usePriceEstimation` hook

API: `getBestAsk` URL looks like: `https://price-estimate-mainnet.dev.gnosisdev.com/api/v1/markets/1-7/estimated-best-ask-price?unit=baseunits&roundingBuffer=enabled`

With `?unit=baseunits&roundingBuffer=enabled` appended to end - any issues there?

Testing (in chrome console on localhost Mesa):
```js
(await dexPriceEstimatorApi.getBestAsk({ networkId: 1, baseToken: { id: 1 }, quoteToken: { id: 7 }})).toString()
```

Have to `invert` bestAsk BigNumber via `invertPrice` as:

estimatePrice endpoint returns:
![Screenshot from 2020-09-11 12-57-57](https://user-images.githubusercontent.com/21335563/92917661-fc7dd780-f42e-11ea-85c5-43eda6e1015b.png)
==> **`0.0026...`**

while `bestAsk` enpoint returns:
![Screenshot from 2020-09-11 13-03-16](https://user-images.githubusercontent.com/21335563/92917887-2e8f3980-f42f-11ea-88a2-a2bb803f25ff.png)
==> **`358.29317033862816`**

