### PR TITLE
Fix long price estimation style

### DIFF
--- a/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
@@ -9,6 +9,12 @@ import { displayTokenSymbolOrLink } from 'utils/display'
 import Spinner from 'components/common/Spinner'
 import { SwapPrice } from 'components/common/SwapPrice'
 
+import styled from 'styled-components'
+
+const LongPriceStrong = styled.strong`
+  word-break: break-all;
+`
+
 export interface Props {
   label: string
   baseToken: TokenDetails
@@ -67,9 +73,9 @@ export const PriceSuggestionItem: React.FC<Props> = (props) => {
       <span>
         <span>{label}</span>{' '}
         {amount && (
-          <strong>
+          <LongPriceStrong>
             ({amount} {displayTokenSymbolOrLink(quoteToken)})
-          </strong>
+          </LongPriceStrong>
         )}
       </span>
       <button


### PR DESCRIPTION
Fixes #1423 
This is a small fix
![localhost_8080_trade_DAI-USDC_sell=0 price=0 from= expires= (10)](https://user-images.githubusercontent.com/5121491/94160167-0a9b1180-fe8d-11ea-8274-87f8cc54bfa1.png)


Can instead do this
![localhost_8080_trade_DAI-USDC_sell=0 price=0 from= expires= (11)](https://user-images.githubusercontent.com/5121491/94160210-11c21f80-fe8d-11ea-8268-1aa34fac933d.png)


For anything more we will have to rearrange containing component's styles