### PR TITLE
Allow to click in any part of the disconnect button

### DIFF
--- a/src/components/UserWallet/WalletComponent.tsx
+++ b/src/components/UserWallet/WalletComponent.tsx
@@ -118,10 +118,8 @@ const UserWallet: React.FC<RouteComponentProps> = (props: UserWalletProps) => {
     }
 
     return (
-      <LogInOutButton $loggedIn={isConnected}>
-        <a onClick={onClick} className={props.className}>
-          {content}
-        </a>
+      <LogInOutButton $loggedIn={isConnected} onClick={onClick}>
+        <a className={props.className}>{content}</a>
       </LogInOutButton>
     )
   }, [connectWallet, disconnectWallet, isConnected, loadingLabel, props.className])


### PR DESCRIPTION
The disconnect button doesn't work if you click on it.
This is because the onClick event was added only to the text, not to the button