### PR TITLE
Refactor and simplify token types

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.12.0",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/react-fontawesome": "^0.1.8",
-    "@gnosis.pm/dex-js": "^0.7.1",
+    "@gnosis.pm/dex-js": "^0.8.0",
     "@hookform/error-message": "^0.0.3",
     "@hot-loader/react-dom": "^16.11.0",
     "@material-ui/core": "^4.11.0",

--- a/src/api/tokenList/TokenListApi.ts
+++ b/src/api/tokenList/TokenListApi.ts
@@ -2,8 +2,8 @@ import { TokenDetails } from 'types'
 import { getTokensByNetwork } from './tokenList'
 import { logDebug } from 'utils'
 import GenericSubscriptions, { SubscriptionsInterface } from './Subscriptions'
-import { TokenDetailsConfig } from '@gnosis.pm/dex-js'
 import { DISABLED_TOKEN_MAPS } from 'const'
+import { TokenDetailsConfigLegacy } from '@gnosis.pm/dex-js'
 
 const addOverrideToDisabledTokens = (networkId: number) => (token: TokenDetails): TokenDetails => {
   const tokenOverride = DISABLED_TOKEN_MAPS[networkId]?.[token.address]
@@ -30,7 +30,7 @@ export interface TokenList extends SubscriptionsInterface<TokenDetails[]> {
 
 export interface TokenListApiParams {
   networkIds: number[]
-  initialTokenList: TokenDetailsConfig[]
+  initialTokenList: TokenDetailsConfigLegacy[]
 }
 
 export interface AddTokenParams {

--- a/src/api/tokenList/tokenList.ts
+++ b/src/api/tokenList/tokenList.ts
@@ -1,9 +1,8 @@
 import { TokenDetails, Network } from 'types'
 import { DEFAULT_PRECISION } from 'const'
+import { TokenDetailsConfigLegacy } from '@gnosis.pm/dex-js'
 
-import { TokenDetailsConfig } from '@gnosis.pm/dex-js'
-
-export function getTokensByNetwork(networkId: number, tokenList: TokenDetailsConfig[]): TokenDetails[] {
+export function getTokensByNetwork(networkId: number, tokenList: TokenDetailsConfigLegacy[]): TokenDetails[] {
   // Return token details
   const tokenDetails: TokenDetails[] = tokenList.reduce((acc: TokenDetails[], token) => {
     const address = token.addressByNetwork[networkId]

--- a/src/components/PoolingWidget/CreateStrategy.tsx
+++ b/src/components/PoolingWidget/CreateStrategy.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { TokenDetails } from '@gnosis.pm/dex-js'
+import { TokenDex } from '@gnosis.pm/dex-js'
 
 // types, util, const
 import { Receipt } from 'types'
@@ -14,7 +14,7 @@ import AddFunding from 'components/PoolingWidget/AddFunding'
 
 export interface CreateStrategyProps {
   isSubmitting: boolean
-  selectedTokensMap: Map<number, TokenDetails>
+  selectedTokensMap: Map<number, TokenDex>
   spread: number
   setSpread: (spread: number) => void
   txIdentifier: string
@@ -23,7 +23,7 @@ export interface CreateStrategyProps {
 }
 
 interface SpreadInformationProps {
-  selectedTokensMap: Map<number, TokenDetails>
+  selectedTokensMap: Map<number, TokenDex>
   spread: number
 }
 

--- a/src/components/PoolingWidget/SubComponents.tsx
+++ b/src/components/PoolingWidget/SubComponents.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 // types
 import { Receipt } from 'types'
-import { TokenDetails } from '@gnosis.pm/dex-js'
+import { TokenDex } from '@gnosis.pm/dex-js'
 
 // PoolingWidget: subcomponents
 import TokenSelector from 'components/PoolingWidget/TokenSelector'
@@ -12,7 +12,7 @@ import { CreateStrategy } from 'components/PoolingWidget/CreateStrategy'
 export interface SubComponentProps extends TokenSelectorProps {
   isSubmitting: boolean
   step: number
-  selectedTokensMap: Map<number, TokenDetails>
+  selectedTokensMap: Map<number, TokenDex>
   spread: number
   setSpread: React.Dispatch<React.SetStateAction<number>>
   txHash: string

--- a/src/components/PoolingWidget/TokenSelector.tsx
+++ b/src/components/PoolingWidget/TokenSelector.tsx
@@ -5,16 +5,16 @@ import { TokenImgWrapper } from 'components/common/TokenImg'
 import checkIcon from 'assets/img/li-check.svg'
 
 // types
-import { TokenDetails } from '@gnosis.pm/dex-js'
+import { TokenDex } from '@gnosis.pm/dex-js'
 
 // PoolingWidget: subcomponent
 import { ProgressStepText } from 'components/PoolingWidget/PoolingWidget.styled'
 import { TokenSelectorWrapper, TokenBox, CheckboxWrapper } from 'components/PoolingWidget/TokenSelector.styled'
 
 export interface TokenSelectorProps {
-  handleTokenSelect: (tokenData: TokenDetails) => void
-  selectedTokensMap: Map<number, TokenDetails>
-  tokens: TokenDetails[]
+  handleTokenSelect: (tokenData: TokenDex) => void
+  selectedTokensMap: Map<number, TokenDex>
+  tokens: TokenDex[]
 }
 
 const TokenSelector: React.FC<TokenSelectorProps> = ({ handleTokenSelect, selectedTokensMap, tokens }) => {

--- a/src/components/PoolingWidget/index.tsx
+++ b/src/components/PoolingWidget/index.tsx
@@ -9,7 +9,7 @@ import joi from 'joi'
 // const, type, utils
 import { DEFAULT_PRECISION, LIQUIDITY_TOKEN_LIST, INPUT_PRECISION_SIZE } from 'const'
 import { Receipt } from 'types'
-import { TokenDetails, ZERO } from '@gnosis.pm/dex-js'
+import { TokenDex, ZERO } from '@gnosis.pm/dex-js'
 import { maxAmountsForSpread, resolverFactory, VALIDATOR_ERROR_KEYS } from 'utils'
 
 // components
@@ -36,7 +36,7 @@ import { useTokenList } from 'hooks/useTokenList'
 export const FIRST_STEP = 1
 export const LAST_STEP = 2
 
-function addRemoveMapItem(map: Map<number, TokenDetails>, newToken: TokenDetails): Map<number, TokenDetails> {
+function addRemoveMapItem(map: Map<number, TokenDex>, newToken: TokenDex): Map<number, TokenDex> {
   // Cache map (no mutate)
   const copyMap = new Map(map)
   // Map item doesn't exist? Add that fool in
@@ -46,14 +46,14 @@ function addRemoveMapItem(map: Map<number, TokenDetails>, newToken: TokenDetails
   return copyMap
 }
 
-function setFullTokenMap(tokens: TokenDetails[]): Map<number, TokenDetails> {
+function setFullTokenMap(tokens: TokenDex[]): Map<number, TokenDex> {
   const tokenMap = new Map()
   tokens.forEach((token) => tokenMap.set(token.id, token))
   return tokenMap
 }
 
 // TODO: Decide the best place to put this. This file is too long already, but feels to specific for utils
-export function createOrderParams(tokens: TokenDetails[], spread: number): MultipleOrdersOrder[] {
+export function createOrderParams(tokens: TokenDex[], spread: number): MultipleOrdersOrder[] {
   // We'll create 2 orders for each pair: SELL_A -> BUY_B and SELL_B -> BUY_A
 
   // With 2 tokens A, B, we have 1 pair [(A, B)] == 2 orders
@@ -161,9 +161,7 @@ const PoolingInterface: React.FC = () => {
     )
   }, [tokenList])
 
-  const [selectedTokensMap, setSelectedTokensMap] = useSafeState<Map<number, TokenDetails>>(() =>
-    setFullTokenMap(tokens),
-  )
+  const [selectedTokensMap, setSelectedTokensMap] = useSafeState<Map<number, TokenDex>>(() => setFullTokenMap(tokens))
 
   useEffect(() => {
     setSelectedTokensMap(setFullTokenMap(tokens))
@@ -254,7 +252,7 @@ const PoolingInterface: React.FC = () => {
   ])
 
   const handleTokenSelect = useCallback(
-    (token: TokenDetails): void => {
+    (token: TokenDex): void => {
       const state = addRemoveMapItem(selectedTokensMap, token)
       return setSelectedTokensMap(state)
     },

--- a/src/components/TokenOptionItem.tsx
+++ b/src/components/TokenOptionItem.tsx
@@ -153,19 +153,16 @@ const generateMessage = ({
   switch (reason) {
     // not registered --> advise to register
     case TokenFromExchange.NOT_REGISTERED_ON_CONTRACT:
-      if (!token)
+      if (!token) {
         return (
           <a href="https://docs.gnosis.io/protocol/docs/addtoken1/" rel="noopener noreferrer" target="_blank">
             Register token on Exchange first
           </a>
         )
+      }
+
       return (
-        <OptionItem
-          name={token.name}
-          symbol={token.symbol}
-          address={token.address}
-          addressMainnet={token.addressMainnet}
-        >
+        <OptionItem name={token.name} symbol={token.symbol} address={token.address}>
           <ExtraOptionsMessage
             href="https://docs.gnosis.io/protocol/docs/addtoken1/"
             rel="noopener noreferrer"

--- a/src/components/common/SwapPrice.tsx
+++ b/src/components/common/SwapPrice.tsx
@@ -4,7 +4,7 @@ import { displayTokenSymbolOrLink, symbolOrAddress } from 'utils/display'
 import { EllipsisText } from 'components/common/EllipsisText'
 
 import { SwapIcon } from 'components/TradeWidget/SwapIcon'
-import { TokenDetails } from '@gnosis.pm/dex-js'
+import { TokenDex } from '@gnosis.pm/dex-js'
 
 const SwapPriceWrapper = styled.div`
   display: inline-block;
@@ -20,8 +20,8 @@ const SwapPriceWrapper = styled.div`
   }
 `
 export interface Props {
-  baseToken: TokenDetails
-  quoteToken: TokenDetails
+  baseToken: TokenDex
+  quoteToken: TokenDex
   showBaseToken?: boolean
   isPriceInverted: boolean
   onSwapPrices: () => void

--- a/src/components/common/TokenImg.tsx
+++ b/src/components/common/TokenImg.tsx
@@ -57,7 +57,7 @@ export const TokenImg: React.FC<Props> = (props) => {
   const iconFileUrl = iconFile ? tokensIconsRequire(iconFile) : getImageUrl(addressMainnet || address)
   // TODO: Simplify safeTokenName signature, it doesn't need the addressMainnet or id!
   // https://github.com/gnosis/dex-react/issues/1442
-  const safeName = safeTokenName({ id: 0, address, addressMainnet, symbol, name })
+  const safeName = safeTokenName({ address, symbol, name })
 
   return <Wrapper alt={safeName} src={iconFileUrl} onError={_loadFallbackTokenImage} {...props} />
 }

--- a/src/components/trade/LimitOrder/LimitOrder.tsx
+++ b/src/components/trade/LimitOrder/LimitOrder.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { TokenDetails, safeTokenName, invertPrice } from '@gnosis.pm/dex-js'
+import { safeTokenName, invertPrice, TokenDex } from '@gnosis.pm/dex-js'
 import BigNumber from 'bignumber.js'
 import { Frame } from 'components/common/Frame'
 import { useForm } from 'react-hook-form'
@@ -15,8 +15,8 @@ const Wrapper = styled.div`
 `
 
 export interface Props {
-  sellToken?: TokenDetails
-  receiveToken?: TokenDetails
+  sellToken?: TokenDex
+  receiveToken?: TokenDex
   limitPrice: BigNumber | null
   isPriceInverted: boolean
   amount?: string
@@ -30,7 +30,7 @@ export interface LimitOrderFormData {
   amount: string
 }
 
-function formatToken(token?: TokenDetails): string {
+function formatToken(token?: TokenDex): string {
   return token ? safeTokenName(token) : 'N/A'
 }
 

--- a/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import BigNumber from 'bignumber.js'
 
 import { PRICE_ESTIMATION_PRECISION } from 'const'
-import { invertPrice, TokenDetails } from '@gnosis.pm/dex-js'
+import { invertPrice, TokenDex } from '@gnosis.pm/dex-js'
 
 import { displayTokenSymbolOrLink } from 'utils/display'
 
@@ -17,8 +17,8 @@ const LongPriceStrong = styled.strong`
 
 export interface Props {
   label: string
-  baseToken: TokenDetails
-  quoteToken: TokenDetails
+  baseToken: TokenDex
+  quoteToken: TokenDex
   amount?: string
   price: BigNumber | null
   isPriceInverted: boolean

--- a/src/components/trade/PriceSuggestions/PriceSuggestions.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestions.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import styled from 'styled-components'
-import { TokenDetails } from '@gnosis.pm/dex-js'
 
 import { MEDIA } from 'const'
 
@@ -9,6 +8,7 @@ import { SwapPrice } from 'components/common/SwapPrice'
 import { EllipsisText } from 'components/common/EllipsisText'
 import { PriceSuggestionItem } from 'components/trade/PriceSuggestions/PriceSuggestionItem'
 import BigNumber from 'bignumber.js'
+import { TokenDex } from '@gnosis.pm/dex-js'
 
 const Wrapper = styled.div`
   > div {
@@ -116,8 +116,8 @@ const OnchainOrderbookTooltip = (
 
 export interface Props {
   // Market
-  baseToken: TokenDetails
-  quoteToken: TokenDetails
+  baseToken: TokenDex
+  quoteToken: TokenDex
   isPriceInverted: boolean
 
   // Order Size

--- a/src/hooks/useBetterAddTokenModal.tsx
+++ b/src/hooks/useBetterAddTokenModal.tsx
@@ -136,12 +136,7 @@ const ExplainTokenReason: React.FC<ExplainTokenReasonProps> = ({ token, reason, 
         )
       return (
         <TokenDisplay>
-          <TokenImageStyled
-            address={token.address}
-            addressMainnet={token.addressMainnet}
-            name={token.name}
-            symbol={token.symbol}
-          />
+          <TokenImageStyled address={token.address} name={token.name} symbol={token.symbol} />
           <div className="tokenSymbol">
             <strong>{token.symbol}</strong>
           </div>

--- a/src/reducers-actions/trade.ts
+++ b/src/reducers-actions/trade.ts
@@ -1,11 +1,11 @@
-import { TokenDetails } from '@gnosis.pm/dex-js'
+import { TokenDex } from '@gnosis.pm/dex-js'
 import { Actions } from 'reducers-actions'
 
 export interface TradeState {
   price: string | null
   sellAmount: string | null
-  sellToken: Required<TokenDetails> | null
-  buyToken: Required<TokenDetails> | null
+  sellToken: Required<TokenDex> | null
+  buyToken: Required<TokenDex> | null
   validFrom: string | null
   validUntil: string | null
 }

--- a/src/services/factories/getTokenFromErc20.ts
+++ b/src/services/factories/getTokenFromErc20.ts
@@ -1,4 +1,3 @@
-import { TokenDetails } from 'types'
 import { getErc20Info } from 'services/helpers'
 import { Erc20Api } from 'api/erc20/Erc20Api'
 import Web3 from 'web3'

--- a/src/services/factories/getTokenFromErc20.ts
+++ b/src/services/factories/getTokenFromErc20.ts
@@ -3,6 +3,8 @@ import { getErc20Info } from 'services/helpers'
 import { Erc20Api } from 'api/erc20/Erc20Api'
 import Web3 from 'web3'
 import { logDebug } from 'utils'
+import { TokenErc20 } from '@gnosis.pm/dex-js'
+// import { TokenErc20 } from '@gnosis.pm/dex-js'
 
 interface Params {
   erc20Api: Erc20Api
@@ -14,10 +16,8 @@ export interface TokenFromErc20Params {
   networkId: number
 }
 
-export type TokenFromErc20 = Omit<TokenDetails, 'id'> | null
-
 export function getTokenFromErc20Factory(closureParams: Params) {
-  return async (params: TokenFromErc20Params): Promise<TokenFromErc20> => {
+  return async (params: TokenFromErc20Params): Promise<TokenErc20 | null> => {
     // Get base info from the ERC20 contract
     const erc20Info = await getErc20Info({ ...closureParams, ...params })
     if (!erc20Info) {

--- a/src/services/factories/getTokenFromExchange.ts
+++ b/src/services/factories/getTokenFromExchange.ts
@@ -6,14 +6,15 @@ import { getToken } from 'utils'
 import { Erc20Api } from 'api/erc20/Erc20Api'
 import { ExchangeApi } from 'api/exchange/ExchangeApi'
 import { TokenList } from 'api/tokenList/TokenListApi'
-import { TokenFromErc20Params, TokenFromErc20 } from './'
+import { TokenFromErc20Params } from './'
+import { TokenErc20 } from '@gnosis.pm/dex-js'
 
 interface FactoryParams {
   tokenListApi: TokenList
   exchangeApi: ExchangeApi
   erc20Api: Erc20Api
   web3: Web3
-  getTokenFromErc20(params: TokenFromErc20Params): Promise<TokenFromErc20>
+  getTokenFromErc20(params: TokenFromErc20Params): Promise<TokenErc20 | null>
 }
 
 interface GetByAddressParams {

--- a/src/services/factories/tokenList.ts
+++ b/src/services/factories/tokenList.ts
@@ -5,13 +5,14 @@ import { TcrApi } from 'api/tcr/TcrApi'
 import { TokenDetails, Command } from 'types'
 import { logDebug, retry } from 'utils'
 
-import { TokenFromErc20Params, TokenFromErc20 } from './'
+import { TokenFromErc20Params } from './'
+import { TokenErc20 } from '@gnosis.pm/dex-js'
 
 export function getTokensFactory(factoryParams: {
   tokenListApi: TokenList
   exchangeApi: ExchangeApi
   tcrApi?: TcrApi
-  getTokenFromErc20: (params: TokenFromErc20Params) => Promise<TokenFromErc20>
+  getTokenFromErc20: (params: TokenFromErc20Params) => Promise<TokenErc20 | null>
 }): (networkId: number) => TokenDetails[] {
   const { tokenListApi, exchangeApi, tcrApi, getTokenFromErc20 } = factoryParams
 
@@ -103,7 +104,7 @@ export function getTokensFactory(factoryParams: {
     }
   }
 
-  async function getErc20DetailsOrAddress(networkId: number, tokenAddress: string): Promise<TokenFromErc20 | string> {
+  async function getErc20DetailsOrAddress(networkId: number, tokenAddress: string): Promise<TokenErc20 | string> {
     // Simple wrapper function to return original address instead of null for make logging easier
     const erc20Details = await getTokenFromErc20({ networkId, tokenAddress })
     return erc20Details || tokenAddress
@@ -161,7 +162,7 @@ export function getTokensFactory(factoryParams: {
         .map((token) => [token.address, token]),
     )
 
-    const promises: Promise<TokenFromErc20 | string>[] = []
+    const promises: Promise<TokenErc20 | string>[] = []
 
     // Go over all value (id) and key (tokenAddress) pairs registered on the contract
     addressesAndIds.forEach((id, tokenAddress) => {

--- a/src/services/helpers/getErc20Info.ts
+++ b/src/services/helpers/getErc20Info.ts
@@ -1,9 +1,9 @@
 import Web3 from 'web3'
 
-import { MinimalTokenDetails } from 'types'
 import { logDebug, silentPromise } from 'utils'
 import { DEFAULT_PRECISION } from 'const'
 import { Erc20Api } from 'api/erc20/Erc20Api'
+import { TokenErc20 } from '@gnosis.pm/dex-js'
 
 interface Params {
   tokenAddress: string
@@ -15,12 +15,7 @@ interface Params {
 /**
  * Fetches info for an arbitrary ERC20 token from given address
  */
-export async function getErc20Info({
-  tokenAddress,
-  networkId,
-  erc20Api,
-  web3,
-}: Params): Promise<MinimalTokenDetails | null> {
+export async function getErc20Info({ tokenAddress, networkId, erc20Api, web3 }: Params): Promise<TokenErc20 | null> {
   // First check whether given address is a contract
   const code = await web3.eth.getCode(tokenAddress)
   if (code === '0x') {

--- a/src/storybook/data/types.ts
+++ b/src/storybook/data/types.ts
@@ -1,5 +1,5 @@
+import { WithAddress, WithDecimals, WithId, WithSymbolAndName } from '@gnosis.pm/dex-js'
 import { Network } from 'types'
-import { TokenDetails } from 'types'
 
 export type NetworkMap = Record<keyof typeof Network, Network>
-export type DefaultTokenDetails = Required<Pick<TokenDetails, 'id' | 'name' | 'symbol' | 'address' | 'decimals'>>
+export type DefaultTokenDetails = Required<WithId & WithSymbolAndName & WithAddress & WithDecimals>

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,7 +3,7 @@ import { MultiTcrApiParams } from 'api/tcr/MultiTcrApi'
 import { DexPriceEstimatorParams } from 'api/dexPriceEstimator/DexPriceEstimatorApi'
 import { ContractDeploymentBlock } from 'api/exchange/ExchangeApi'
 import { Network } from 'types'
-import { TokenDetailsConfig } from '@gnosis.pm/dex-js'
+import { TokenDetailsConfigLegacy } from '@gnosis.pm/dex-js'
 
 export interface TokenSelection {
   sellToken: string
@@ -68,7 +68,7 @@ export interface Config {
   logoPath: string
   templatePath: string
   initialTokenSelection: TokenSelection
-  initialTokenList: TokenDetailsConfig[]
+  initialTokenList: TokenDetailsConfigLegacy[]
   tcr: MultiTcrConfig | NoTcrConfig
   dexPriceEstimator: DexPriceEstimatorConfig
   theGraphApi: TheGraphApiConfig

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ import BN from 'bn.js'
 import { TransactionReceipt } from 'web3-core'
 import { PendingFlux } from 'api/deposit/DepositApi'
 import { TokenOverride } from './config'
+import { TokenDex } from '@gnosis.pm/dex-js'
 
 export type Command = () => void
 export type Mutation<T> = (original: T) => T
@@ -15,21 +16,12 @@ export enum Network {
   Kovan = 42,
 }
 
-export interface MinimalTokenDetails {
-  address: string
-  symbol?: string
-  name?: string
-  decimals: number
-}
-
-export interface TokenDetails extends MinimalTokenDetails {
-  id: number
-  addressMainnet?: string
+export interface TokenDetails extends TokenDex {
   disabled?: boolean
   override?: TokenOverride
 }
 
-export interface TokenBalanceDetails extends TokenDetails {
+export interface BalanceDetails {
   exchangeBalance: BN
   pendingDeposit: PendingFlux
   pendingWithdraw: PendingFlux
@@ -39,6 +31,8 @@ export interface TokenBalanceDetails extends TokenDetails {
   totalExchangeBalance: BN
   immatureClaim?: boolean
 }
+
+export type TokenBalanceDetails = TokenDetails & BalanceDetails
 
 export interface WithTxOptionalParams {
   txOptionalParams?: TxOptionalParams

--- a/src/utils/display.tsx
+++ b/src/utils/display.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { TokenDetails, safeTokenName } from '@gnosis.pm/dex-js'
+import { TokenDex, safeTokenName } from '@gnosis.pm/dex-js'
 import { EtherscanLink } from 'components/common/EtherscanLink'
 
-export function displayTokenSymbolOrLink(token: TokenDetails): React.ReactNode | string {
+export function displayTokenSymbolOrLink(token: TokenDex): React.ReactNode | string {
   const displayName = safeTokenName(token)
   if (displayName.startsWith('0x')) {
     return <EtherscanLink type="token" identifier={token.address} />
@@ -10,7 +10,7 @@ export function displayTokenSymbolOrLink(token: TokenDetails): React.ReactNode |
   return displayName
 }
 
-export function symbolOrAddress(token: TokenDetails): string {
+export function symbolOrAddress(token: TokenDex): string {
   return token.symbol || token.address
 }
 
@@ -25,8 +25,8 @@ export function computeMarketProp({
   acceptedSeparators = ['-', '/', ''],
   inverseMarket = false,
 }: {
-  sellToken: TokenDetails
-  buyToken: TokenDetails
+  sellToken: TokenDex
+  buyToken: TokenDex
   acceptedSeparators?: string[]
   inverseMarket?: boolean
 }): string[] {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1637,10 +1637,8 @@
   dependencies:
     bn.js "^5.1.3"
 
-"@gnosis.pm/dex-js@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.7.1.tgz#1b399efabd12c1f8915171265558d84e518e6ca4"
-  integrity sha512-8IfhBhtn959ij0bz5ur0q4W17oa76+cO8OQqByqyRFnWAwcrBsfQ/hkfGeCdqpYotkhBdyoh72T5aA3zE0rckw==
+"@gnosis.pm/dex-js@file:.yalc/@gnosis.pm/dex-js":
+  version "0.6.0-addf229f"
   dependencies:
     "@gnosis.pm/dex-contracts" "^0.4.3"
     bignumber.js "^9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1637,8 +1637,10 @@
   dependencies:
     bn.js "^5.1.3"
 
-"@gnosis.pm/dex-js@file:.yalc/@gnosis.pm/dex-js":
-  version "0.6.0-addf229f"
+"@gnosis.pm/dex-js@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-js/-/dex-js-0.8.0.tgz#aa96a30d2c17efea121f160f54eca1e82a08dbcd"
+  integrity sha512-/IjDZOrMGaR2cyzkVGaXSvzkr8EADwEfpvkkVIziSlWVG853xpKK6OKB2lO2et9IOGRwTKniSLEjXnjn3a3K/g==
   dependencies:
     "@gnosis.pm/dex-contracts" "^0.4.3"
     bignumber.js "^9.0.0"


### PR DESCRIPTION
Addresses #1442 

This is a big refactor of the types. 
There was too many Token definitions. Now most of the token definitions are in `dex-js`

Also, addresses one annoying thing, that we declared `TokenDetails` in dex-js and dex-react, making it super confusing.
Now TokenDetail is only in dex-react. 

dex-js has TokenDex (former TokenDetail) and these other definitions:
```
export type TokenErc20 = WithSymbolAndName & WithAddress & WithDecimals
export type Token = TokenErc20 & WithAddressMainnetOpt & Partial<WithId>
export type TokenDex = TokenErc20 & WithAddressMainnetOpt & WithId
```

Depends on dex-js `v0.7.2` that shoud be tagged as soon as we merge https://github.com/gnosis/dex-js/pull/187


Also, I leave this for other PR because is 100% independent of this one: https://github.com/gnosis/dex-react/issues/1453
Here I just gave a name signaling the intent of changing the config so we don't use the `id` anymore.