### PR TITLE
More linter rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   extends: [
+    'eslint:recommended',
     'plugin:react/recommended', // Uses the recommended rules from @eslint-plugin-react
     'plugin:@typescript-eslint/recommended', // Uses the recommended rules from @typescript-eslint/eslint-plugin
     'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,4 +45,9 @@ module.exports = {
   globals: {
     VERSION: true,
   },
+  env: {
+    browser: true,
+    node: true,
+    jest: true,
+  },
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -167,10 +167,11 @@ function createTcrApi(web3: Web3): TcrApi | undefined {
     case 'none':
       tcrApi = undefined
       break
-    case 'multi-tcr':
+    case 'multi-tcr': {
       const multiTcrApiConfig = CONFIG.tcr
       tcrApi = new MultiTcrApiProxy({ web3, ...multiTcrApiConfig.config })
       break
+    }
 
     default:
       throw new Error('Unknown implementation for DexPriceEstimatorApi: ' + type)

--- a/src/components/TokenOptionItem.tsx
+++ b/src/components/TokenOptionItem.tsx
@@ -176,7 +176,7 @@ const generateMessage = ({
     case TokenFromExchange.NOT_ERC20:
       return <>Not a valid ERC20 token</>
     // registered but not in list --> option to add
-    case TokenFromExchange.NOT_IN_TOKEN_LIST:
+    case TokenFromExchange.NOT_IN_TOKEN_LIST: {
       if (!token || !('id' in token)) return <>{defaultText}</>
 
       const handleAddToken: React.MouseEventHandler<HTMLButtonElement> = async (e) => {
@@ -201,6 +201,7 @@ const generateMessage = ({
           <button onClick={handleAddToken}>Add Token</button>
         </OptionItem>
       )
+    }
     default:
       return <>{defaultText}</>
   }

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -114,6 +114,7 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
           return `${fillPercentage} matched out of ${orderAmount} ${displayTokenSymbolOrLink(sellToken)}`
         }
       }
+      // falls through
       case 'liquidity':
       case 'unknown':
       default:

--- a/src/reducers-actions/orders.ts
+++ b/src/reducers-actions/orders.ts
@@ -114,12 +114,13 @@ export async function sideEffect(state: OrdersState, action: ReducerActionType):
   switch (action.type) {
     case 'OVERWRITE_ORDERS':
     case 'UPDATE_ORDERS':
-    case 'APPEND_ORDERS':
+    case 'APPEND_ORDERS': {
       const newTokenIdsFromOrders = new Set<number>()
 
       // orders can contain many duplicated tokenIds
       state.orders.forEach(({ sellTokenId, buyTokenId }) => newTokenIdsFromOrders.add(sellTokenId).add(buyTokenId))
 
       addUnlistedTokensToUserTokenListById(Array.from(newTokenIdsFromOrders))
+    }
   }
 }

--- a/src/reducers-actions/pendingOrders.ts
+++ b/src/reducers-actions/pendingOrders.ts
@@ -111,6 +111,7 @@ export const sideEffect = (state: PendingOrdersState, action: ReducerType): Pend
     case 'SAVE_PENDING_ORDERS':
     case 'REPLACE_PENDING_ORDERS':
       setStorageItem(STORAGE_PENDING_ORDER_KEY, state)
+    // falls through
     default:
       return state
   }

--- a/src/reducers-actions/trades.ts
+++ b/src/reducers-actions/trades.ts
@@ -134,7 +134,7 @@ function getPendingTrades(tradesByRevertKey: Map<string, Trade[]>): Map<string, 
 
   // Filter out trades in that range (curr ... curr -2).
   // The `revertKey` is composed by batchId|orderId, so this regex looks for the batchIds in the keys
-  const batchesRegex = new RegExp(`^(${currentBatchId}|${currentBatchId - 1}|${currentBatchId - 2})\\\|`)
+  const batchesRegex = new RegExp(`^(${currentBatchId}|${currentBatchId - 1}|${currentBatchId - 2})\\|`)
 
   const pending = new Map<string, Trade[]>()
 


### PR DESCRIPTION
Not having `switch case -- break`  broke #1517 This PR is so that doesn't happen again

- Adds `eslint:recommend` rules
- Fixes scoping in switch-case
- Fixes switch-case fallthrough
- Removes extra escaping in `RegExp`