### PR TITLE
Stories for layouts

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,0 @@
-
-export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
-}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,18 +1,4 @@
 
-import React from 'react'
-import GlobalStyles from 'styles/global'
-import { BaseDecorators } from '@storybook/addons'
-
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
 }
-
-export const decorators: BaseDecorators<JSX.Element> = [
-  (Story) => (
-    <>
-      <GlobalStyles />
-      {/* TODO: change to <Story/> when https://github.com/storybookjs/storybook/issues/12255 is fixed */}
-      {Story()}
-    </>
-  ),
-];

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "node": "12"
   },
   "scripts": {
-    "start": "NODE_ENV=development webpack-dev-server --mode development --hot",
-    "start:browserstack": "yarn start --host 0.0.0.0 --disable-host-check",
+    "start": "NODE_ENV=development webpack-dev-server --mode development --hot --host 0.0.0.0 --disable-host-check",
     "mock": "MOCK=true yarn start",
     "build": "rimraf ./dist && NODE_ENV=production webpack --mode production",
     "lint": "eslint src --ext .ts,.tsx,.js",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { BrowserRouter, HashRouter, Route, Switch, Redirect } from 'react-router-dom'
 import Console from './Console'
 import { encodeSymbol } from '@gnosis.pm/dex-js'
+import GlobalStyles from 'styles/global'
 
 // Main layout
 import { SwapLayout, TradingLayout } from 'components/layout'
@@ -124,7 +125,7 @@ const App: React.FC = () => (
           <TradingLayout>
             <React.Suspense fallback={null}>
               <Switch>
-                <Route path="" exact component={Trading} />
+                <Route path="/v2" exact component={Trading} />
                 <Route component={NotFound2} />
               </Switch>
             </React.Suspense>
@@ -132,6 +133,7 @@ const App: React.FC = () => (
         </Route>
         <Route>
           <SwapLayout>
+            <GlobalStyles />
             <React.Suspense fallback={null}>
               <Switch>
                 <PrivateRoute path="/orders" exact component={Orders} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,9 +6,6 @@ import { BrowserRouter, HashRouter, Route, Switch, Redirect } from 'react-router
 import Console from './Console'
 import { encodeSymbol } from '@gnosis.pm/dex-js'
 
-// SCSS
-import GlobalStyles from 'styles/global'
-
 // Main layout
 import { SwapLayout, TradingLayout } from 'components/layout'
 
@@ -135,7 +132,6 @@ const App: React.FC = () => (
         </Route>
         <Route>
           <SwapLayout>
-            <GlobalStyles />
             <React.Suspense fallback={null}>
               <Switch>
                 <PrivateRoute path="/orders" exact component={Orders} />

--- a/src/api/dexPriceEstimator/DexPriceEstimatorApi.ts
+++ b/src/api/dexPriceEstimator/DexPriceEstimatorApi.ts
@@ -6,6 +6,8 @@ export interface DexPriceEstimatorApi {
   getPrice(params: GetPriceParams): Promise<BigNumber | null>
   getOrderBookUrl(params: OrderBookParams): string
   getOrderBookData(params: OrderBookParams): Promise<OrderBookData>
+  getMinOrderAmounInOWLUrl(networkId: number): string
+  getMinOrderAmounInOWL(networkId: number): Promise<BigNumber>
 }
 
 interface GetPriceParams {
@@ -73,6 +75,9 @@ export type DexPriceEstimatorParams = PriceEstimatorEndpoint[]
 function getDexPriceEstimatorUrl(baseUlr: string): string {
   return `${baseUlr}${baseUlr.endsWith('/') ? '' : '/'}api/v1/`
 }
+
+// when price-estimation service doesn't return anything
+export const DEFAULT_MIN_AMOUNT_IN_OWL_ATOMS = new BigNumber(2500)
 
 export class DexPriceEstimatorApiImpl implements DexPriceEstimatorApi {
   private urlsByNetwork: { [networkId: number]: string } = {}
@@ -153,6 +158,26 @@ export class DexPriceEstimatorApiImpl implements DexPriceEstimatorApi {
       throw new Error(
         `Failed to query orderbook data for baseToken id ${baseTokenId} quoteToken id ${quoteTokenId}: ${error.message}`,
       )
+    }
+  }
+
+  public getMinOrderAmounInOWLUrl(networkId: number): string {
+    const baseUrl = this._getBaseUrl(networkId)
+    return `${baseUrl}minimum-order-size-owl`
+  }
+
+  public async getMinOrderAmounInOWL(networkId: number): Promise<BigNumber> {
+    try {
+      const url = this.getMinOrderAmounInOWLUrl(networkId)
+      const res = await fetch(url)
+      // not res.json() because backend returns "8738236863863283268688" big number of OWL in atoms
+      const minAmount = await res.text()
+
+      return new BigNumber(minAmount).div(1e18)
+    } catch (error) {
+      console.error(error)
+
+      return DEFAULT_MIN_AMOUNT_IN_OWL_ATOMS
     }
   }
 

--- a/src/api/dexPriceEstimator/DexPriceEstimatorApiProxy.ts
+++ b/src/api/dexPriceEstimator/DexPriceEstimatorApiProxy.ts
@@ -10,6 +10,9 @@ export class DexPriceEstimatorApiProxy extends DexPriceEstimatorApiImpl {
 
     this.cache = new CacheMixin()
 
-    this.cache.injectCache<DexPriceEstimatorApi>(this, [{ method: 'getPrice', ttl: PRICES_CACHE_TIME }])
+    this.cache.injectCache<DexPriceEstimatorApi>(this, [
+      { method: 'getPrice', ttl: PRICES_CACHE_TIME },
+      { method: 'getMinOrderAmounInOWL', ttl: PRICES_CACHE_TIME },
+    ])
   }
 }

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -50,7 +50,7 @@ import {
 import TokensAdder from './TokenAdder'
 import TokenRow from 'components/TradeWidget/TokenRow'
 import OrderValidity from 'components/TradeWidget/OrderValidity'
-import { PriceSuggestionsComp as PriceSuggestions } from 'components/trade/PriceSuggestions'
+import { PriceSuggestionWidget as PriceSuggestions } from 'components/trade/PriceSuggestions'
 import Price, { invertPriceFromString } from 'components/trade/Price'
 
 // hooks

--- a/src/components/common/EllipsisText.stories.tsx
+++ b/src/components/common/EllipsisText.stories.tsx
@@ -6,6 +6,7 @@ import { EllipsisText, Props } from 'components/common/EllipsisText'
 
 export default {
   title: 'Common/EllipsisText',
+  component: EllipsisText,
 } as Meta
 
 const Template: Story<Props> = (args) => (

--- a/src/components/common/Frame.tsx
+++ b/src/components/common/Frame.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties } from 'react'
 
 const CSS_DEFAULT: CSSProperties = {
   margin: '2rem auto',
-  border: '2px dashed gray',
+  outline: '2px dashed gray',
   padding: '1.5rem',
 }
 

--- a/src/components/common/SwapPrice.stories.tsx
+++ b/src/components/common/SwapPrice.stories.tsx
@@ -1,20 +1,33 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
 import { Meta, Story } from '@storybook/react/types-6-0'
 import { SwapPrice, Props } from './SwapPrice'
 import { GNO, DAI } from 'storybook/tokens'
+import { CenteredAndFramed } from 'storybook/decorators'
 
 export default {
   title: 'Common/SwapPrice',
   component: SwapPrice,
+  decorators: [CenteredAndFramed],
 } as Meta
 
-const Template: Story<Props> = (props) => <SwapPrice {...props} />
+const Template: Story<Partial<Props>> = (props) => {
+  const [isPriceInverted, setIsPriceInverted] = useState(false)
+
+  return (
+    <SwapPrice
+      baseToken={GNO}
+      quoteToken={DAI}
+      isPriceInverted={isPriceInverted}
+      onSwapPrices={(): void => {
+        console.log('[LimitOrder.story] Swap Prices')
+        setIsPriceInverted((inverted) => !inverted)
+      }}
+      {...props}
+    />
+  )
+}
 
 export const Basic = Template.bind({})
-Basic.args = {
-  baseToken: GNO,
-  quoteToken: DAI,
-  isPriceInverted: true,
-}
+Basic.args = {} as Props

--- a/src/components/common/SwapPrice.tsx
+++ b/src/components/common/SwapPrice.tsx
@@ -7,16 +7,17 @@ import { SwapIcon } from 'components/TradeWidget/SwapIcon'
 import { safeTokenName, TokenDetails } from '@gnosis.pm/dex-js'
 
 const SwapPriceWrapper = styled.div`
+  display: inline-block;
   cursor: pointer;
-  div.separator {
-    margin: 0 0.4rem;
+
+  ${EllipsisText} {
+    display: inline-block;
   }
 `
 export interface Props {
   baseToken: TokenDetails
   quoteToken: TokenDetails
   isPriceInverted: boolean
-  separator?: SVGAnimatedString
   onSwapPrices: () => void
 }
 

--- a/src/components/layout/SwapLayout/SwapLayout.stories.tsx
+++ b/src/components/layout/SwapLayout/SwapLayout.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Meta } from '@storybook/react/types-6-0'
+
+import { SwapLayout } from 'components/layout'
+import { RouterDecorator } from 'storybook/RouterDecorator'
+import { LoremIpsum } from 'storybook/LoremIpsum'
+
+export default {
+  title: 'Layout/SwapLayout',
+  component: SwapLayout,
+  decorators: [RouterDecorator],
+} as Meta
+
+export const Normal: React.FC = () => (
+  <SwapLayout>
+    <LoremIpsum />
+  </SwapLayout>
+)
+
+export const ShortPage: React.FC = () => <SwapLayout>This is a really short page...</SwapLayout>

--- a/src/components/layout/SwapLayout/index.tsx
+++ b/src/components/layout/SwapLayout/index.tsx
@@ -11,6 +11,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Header from 'components/layout/SwapLayout/Header'
 import Footer from 'components/layout/SwapLayout/Footer'
 import LegalBanner from 'components/LegalBanner'
+import GlobalStyles from 'styles/global'
 
 const Wrapper = styled.div`
   width: 100%;
@@ -74,17 +75,20 @@ const navigation = [
 ]
 
 export const SwapLayout: React.FC = ({ children }) => (
-  <Wrapper>
-    <LegalBanner>
-      <p>
-        <FontAwesomeIcon icon={faSkull} style={{ marginRight: '0.3rem' }} /> This project is in beta. Use at your own
-        risk.
-      </p>
-    </LegalBanner>
-    <Header navigation={navigation} />
-    <main>{children}</main>
-    <Footer />
-  </Wrapper>
+  <>
+    <GlobalStyles />
+    <Wrapper>
+      <LegalBanner>
+        <p>
+          <FontAwesomeIcon icon={faSkull} style={{ marginRight: '0.3rem' }} /> This project is in beta. Use at your own
+          risk.
+        </p>
+      </LegalBanner>
+      <Header navigation={navigation} />
+      <main>{children}</main>
+      <Footer />
+    </Wrapper>
+  </>
 )
 
 export default SwapLayout

--- a/src/components/layout/TradingLayout/TradingLayout.stories.tsx
+++ b/src/components/layout/TradingLayout/TradingLayout.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Meta } from '@storybook/react/types-6-0'
+
+import { TradingLayout } from 'components/layout'
+import { RouterDecorator } from 'storybook/RouterDecorator'
+import { LoremIpsum } from 'storybook/LoremIpsum'
+
+export default {
+  title: 'Layout/TradingLayout',
+  component: TradingLayout,
+  decorators: [RouterDecorator],
+} as Meta
+
+export const Normal: React.FC = () => (
+  <TradingLayout>
+    <LoremIpsum />
+  </TradingLayout>
+)
+
+export const ShortPage: React.FC = () => <TradingLayout>This is a really short page...</TradingLayout>

--- a/src/components/trade/Price.stories.tsx
+++ b/src/components/trade/Price.stories.tsx
@@ -9,7 +9,6 @@ import { GNO, DAI } from 'storybook/tokens'
 
 export default {
   title: 'Trade/Price',
-  component: Price,
 } as Meta
 
 const Template: Story<Props> = (props) => {

--- a/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
@@ -56,7 +56,7 @@ function getPriceFormatted(price: BigNumber | null, isPriceInverted: boolean): F
   }
 }
 
-export const PriceSuggestion: React.FC<Props> = (props) => {
+export const PriceSuggestionItem: React.FC<Props> = (props) => {
   const { label, isPriceInverted, price, loading, amount, baseToken, quoteToken, onSwapPrices, onClickPrice } = props
 
   const { priceFormatted, invertedPriceFormatted } = getPriceFormatted(price, isPriceInverted)

--- a/src/components/trade/PriceSuggestions/PriceSuggestionWidget.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestionWidget.tsx
@@ -13,7 +13,7 @@ interface Props
   priceInverseInputId: string
 }
 
-export const PriceSuggestionsComp: React.FC<Props> = (props) => {
+export const PriceSuggestionWidget: React.FC<Props> = (props) => {
   const {
     networkId,
     amount,

--- a/src/components/trade/PriceSuggestions/PriceSuggestions.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestions.tsx
@@ -7,7 +7,7 @@ import { MEDIA } from 'const'
 import { HelpTooltip, HelpTooltipContainer } from 'components/Tooltip'
 import { SwapPrice } from 'components/common/SwapPrice'
 import { EllipsisText } from 'components/common/EllipsisText'
-import { PriceSuggestion } from 'components/trade/PriceSuggestions/PriceSuggestion'
+import { PriceSuggestionItem } from 'components/trade/PriceSuggestions/PriceSuggestionItem'
 import BigNumber from 'bignumber.js'
 
 const Wrapper = styled.div`
@@ -169,9 +169,9 @@ export const PriceSuggestions: React.FC<Props> = (props) => {
         />
       </div>
       <div className="container">
-        <PriceSuggestion label="Best ask" price={bestAskPrice} loading={bestAskPriceLoading} {...commonProps} />
+        <PriceSuggestionItem label="Best ask" price={bestAskPrice} loading={bestAskPriceLoading} {...commonProps} />
         {amount && +amount != 0 && +amount != 1 && (
-          <PriceSuggestion
+          <PriceSuggestionItem
             label="Fill price"
             amount={amount}
             price={fillPrice}

--- a/src/components/trade/PriceSuggestions/index.tsx
+++ b/src/components/trade/PriceSuggestions/index.tsx
@@ -1,2 +1,2 @@
 export { PriceSuggestions } from './PriceSuggestions'
-export { PriceSuggestionsComp } from './PriceSuggestionComp'
+export { PriceSuggestionWidget } from './PriceSuggestionWidget'

--- a/src/hooks/useMinTradableAmountInOwl.ts
+++ b/src/hooks/useMinTradableAmountInOwl.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+import useSafeState from './useSafeState'
+import { dexPriceEstimatorApi } from 'api'
+import BigNumber from 'bignumber.js'
+
+export function useMinTradableAmountInOwl(networkId: number): null | BigNumber {
+  const [minAmount, setMinAmount] = useSafeState<null | BigNumber>(null)
+
+  useEffect(() => {
+    dexPriceEstimatorApi.getMinOrderAmounInOWL(networkId).then(setMinAmount)
+  }, [networkId, setMinAmount])
+
+  return minAmount
+}

--- a/src/storybook/LoremIpsum.tsx
+++ b/src/storybook/LoremIpsum.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+
+export const LoremIpsum: React.FC = () => (
+  <div>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. In eu lacus ut mi maximus feugiat sit amet in arcu.
+      Mauris sit amet massa nisl. Aliquam et elit sollicitudin, auctor sem eu, posuere est. Cras commodo massa vel porta
+      bibendum. Sed egestas tellus lacus, non luctus nisi placerat non. Donec et pulvinar dolor, at posuere risus. Morbi
+      sed urna metus. Nullam tempus egestas ex, vitae accumsan massa bibendum non. Donec eget commodo nunc, ac congue
+      neque. Cras a nulla fermentum, tempor nisi sed, semper nisl.
+    </p>
+    <p>
+      Ut sollicitudin erat odio, tempus tempor lacus mollis et. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      Vivamus consequat quis felis id malesuada. Proin tincidunt turpis efficitur aliquam mattis. Cras quis faucibus
+      nisi, nec lobortis nibh. Integer in facilisis lacus, id mattis ligula. Mauris efficitur magna ut orci facilisis
+      ullamcorper.
+    </p>
+    <p>
+      Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Mauris euismod nisl eu
+      risus euismod mollis. Nunc eget facilisis nisl. Nullam bibendum enim urna, quis cursus nulla bibendum vitae. Etiam
+      aliquet accumsan lacus, vitae auctor nisl finibus at. Phasellus iaculis dui id lorem viverra, et pulvinar elit
+      aliquet. Sed libero lorem, tristique vitae rhoncus eget, pretium nec nisl. Nam erat eros, volutpat et rutrum in,
+      feugiat a ipsum. Morbi suscipit interdum odio a dictum. Vestibulum et lacinia nisi. Fusce gravida purus sed odio
+      pretium commodo. Nullam quis lectus id turpis pharetra porttitor sit amet eu lacus. Integer non erat maximus,
+      dignissim odio sagittis, sagittis nibh. Vestibulum mattis, quam a auctor commodo, ante magna convallis orci, quis
+      varius purus arcu at libero. Cras molestie enim a mollis faucibus. Sed condimentum ligula ut commodo eleifend.
+    </p>
+    <p>
+      In at ipsum orci. Etiam ornare metus pharetra ex aliquam, vel vehicula felis ultricies. Nulla vulputate et diam
+      vel blandit. Morbi hendrerit tempus facilisis. Ut tempor sit amet odio vitae euismod. Maecenas porttitor nunc non
+      sapien commodo varius. Cras suscipit orci sed libero dapibus, gravida molestie ipsum ornare. Cras semper et turpis
+      at congue. Proin volutpat justo nec ex vulputate vehicula. Aliquam et enim euismod, lacinia metus et, mollis arcu.
+      Nulla a aliquam nibh. Sed dapibus sapien nunc, nec condimentum enim dictum sit amet. Class aptent taciti sociosqu
+      ad litora torquent per conubia nostra, per inceptos himenaeos. Mauris quis mi convallis, volutpat nisl quis,
+      congue leo. Fusce blandit sapien a imperdiet commodo. Nulla eget auctor ex.
+    </p>
+    <p>
+      Donec facilisis elit arcu, ut scelerisque velit pretium sed. Integer placerat, nisi sit amet ultrices
+      sollicitudin, magna lacus volutpat augue, ut placerat lacus nibh auctor nisi. Phasellus viverra dignissim erat,
+      tincidunt luctus dolor placerat auctor. Sed ornare sapien vel suscipit sagittis. Pellentesque tempor eleifend
+      enim, condimentum semper lectus semper vel. Etiam urna metus, convallis nec lorem at, rutrum vestibulum sem. Cras
+      scelerisque leo sed elit sodales sodales. Pellentesque orci ante, sollicitudin ultricies augue sed, dictum feugiat
+      neque.
+    </p>
+  </div>
+)

--- a/src/storybook/RouterDecorator.tsx
+++ b/src/storybook/RouterDecorator.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
-import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types'
 import { MemoryRouter } from 'react-router'
 
-export const RouterDecorator = (DecoratedStory: () => StoryFnReactReturnType): JSX.Element => (
+export const RouterDecorator = (DecoratedStory: () => JSX.Element): JSX.Element => (
   <MemoryRouter initialEntries={['/']}>{DecoratedStory()}</MemoryRouter>
 )

--- a/src/storybook/RouterDecorator.tsx
+++ b/src/storybook/RouterDecorator.tsx
@@ -3,5 +3,5 @@ import React from 'react'
 import { MemoryRouter } from 'react-router'
 
 export const RouterDecorator = (DecoratedStory: () => JSX.Element): JSX.Element => (
-  <MemoryRouter initialEntries={['/']}>{DecoratedStory()}</MemoryRouter>
+  <MemoryRouter>{DecoratedStory()}</MemoryRouter>
 )

--- a/src/storybook/RouterDecorator.tsx
+++ b/src/storybook/RouterDecorator.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types'
+import { MemoryRouter } from 'react-router'
+
+export const RouterDecorator = (DecoratedStory: () => StoryFnReactReturnType): JSX.Element => (
+  <MemoryRouter initialEntries={['/']}>{DecoratedStory()}</MemoryRouter>
+)

--- a/src/storybook/decorators.tsx
+++ b/src/storybook/decorators.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Frame } from 'components/common/Frame'
+import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types'
+
+export const CenteredAndFramed = (DecoratedStory: () => StoryFnReactReturnType): JSX.Element => (
+  <div style={{ textAlign: 'center' }}>
+    <Frame style={{ display: 'inline-block' }}>{DecoratedStory()}</Frame>
+  </div>
+)

--- a/src/utils/minFee.ts
+++ b/src/utils/minFee.ts
@@ -2,7 +2,6 @@ import { BigNumber } from 'bignumber.js'
 import { logDebug } from './miscellaneous'
 
 export const DEFAULT_GAS_PRICE = 40e9 // 40 Gwei
-export const SUBSIDIZE_FACTOR = 1 // no subsidy
 
 // account for a 20% change in the time it takes to mine the tx, and start the batch
 export const BUFFER_MULTIPLIER = 1.2
@@ -16,18 +15,20 @@ const OWL_DECIMAL_UNITS = 1e18
 interface CalcMinTradableAmountInOwlParams {
   gasPrice: number
   ethPriceInOwl: BigNumber
+  subsidizeFactor: number
 }
 
 export const calcMinTradableAmountInOwl = ({
   gasPrice,
   ethPriceInOwl,
+  subsidizeFactor,
 }: CalcMinTradableAmountInOwlParams): BigNumber => {
   const minEconomicalViableFeeInOwl = ethPriceInOwl
     .multipliedBy(TRADE_TX_GASLIMIT * gasPrice)
     .dividedBy(OWL_DECIMAL_UNITS)
   logDebug('MIN_ECONOMICAL_VIABLE_FEE_IN_OWL', minEconomicalViableFeeInOwl.toString(10))
 
-  const minFee = minEconomicalViableFeeInOwl.multipliedBy(BUFFER_MULTIPLIER).dividedBy(SUBSIDIZE_FACTOR)
+  const minFee = minEconomicalViableFeeInOwl.multipliedBy(BUFFER_MULTIPLIER).dividedBy(subsidizeFactor)
   return minFee.multipliedBy(FEE_FACTOR * SETTLEMENT_FACTOR)
 }
 

--- a/test/utils/minFee.spec.ts
+++ b/test/utils/minFee.spec.ts
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js'
-
 import { calcMinTradableAmountInOwl, roundToNext } from 'utils/minFee'
+
+const DEFAULT_SUBSIDIZE_FACTOR = 1
 
 describe('calcMinTradableAmountInOwl', () => {
   const samples = {
@@ -18,6 +19,7 @@ describe('calcMinTradableAmountInOwl', () => {
         const minAmountInOwl = calcMinTradableAmountInOwl({
           gasPrice: gasPrice * Gwei,
           ethPriceInOwl: new BigNumber(ethPrice),
+          subsidizeFactor: DEFAULT_SUBSIDIZE_FACTOR,
         })
 
         results.push({


### PR DESCRIPTION
Waterfall PR depending on #1404 

----

This PR create the stories for the 2 layouts of the App:
* SwapLayout: Dapp v1.0
* TradingLayout: Dapp v2.0

It also: 
* moves the global styles to TradingLayout, since we don't have global styles for the v2.0
* Delete the global decorator for global styles in Storybook. Now the components look very neutral, which I think it's good thing! This should help with the redesign

v1:
![image](https://user-images.githubusercontent.com/2352112/92930529-7bc8d680-f442-11ea-8966-f61cc471075c.png)

v2:
![image](https://user-images.githubusercontent.com/2352112/92930621-97cc7800-f442-11ea-9038-02cfabab8b7a.png)
