### PR TITLE
Require(*).default storybook workaround

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -34,6 +34,20 @@ module.exports = {
       customRules: custom.module.rules,
     })
 
+    const rulesWithMarkdownAndImages = replaceRulesForFile({
+      filename: 'token_address.png',
+      baseRules: rulesWithMarkdown,
+      customRules: [{
+        // what storybook uses
+        test: /\.(svg|ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|cur|ani|pdf)(\?.*)?$/,
+        loader: 'file-loader',
+        // only change from storybook -- esModule: false -> true
+        // this way require() and require.context need module.default
+        // same as in webpack config
+        options: { name: 'static/media/[name].[hash:8].[ext]', esModule: true }
+      }]
+    })
+  
     return {
       ...config,
       module: {
@@ -41,7 +55,7 @@ module.exports = {
         // enable rules override sparingly
         // only if storybook can't transpile something
         // rules: custom.module.rules,
-        rules: rulesWithMarkdown,
+        rules: rulesWithMarkdownAndImages,
       },
       resolve: {
         ...config.resolve,

--- a/src/components/common/TokenImg.tsx
+++ b/src/components/common/TokenImg.tsx
@@ -46,18 +46,6 @@ const tokensIconsFilesByAddress: Record<string, string> = tokensIconsRequire.key
   return acc
 }, {})
 
-const defaultFallbackRequire = <T,>(reqPath: string): T => {
-  const module = tokensIconsRequire(reqPath)
-  // https://github.com/storybookjs/storybook/issues/11610
-  // in storybook module = 'static/media/0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d.5a86806e.png'
-  // in webpack module = {
-  //   default: "/5a86806e7c0681c126888fe301054197.png",
-  //   Symbol(Symbol.toStringTag): "Module",
-  //   __esModule: true
-  // }
-  return module.default ?? module
-}
-
 export const TokenImg: React.FC<Props> = (props) => {
   const { address, addressMainnet, symbol, name } = props
 

--- a/src/components/common/TokenImg.tsx
+++ b/src/components/common/TokenImg.tsx
@@ -54,7 +54,9 @@ export const TokenImg: React.FC<Props> = (props) => {
     iconFile = tokensIconsFilesByAddress[addressMainnet.toLowerCase()]
   }
 
-  const iconFileUrl = iconFile ? defaultFallbackRequire<string>(iconFile) : getImageUrl(addressMainnet || address)
+  const iconFileUrl: string | undefined = iconFile
+    ? tokensIconsRequire(iconFile)
+    : getImageUrl(addressMainnet || address)
 
   // TODO: Simplify safeTokenName signature, it doesn't need the addressMainnet or id!
   // https://github.com/gnosis/dex-react/issues/1442


### PR DESCRIPTION
When using `require.context` with our webpack config a required module takes shape of
```ts
{
    default: "/5a86806e7c0681c126888fe301054197.png",
    Symbol(Symbol.toStringTag): "Module",
    __esModule: true
 }
```

When using with storybook module becomes `'static/media/0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d.5a86806e.png'`

Issue storybookjs/storybook#11610