### PR TITLE
Add debug in case of estimation error, and when sending a tx

### DIFF
--- a/src/api/deposit/DepositApi.ts
+++ b/src/api/deposit/DepositApi.ts
@@ -149,6 +149,8 @@ export class DepositApiImpl implements DepositApi {
     txOptionalParams,
   }: DepositParams): Promise<Receipt> {
     const contract = await this._getContract(networkId)
+    logDebug('[DepositApi] deposit:', { tokenAddress, amount: amount.toString() })
+
     // TODO: Remove temporal fix for web3. See https://github.com/gnosis/dex-react/issues/231
     const tx = contract.methods.deposit(tokenAddress, amount.toString()).send({ from: userAddress })
 
@@ -168,6 +170,8 @@ export class DepositApiImpl implements DepositApi {
     txOptionalParams,
   }: RequestWithdrawParams): Promise<Receipt> {
     const contract = await this._getContract(networkId)
+    logDebug('[DepositApi] requestWithdraw:', { tokenAddress, amount: amount.toString() })
+
     // TODO: Remove temporal fix for web3. See https://github.com/gnosis/dex-react/issues/231
     const tx = contract.methods.requestWithdraw(tokenAddress, amount.toString()).send({ from: userAddress })
 
@@ -183,6 +187,7 @@ export class DepositApiImpl implements DepositApi {
 
   public async withdraw({ userAddress, tokenAddress, networkId, txOptionalParams }: WithdrawParams): Promise<Receipt> {
     const contract = await this._getContract(networkId)
+    logDebug('[DepositApi] requestWithdraw:', { userAddress, tokenAddress })
     const tx = contract.methods.withdraw(userAddress, tokenAddress).send({ from: userAddress })
 
     if (txOptionalParams?.onSentTransaction) {

--- a/src/api/erc20/Erc20Api.ts
+++ b/src/api/erc20/Erc20Api.ts
@@ -5,7 +5,7 @@ import erc20Abi from '@gnosis.pm/dex-js/build/contracts/abi/Erc20.json'
 
 import { TxOptionalParams, Receipt } from 'types'
 import { ZERO } from 'const'
-import { toBN } from 'utils'
+import { logDebug, toBN } from 'utils'
 
 import ERC20_DETAILS from 'api/erc20/erc20Details.json'
 
@@ -165,6 +165,7 @@ export class Erc20ApiImpl implements Erc20Api {
 
     const erc20 = this._getERC20AtAddress(networkId, tokenAddress)
 
+    logDebug('[Erc20Api] allowance:', { userAddress, spenderAddress })
     const result = await erc20.methods.allowance(userAddress, spenderAddress).call()
 
     return toBN(result)
@@ -179,6 +180,8 @@ export class Erc20ApiImpl implements Erc20Api {
     txOptionalParams,
   }: ApproveParams): Promise<Receipt> {
     const erc20 = this._getERC20AtAddress(networkId, tokenAddress)
+
+    logDebug('[Erc20Api] approve:', { spenderAddress, amount: amount.toString() })
 
     // TODO: Remove temporal fix for web3. See https://github.com/gnosis/dex-react/issues/231
     const tx = erc20.methods.approve(spenderAddress, amount.toString()).send({
@@ -201,6 +204,8 @@ export class Erc20ApiImpl implements Erc20Api {
     txOptionalParams,
   }: TransferParams): Promise<Receipt> {
     const erc20 = this._getERC20AtAddress(networkId, tokenAddress)
+
+    logDebug('[Erc20Api] transfer:', { toAddress, amount: amount.toString() })
 
     // TODO: Remove temporal fix for web3. See https://github.com/gnosis/dex-react/issues/231
     const tx = erc20.methods.transfer(toAddress, amount.toString()).send({
@@ -225,6 +230,7 @@ export class Erc20ApiImpl implements Erc20Api {
   }: TransferFromParams): Promise<Receipt> {
     const erc20 = this._getERC20AtAddress(networkId, tokenAddress)
 
+    logDebug('[Erc20Api] transferFrom:', { userAddress, toAddress, amount: amount.toString() })
     const tx = erc20.methods.transferFrom(userAddress, toAddress, amount.toString()).send({
       from: fromAddress,
     })

--- a/src/api/exchange/ExchangeApi.ts
+++ b/src/api/exchange/ExchangeApi.ts
@@ -358,6 +358,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
 
   public async addToken({ userAddress, tokenAddress, networkId, txOptionalParams }: AddTokenParams): Promise<Receipt> {
     const contract = await this._getContract(networkId)
+    logDebug('[ExchangeApi] addToken:', tokenAddress)
     const tx = contract.methods.addToken(tokenAddress).send({ from: userAddress })
 
     if (txOptionalParams?.onSentTransaction) {
@@ -383,7 +384,13 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
 
     const contract = await this._getContract(networkId)
 
-    // TODO: Remove temporal fix for web3. See https://github.com/gnosis/dex-react/issues/231
+    logDebug('[ExchangeApi] placeOrder:', {
+      buyTokenId,
+      sellTokenId,
+      validUntil,
+      buyAmount: buyAmount.toString(),
+      sellAmount: sellAmount.toString(),
+    })
     const tx = contract.methods
       .placeOrder(buyTokenId, sellTokenId, validUntil, buyAmount.toString(), sellAmount.toString())
       .send({ from: userAddress })
@@ -425,6 +432,14 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     const buyAmountsStr = buyAmounts.map(String)
     const sellAmountsStr = sellAmounts.map(String)
 
+    logDebug('[ExchangeApi] placeValidFromOrders:', {
+      buyTokens,
+      sellTokens,
+      validFroms,
+      validUntils,
+      buyAmountsStr,
+      sellAmountsStr,
+    })
     const tx = contract.methods
       .placeValidFromOrders(buyTokens, sellTokens, validFroms, validUntils, buyAmountsStr, sellAmountsStr)
       .send({ from: userAddress })
@@ -453,6 +468,7 @@ export class ExchangeApiImpl extends DepositApiImpl implements ExchangeApi {
     txOptionalParams,
   }: CancelOrdersParams): Promise<Receipt> {
     const contract = await this._getContract(networkId)
+    logDebug('[ExchangeApi] cancelOrders:', orderIds)
     const tx = contract.methods.cancelOrders(orderIds).send({ from: userAddress })
 
     if (txOptionalParams?.onSentTransaction) {

--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -169,12 +169,17 @@ export const composeProvider = <T extends Provider>(
         if (!txConfig) return false
 
         if (!txConfig.gas) {
-          const gasLimit = await web3.eth.estimateGas(txConfig)
+          const gasLimit = await web3.eth.estimateGas(txConfig).catch((error) => {
+            console.error('[composeProvider] Error estimating gas, probably failing transaction', txConfig)
+            throw error
+          })
           logDebug('[composeProvider] No gas Limit. Using estimation ' + gasLimit)
           txConfig.gas = numberToHex(gasLimit)
         } else {
           logDebug('[composeProvider] Gas Limit: ' + txConfig.gas)
         }
+
+        logDebug('[composeProvider] Sending transaction', txConfig)
 
         // don't mark as handled
         // pass modified tx on

--- a/src/api/weth/WethApi.ts
+++ b/src/api/weth/WethApi.ts
@@ -54,6 +54,7 @@ export class WethApiImpl implements WethApi {
     const { networkId, amount, userAddress, txOptionalParams } = params
     const contract = await this._getContract(networkId)
 
+    logDebug('[WethApi] deposit:', { from: userAddress, value: amount })
     const tx = contract.methods.deposit().send({ from: userAddress, value: amount })
 
     if (txOptionalParams?.onSentTransaction) {
@@ -69,6 +70,7 @@ export class WethApiImpl implements WethApi {
     const { networkId, amount, userAddress, txOptionalParams } = params
     const contract = await this._getContract(networkId)
 
+    logDebug('[WethApi] withdraw:', amount)
     const tx = contract.methods.withdraw(amount).send({ from: userAddress })
 
     if (txOptionalParams?.onSentTransaction) {


### PR DESCRIPTION
Adds some logs for when the estimation failed. 

It helped me now to debug an issue, I think is good to add. Also, now we also show the transaction details in the log even if we succeed on the estimation

Also, it adds logs at API level, for methods that send transactions