### PR TITLE
1336/tooltip date orders

### DIFF
--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -151,14 +151,19 @@ const Amounts: React.FC<AmountsProps> = ({ sellToken, order }) => {
 }
 
 const Expires: React.FC<Pick<Props, 'order' | 'pending' | 'isPendingOrder'>> = ({ order, isPendingOrder }) => {
-  const { isNeverExpires, expiresOn } = useMemo(() => {
+  const { isNeverExpires, expiresOn, expireDateLocal } = useMemo(() => {
     const isNeverExpires = isNeverExpiresOrder(order.validUntil) || (isPendingOrder && order.validUntil === 0)
     const expiresOn = isNeverExpires ? '' : formatDateFromBatchId(order.validUntil)
+    const expireDateLocal = batchIdToDate(order.validUntil).toLocaleString()
 
-    return { isNeverExpires, expiresOn }
+    return { isNeverExpires, expiresOn, expireDateLocal }
   }, [isPendingOrder, order.validUntil])
 
-  return <td data-label="Expires">{isNeverExpires ? <span>Never</span> : <span>{expiresOn}</span>}</td>
+  return (
+    <td data-label="Expires">
+      {isNeverExpires ? <span>Never</span> : <span title={expireDateLocal}>{expiresOn}</span>}
+    </td>
+  )
 }
 
 const OrderID: React.FC<Pick<MarketProps, 'onCellClick'> & { isPendingOrder: boolean; orderId: string }> = ({
@@ -191,8 +196,9 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
   const batchId = dateToBatchId(now)
   const msRemainingInBatch = getTimeRemainingInBatch({ inMilliseconds: true })
 
+  const validFromDate = batchIdToDate(order.validFrom)
   const isExpiredOrder = batchIdToDate(order.validUntil) <= now
-  const isScheduled = batchIdToDate(order.validFrom) > now
+  const isScheduled = validFromDate > now
   const isActiveNextBatch = batchId === order.validFrom
   const isFirstActiveBatch = batchId === order.validFrom + 1 && msRemainingInBatch > 60 * 1000 // up until minute 4
   const isUnlimited = order.isUnlimited
@@ -251,7 +257,7 @@ const Status: React.FC<Pick<Props, 'order' | 'isOverBalance' | 'transactionHash'
   }, [forceUpdate, isActiveNextBatch, isFirstActiveBatch])
 
   return (
-    <td className="status showResponsive" data-label="Status">
+    <td className="status showResponsive" data-label="Status" title={isScheduled ? validFromDate.toLocaleString() : ''}>
       {pending ? (
         pending
       ) : isFilled ? (

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -151,17 +151,17 @@ const Amounts: React.FC<AmountsProps> = ({ sellToken, order }) => {
 }
 
 const Expires: React.FC<Pick<Props, 'order' | 'pending' | 'isPendingOrder'>> = ({ order, isPendingOrder }) => {
-  const { isNeverExpires, expiresOn, expireDateLocal } = useMemo(() => {
+  const { isNeverExpires, expiresOn, expireDateFormatted } = useMemo(() => {
     const isNeverExpires = isNeverExpiresOrder(order.validUntil) || (isPendingOrder && order.validUntil === 0)
     const expiresOn = isNeverExpires ? '' : formatDateFromBatchId(order.validUntil)
-    const expireDateLocal = batchIdToDate(order.validUntil).toLocaleString()
+    const expireDateFormatted = batchIdToDate(order.validUntil).toLocaleString()
 
-    return { isNeverExpires, expiresOn, expireDateLocal }
+    return { isNeverExpires, expiresOn, expireDateFormatted }
   }, [isPendingOrder, order.validUntil])
 
   return (
     <td data-label="Expires">
-      {isNeverExpires ? <span>Never</span> : <span title={expireDateLocal}>{expiresOn}</span>}
+      {isNeverExpires ? <span>Never</span> : <span title={expireDateFormatted}>{expiresOn}</span>}
     </td>
   )
 }


### PR DESCRIPTION
Closes #1336 

Adds locale aware date strings on `Status` and `Expire` cells of Trade page showing full date

**Not sure if this is what we wanted?** the issue says like in `Trades` page but that date is the date of the order being filled, aka block timestamp. Is this what we want?

![Screenshot from 2020-10-07 20-19-59](https://user-images.githubusercontent.com/21335563/95371442-8019cf80-08da-11eb-9579-1870c42de7b8.png)
