### PR TITLE
Explicitly not support provider.request

### DIFF
--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -199,6 +199,10 @@ export const composeProvider = <T extends Provider>(
         // composedProvider handles it
         return Reflect.get(target, prop, receiver)
       }
+      // pretend we don't support provider.request yet
+      if (prop === 'request') {
+        return undefined
+      }
       // MMask or other provider handles it
       return Reflect.get(provider, prop, receiver)
     },


### PR DESCRIPTION
Workaround for issue with **WalletConnect** `request` method being called with Window context
Issue came with a regression in **web3** `RequestProvider`.