### PR TITLE
Fix xDAI token break

### DIFF
--- a/src/api/tokenList/TokenListApi.ts
+++ b/src/api/tokenList/TokenListApi.ts
@@ -3,7 +3,7 @@ import { getTokensByNetwork } from './tokenList'
 import { logDebug } from 'utils'
 import GenericSubscriptions, { SubscriptionsInterface } from './Subscriptions'
 import { TokenDetailsConfig } from '@gnosis.pm/dex-js'
-import { DISABLED_TOKEN_MAPS } from 'const'
+import { DISABLED_TOKEN_MAPS, EMPTY_ARRAY } from 'const'
 
 const addOverrideToDisabledTokens = (networkId: number) => (token: TokenDetails): TokenDetails => {
   const tokenOverride = DISABLED_TOKEN_MAPS[networkId]?.[token.address]
@@ -98,7 +98,7 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
   }
 
   public getTokens(networkId: number): TokenDetails[] {
-    return this._tokensByNetwork[networkId] || []
+    return this._tokensByNetwork[networkId] || EMPTY_ARRAY
   }
 
   private static mergeTokenLists(...lists: TokenDetails[][]): TokenDetails[] {

--- a/src/api/wallet/WalletApi.ts
+++ b/src/api/wallet/WalletApi.ts
@@ -259,7 +259,11 @@ export class WalletApiImpl implements WalletApi {
   private _web3: Web3
   private _providerInfo: ProviderInfo | null = null
   public userPrintAsync: Promise<UserPrint> = Promise.resolve({ userPrint: '', gas: 0 })
-  public blockchainState: BlockchainUpdatePrompt
+  public blockchainState: BlockchainUpdatePrompt = {
+    account: '',
+    chainId: 0,
+    blockHeader: null,
+  }
 
   private _unsubscribe: Command
   private _fetchGasPrice: ReturnType<typeof fetchGasPriceFactory> = async () => undefined

--- a/src/api/wallet/WalletApi.ts
+++ b/src/api/wallet/WalletApi.ts
@@ -85,7 +85,7 @@ type OnChangeWalletInfo = (walletInfo: WalletInfo) => void
 // 2: account changes
 // 3: new block is mined
 
-interface BlockchainUpdatePrompt {
+export interface BlockchainUpdatePrompt {
   account: string
   chainId: number
   blockHeader: BlockHeader | null

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -14,7 +14,7 @@ import { SwitcherSVG } from 'assets/img/SVG'
 // const, types
 import { ZERO } from 'const'
 import { PRICE_ESTIMATION_DEBOUNCE_TIME } from 'const'
-import { TokenDetails, Network } from 'types'
+import { TokenDetails, Network, TokenBalanceDetails } from 'types'
 
 // utils
 import { getToken, parseAmount, dateToBatchId, resolverFactory, logDebug, batchIdToDate } from 'utils'
@@ -67,11 +67,12 @@ import { useSubmitTxModal } from 'hooks/useSubmitTxModal'
 
 // Reducers
 import { savePendingOrdersAction } from 'reducers-actions/pendingOrders'
-import { updateTradeState } from 'reducers-actions/trade'
+import { updateTradeState, TradeState } from 'reducers-actions/trade'
 
 // Validation
 import validationSchema from 'components/TradeWidget/validationSchema'
 import { TxMessage } from 'components/TradeWidget/TxMessage'
+import { AnyAction } from 'combine-reducers'
 
 const NULL_BALANCE_TOKEN = {
   exchangeBalance: ZERO,
@@ -119,9 +120,10 @@ const validUntilId: TradeFormTokenId = 'validUntil'
 // Grab CONFIG tokens
 const { sellToken: initialSellToken, receiveToken: initialReceiveToken } = CONFIG.initialTokenSelection
 
-const TradeWidget: React.FC = () => {
-  const { networkId, networkIdOrDefault, isConnected, userAddress } = useWalletConnection()
-  const { connectWallet } = useConnectWallet()
+
+const TradeWidgetContainer: React.FC = () => {
+  const { networkIdOrDefault, isConnected } = useWalletConnection()
+
   const [{ trade }, dispatch] = useGlobalState()
 
   // get all token balances but deprecated
@@ -139,31 +141,6 @@ const TradeWidget: React.FC = () => {
   const { sell: encodedSellTokenSymbol, buy: decodeReceiveTokenSymbol } = useParams()
   const sellTokenSymbol = decodeSymbol(encodedSellTokenSymbol || '')
   const receiveTokenSymbol = decodeSymbol(decodeReceiveTokenSymbol || '')
-  const {
-    sellAmount: sellParam,
-    price: priceParam,
-    validFrom: validFromParam,
-    validUntil: validUntilParam,
-  } = useQuery()
-
-  // Combining global state with query params
-  const defaultPrice = trade.price || priceParam
-  const defaultSellAmount = trade.sellAmount || sellParam
-  const defaultValidFrom = calculateValidityTimes(trade.validFrom || validFromParam)
-  const defaultValidUntil = calculateValidityTimes(trade.validUntil || validUntilParam)
-
-  const [priceShown, setPriceShown] = useState<'INVERSE' | 'DIRECT'>('DIRECT')
-
-  const swapPrices = (): void => setPriceShown((oldPrice) => (oldPrice === 'DIRECT' ? 'INVERSE' : 'DIRECT'))
-
-  const defaultFormValues: TradeFormData = {
-    [sellInputId]: defaultSellAmount,
-    [receiveInputId]: '',
-    [validFromId]: defaultValidFrom,
-    [validUntilId]: defaultValidUntil,
-    [priceInputId]: defaultPrice,
-    [priceInverseInputId]: invertPriceFromString(defaultPrice),
-  }
 
   const [sellToken, setSellToken] = useState(() =>
     chooseTokenWithFallback({
@@ -215,6 +192,78 @@ const TradeWidget: React.FC = () => {
   }, [networkIdOrDefault])
   // don't need to depend on more than network as everything else updates together
   // also avoids excessive setStates
+
+  if (!sellToken || !receiveToken) return null
+
+  return (
+    <TradeWidget
+      sellToken={sellToken}
+      receiveToken={receiveToken}
+      trade={trade}
+      dispatch={dispatch}
+      tokens={tokens}
+      balances={balances}
+      setSellToken={setSellToken}
+      setReceiveToken={setReceiveToken}
+      sellTokenSymbol={sellTokenSymbol}
+      receiveTokenSymbol={receiveTokenSymbol}
+    />
+  )
+}
+
+interface TradeWidgetProps {
+  trade: TradeState
+  dispatch: React.Dispatch<AnyAction>
+  sellToken: TokenDetails
+  receiveToken: TokenDetails
+  tokens: TokenDetails[]
+  balances: TokenBalanceDetails[]
+  setSellToken: React.Dispatch<React.SetStateAction<TokenDetails>>
+  setReceiveToken: React.Dispatch<React.SetStateAction<TokenDetails>>
+  sellTokenSymbol: string
+  receiveTokenSymbol: string
+}
+
+const TradeWidget: React.FC<TradeWidgetProps> = ({
+  trade,
+  dispatch,
+  sellToken,
+  receiveToken,
+  tokens,
+  balances,
+  setSellToken,
+  setReceiveToken,
+  sellTokenSymbol,
+  receiveTokenSymbol,
+}) => {
+  const {
+    sellAmount: sellParam,
+    price: priceParam,
+    validFrom: validFromParam,
+    validUntil: validUntilParam,
+  } = useQuery()
+
+  const { connectWallet } = useConnectWallet()
+  const { networkId, networkIdOrDefault, isConnected, userAddress } = useWalletConnection()
+
+  // Combining global state with query params
+  const defaultPrice = trade.price || priceParam
+  const defaultSellAmount = trade.sellAmount || sellParam
+  const defaultValidFrom = calculateValidityTimes(trade.validFrom || validFromParam)
+  const defaultValidUntil = calculateValidityTimes(trade.validUntil || validUntilParam)
+
+  const [priceShown, setPriceShown] = useState<'INVERSE' | 'DIRECT'>('DIRECT')
+
+  const swapPrices = (): void => setPriceShown((oldPrice) => (oldPrice === 'DIRECT' ? 'INVERSE' : 'DIRECT'))
+
+  const defaultFormValues: TradeFormData = {
+    [sellInputId]: defaultSellAmount,
+    [receiveInputId]: '',
+    [validFromId]: defaultValidFrom,
+    [validUntilId]: defaultValidUntil,
+    [priceInputId]: defaultPrice,
+    [priceInverseInputId]: invertPriceFromString(defaultPrice),
+  }
 
   const [unlimited, setUnlimited] = useState(!defaultValidUntil || !Number(defaultValidUntil))
   const [asap, setAsap] = useState(!defaultValidFrom || !Number(defaultValidFrom))
@@ -294,7 +343,7 @@ const TradeWidget: React.FC = () => {
     setReceiveToken(sellTokenBalance)
     // selected price no longer has meaning, reset and force user pick/insert new one
     resetPrices()
-  }, [receiveTokenBalance, resetPrices, sellTokenBalance])
+  }, [receiveTokenBalance, resetPrices, sellTokenBalance, setReceiveToken, setSellToken])
 
   const onSelectChangeFactory = useCallback(
     (
@@ -685,4 +734,4 @@ const TradeWidget: React.FC = () => {
   )
 }
 
-export default TradeWidget
+export default TradeWidgetContainer

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'react-router'
 import { toast } from 'toastify'
 import BN from 'bn.js'
 import Modali from 'modali'
+import styled from 'styled-components'
 
 import { decodeSymbol } from '@gnosis.pm/dex-js'
 
@@ -120,6 +121,15 @@ const validUntilId: TradeFormTokenId = 'validUntil'
 // Grab CONFIG tokens
 const { sellToken: initialSellToken, receiveToken: initialReceiveToken } = CONFIG.initialTokenSelection
 
+const NoTokens = styled.div`
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 3rem;
+  font-weight: bold;
+}
+`
 
 const TradeWidgetContainer: React.FC = () => {
   const { networkIdOrDefault, isConnected } = useWalletConnection()
@@ -193,7 +203,7 @@ const TradeWidgetContainer: React.FC = () => {
   // don't need to depend on more than network as everything else updates together
   // also avoids excessive setStates
 
-  if (!sellToken || !receiveToken) return null
+  if (!sellToken || !receiveToken) return <NoTokens>NO TOKENS FOUND</NoTokens>
 
   return (
     <TradeWidget

--- a/src/components/TradeWidget/utils.ts
+++ b/src/components/TradeWidget/utils.ts
@@ -54,13 +54,13 @@ export const chooseTokenWithFallback = ({
   token,
   tokenSymbolFromUrl,
   defaultTokenSymbol,
-}: ChooseTokenInput): TokenDetails => {
+}: ChooseTokenInput): TokenDetails | undefined => {
   return (
     token ||
     (tokenSymbolFromUrl && isAddress(tokenSymbolFromUrl?.toLowerCase())
       ? getToken('address', tokenSymbolFromUrl, tokens)
       : getToken('symbol', tokenSymbolFromUrl, tokens)) ||
-    (getToken('symbol', defaultTokenSymbol, tokens) as Required<TokenDetails>)
+    getToken('symbol', defaultTokenSymbol, tokens)
   )
 }
 

--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -4,11 +4,14 @@ import { Command, Network } from 'types'
 import useSafeState from './useSafeState'
 import { BlockchainUpdatePrompt, WalletInfo } from 'api/wallet/WalletApi'
 
-type PendingStateObject = { pending: true; networkIdOrDefault: number } & Partial<WalletInfo>
+interface PendingStateObject extends WalletInfo {
+  pending: true
+  networkIdOrDefault: number
+}
 
 const PendingState: PendingStateObject = {
   pending: true,
-  isConnected: undefined,
+  isConnected: false,
   userAddress: undefined,
   networkId: undefined,
   networkIdOrDefault: Network.Mainnet,


### PR DESCRIPTION
When switching to xDAI chain and refreshing the page it would break with `symbol of undefined` error (@anxolin knows what I'm talking about). First experienced at https://pr1449--dexreact.review.gnosisdev.com/

That would happen because we cast TS types for `getToken` to `TokenDetails` when it could be `undefined`
When there are no tokens for the network (in `config.yaml` or elsewhere) `tokens` array becomes empty
So after adding xDAI tokens to config, the error would fix itself, but still not a good idea

This PR allows for `tokens = []` and as a side-effect allows to switch to an unsupported chain without the whole app coming down.
Try Ropsten, for example.