### PR TITLE
Fix unwrapped promise cache result

### DIFF
--- a/src/api/proxy/CacheMixin.ts
+++ b/src/api/proxy/CacheMixin.ts
@@ -62,10 +62,6 @@ export class CacheMixin {
       // store possibly a promise
       this.store(hash, value, ttl)
       Promise.resolve(value)
-        .then((val) => {
-          // store a value of resolved promise
-          this.store(hash, val, ttl)
-        })
         // don't cache errors
         .catch(() => {
           // remove failed promise from store


### PR DESCRIPTION
Using `CacheMixin` cached promise result of a method, but didn't change return type of that method.
So when you would expect `method()` to return a Promise and would call `method().then()` it would fail if returned from cache

This PR removes caching of Promise result. Still leaves in place cache invalidation for rejected promises.