### PR TITLE
Pending Orders: Order ID shown now as Spinner (prev. date timestamp)

### DIFF
--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -161,10 +161,15 @@ const Expires: React.FC<Pick<Props, 'order' | 'pending' | 'isPendingOrder'>> = (
   return <td data-label="Expires">{isNeverExpires ? <span>Never</span> : <span>{expiresOn}</span>}</td>
 }
 
-const OrderID: React.FC<Pick<MarketProps, 'onCellClick'> & { orderId: string }> = ({ orderId, onCellClick }) => (
+const OrderID: React.FC<Pick<MarketProps, 'onCellClick'> & { isPendingOrder: boolean; orderId: string }> = ({
+  orderId,
+  isPendingOrder,
+  onCellClick,
+}) => (
   <td
     data-label="Order ID"
-    onClick={(): void =>
+    onClick={(): false | void =>
+      !isPendingOrder &&
       onCellClick({
         target: {
           value: orderId,
@@ -172,7 +177,7 @@ const OrderID: React.FC<Pick<MarketProps, 'onCellClick'> & { orderId: string }> 
       })
     }
   >
-    <EllipsisText title={orderId}>{orderId}</EllipsisText>
+    {isPendingOrder ? <Spinner /> : <EllipsisText title={orderId}>{orderId}</EllipsisText>}
   </td>
 )
 
@@ -347,7 +352,7 @@ const OrderRow: React.FC<Props> = (props) => {
           pending={pending}
           disabled={disabled || isPendingOrder || pending}
         />
-        <OrderID orderId={order.id} onCellClick={onCellClick} />
+        <OrderID orderId={order.id} isPendingOrder={!!isPendingOrder} onCellClick={onCellClick} />
         <Market sellToken={sellToken} buyToken={buyToken} onCellClick={onCellClick} />
         <OrderDetails order={order} sellToken={sellToken} buyToken={buyToken} />
         <Amounts order={order} sellToken={sellToken} />


### PR DESCRIPTION
Shows a spinner for order id in Pending Orders instead of a date timestamp
![Screenshot from 2020-10-08 13-40-40](https://user-images.githubusercontent.com/21335563/95453863-e7339480-096b-11eb-9d5d-ff7a2b0cf47d.png)
