### PR TITLE
[Smart Quote] Show buy sell fills

### DIFF
--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -11,7 +11,7 @@ import { EllipsisText } from 'components/common/EllipsisText'
 
 import { FoldableRowWrapper } from 'components/layout/SwapLayout/Card'
 
-import { isTradeSettled, divideBN, formatPercentage } from 'utils'
+import { isTradeSettled, divideBN, formatPercentage, getMarket } from 'utils'
 import { displayTokenSymbolOrLink } from 'utils/display'
 import { MEDIA } from 'const'
 
@@ -121,10 +121,22 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
     }
   }, [orderSellAmount, sellAmount, sellToken, sellTokenDecimals, type])
 
-  const market = useMemo(() => `${displayTokenSymbolOrLink(buyToken)}/${displayTokenSymbolOrLink(sellToken)}`, [
-    buyToken,
-    sellToken,
-  ])
+  const { baseToken } = getMarket({ sellToken, receiveToken: buyToken })
+  const sellTokenLabel = displayTokenSymbolOrLink(sellToken)
+  const buyTokenLabel = displayTokenSymbolOrLink(buyToken)
+
+  let side: string, baseTokenLabel: React.ReactNode, quoteTokenLabel: React.ReactNode, market: string
+  if (sellToken === baseToken) {
+    side = 'Sell'
+    baseTokenLabel = sellTokenLabel
+    quoteTokenLabel = buyTokenLabel
+    market = `${sellTokenLabel}/${buyTokenLabel}`
+  } else {
+    side = 'Buy'
+    baseTokenLabel = buyTokenLabel
+    quoteTokenLabel = sellTokenLabel
+    market = `${buyTokenLabel}/${sellTokenLabel}`
+  }
 
   // Do not display trades that are not settled
   return !isTradeSettled(trade) ? null : (
@@ -141,7 +153,7 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
           })
         }
       >
-        {market}
+        {market} ➡ {side}
       </td>
       <td
         data-label="Limit Price / Fill Price"
@@ -152,9 +164,9 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
           },
         )}`}
       >
-        {invertedLimitPrice ? formatPrice(invertedLimitPrice) : 'N/A'}
+        {invertedLimitPrice ? formatPrice(invertedLimitPrice) : 'N/A'} {quoteTokenLabel}
         <br />
-        {formatPrice(invertedFillPrice)}
+        {formatPrice(invertedFillPrice)} {quoteTokenLabel}
       </td>
       <td
         data-label="Sold / Bought"
@@ -164,9 +176,8 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
           precision: sellTokenDecimals,
         })} / ${formatAmountFull({ amount: buyAmount, precision: buyTokenDecimals })}`}
       >
-        {formatSmart({ amount: sellAmount, precision: sellTokenDecimals })} {displayTokenSymbolOrLink(sellToken)}
-        <br />
-        {formatSmart({ amount: buyAmount, precision: buyTokenDecimals })} {displayTokenSymbolOrLink(buyToken)}
+        {formatSmart({ amount: sellAmount, precision: sellTokenDecimals })} {sellTokenLabel} <br />
+        {formatSmart({ amount: buyAmount, precision: buyTokenDecimals })} {buyTokenLabel}
       </td>
       <td data-label="Type" title={typeColumnTitle}>
         <TypePill tradeType={type}>{type}</TypePill>

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -206,7 +206,7 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
       </td>
       <td data-label="Market" className="showResponsive">
         <SwapIcon swap={(): void => setIsPriceInverted(!isPriceInverted)} />{' '}
-        <a
+        <span
           onClick={(): void =>
             onCellClick({
               target: { value: market },
@@ -214,7 +214,7 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
           }
         >
           {market}
-        </a>{' '}
+        </span>{' '}
         ➡ {side}
       </td>
       <td

--- a/src/components/common/SwapPrice.tsx
+++ b/src/components/common/SwapPrice.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { displayTokenSymbolOrLink, symbolOrAddress } from 'utils/display'
+import { displayTokenSymbolOrLink } from 'utils/display'
 import { EllipsisText } from 'components/common/EllipsisText'
 
 import { SwapIcon } from 'components/TradeWidget/SwapIcon'


### PR DESCRIPTION
Part of https://github.com/gnosis/dex-react/issues/1476

So now that have a smarter way to decide what market is the user viewing, we can use it also for the trades.
Actually, now we could bring the concept of "Side" of the trade.

The side of the trade would be if we are buying or selling.

This PR:
- [x] Shows the market as a canonical 
- [x] Decide if we are selling or buying: decide the side
- [x] Add units to the price
- [x] Allow to invert the market
- [x] Memoize, the whole thing :) 

![image](https://user-images.githubusercontent.com/2352112/95225773-6d30cd80-07fc-11eb-8224-22c22044e574.png)

If we invert the market, the user effectively selects a different QUOTE, change the price value and it's units. Also, the TRADE is being seen as a BUY if it was a SELL before, and the other way around:
![image](https://user-images.githubusercontent.com/2352112/95225909-a0735c80-07fc-11eb-9fe8-fcdaad584d03.png)


Future PRs could:
- Move "Side" to its own column. We could get inspiration in https://trade.dydx.exchange/ or our 2.0 designs. @W3stside could you help me with this one?
- Allow to invert the market (the whole row)
- We could consider not displaying 2 prices. Maybe we find a better
- Everything is more clear if we break Sold/Bought into 2 columns. And we called `Amount` and `Filled` for example. Check in other exchanges and our designs for v2.0

All pending tasks are defined in https://github.com/gnosis/dex-react/issues/1476