### PR TITLE
Earmark logic in middleware

### DIFF
--- a/src/api/earmark.ts
+++ b/src/api/earmark.ts
@@ -1,5 +1,4 @@
 import { logDebug } from 'utils'
-import { hexToNumber, numberToHex } from 'web3-utils'
 
 // 0.1 Gwei, reasonable gasPrice that would still allow flags replacement
 export const MIN_GAS_PRICE = (1e8).toString(10)
@@ -26,14 +25,6 @@ export const earmarkTxData = (data = '0x', userPrint: string): string => data + 
 
 const GAS_PER_DATA_CHAR = 8 // wei
 
-// increases pre-estimated gas by the amount needed to save extra earmark data to chain
+// calculates gas needed to save extra earmark data to chain
 // 16 wei per 2 characters
-export const calcEarmarkedGas = (gas: string | number, userPrint: string): string => {
-  const gasNumber = hexToNumber(gas)
-
-  const earmarkGas = GAS_PER_DATA_CHAR * userPrint.length
-
-  const newGas = gasNumber + earmarkGas
-
-  return numberToHex(newGas)
-}
+export const calcEarmarkedGas = (userPrint: string): number => GAS_PER_DATA_CHAR * userPrint.length

--- a/src/api/wallet/WalletApiMock.ts
+++ b/src/api/wallet/WalletApiMock.ts
@@ -23,7 +23,7 @@ export class WalletApiMock implements WalletApi {
     chainId: 1,
     blockHeader: null,
   }
-  public userPrintAsync = Promise.resolve('')
+  public userPrintAsync = Promise.resolve({ userPrint: '', gas: 0 })
 
   public constructor() {
     this._connected = process.env.AUTOCONNECT === 'true'


### PR DESCRIPTION
- Moves gas calculations into middleware
- Extra gas is calculated once per userPrint generation
As per [discussion](https://github.com/gnosis/dex-react/pull/1445/files#r494919850)