### PR TITLE
1486.5/fix wrong tokens orders logic update

### DIFF
--- a/src/api/tokenList/TokenListApi.ts
+++ b/src/api/tokenList/TokenListApi.ts
@@ -20,6 +20,8 @@ const addOverrideToDisabledTokens = (networkId: number) => (token: TokenDetails)
 }
 
 export interface TokenList extends SubscriptionsInterface<TokenDetails[]> {
+  setListReady: (state: boolean) => void
+  isListReady: boolean
   getTokens: (networkId: number) => TokenDetails[]
   addToken: (params: AddTokenParams) => void
   addTokens: (params: AddTokensParams) => void
@@ -64,6 +66,10 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
   private _tokensByNetwork: { [networkId: number]: TokenDetails[] }
   private _tokenAddressNetworkSet: Set<string>
 
+  // token list flag - prevents stale/incorrect data
+  // from being presented during token list calculation
+  public isListReady = true
+
   public constructor({ networkIds, initialTokenList }: TokenListApiParams) {
     super()
 
@@ -91,6 +97,11 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
         )
       })
     })
+    console.log('[getTokenFromExchangeByIdFactory] tokens in API', this._tokensByNetwork)
+  }
+
+  public setListReady(state: boolean): void {
+    this.isListReady = state
   }
 
   public hasToken(params: HasTokenParams): boolean {

--- a/src/api/tokenList/TokenListApi.ts
+++ b/src/api/tokenList/TokenListApi.ts
@@ -97,7 +97,6 @@ export class TokenListApiImpl extends GenericSubscriptions<TokenDetails[]> imple
         )
       })
     })
-    console.log('[getTokenFromExchangeByIdFactory] tokens in API', this._tokensByNetwork)
   }
 
   public setListReady(state: boolean): void {

--- a/src/api/tokenList/TokenListApiMock.ts
+++ b/src/api/tokenList/TokenListApiMock.ts
@@ -5,6 +5,8 @@ import GenericSubscriptions from './Subscriptions'
 export class TokenListApiMock extends GenericSubscriptions<TokenDetails[]> implements TokenList {
   private _tokenList: TokenDetails[]
 
+  public isListReady = false
+
   public constructor(tokenList: TokenDetails[]) {
     super()
 
@@ -33,6 +35,10 @@ export class TokenListApiMock extends GenericSubscriptions<TokenDetails[]> imple
   public persistTokens({ tokenList }: PersistTokensParams): void {
     this._tokenList = tokenList
     this.triggerSubscriptions(tokenList)
+  }
+
+  public setListReady(state: boolean): void {
+    this.isListReady = state
   }
 }
 

--- a/src/components/OrderBookBtn.tsx
+++ b/src/components/OrderBookBtn.tsx
@@ -115,7 +115,7 @@ export const OrderBookBtn: React.FC<OrderBookBtnProps> = (props: OrderBookBtnPro
   const { baseToken: baseTokenDefault, quoteToken: quoteTokenDefault, label, className } = props
   const { networkIdOrDefault: networkId } = useWalletConnection()
   // get all tokens
-  const tokenList = useTokenList({ networkId })
+  const { tokens: tokenList } = useTokenList({ networkId })
   const [baseToken, setBaseToken] = useSafeState<TokenDetails>(baseTokenDefault)
   const [quoteToken, setQuoteToken] = useSafeState<TokenDetails>(quoteTokenDefault)
   const networkDescription = networkId !== Network.Mainnet ? ` (${getNetworkFromId(networkId)})` : ''

--- a/src/components/PoolingWidget/index.tsx
+++ b/src/components/PoolingWidget/index.tsx
@@ -151,7 +151,7 @@ const PoolingInterface: React.FC = () => {
 
   const { networkId, networkIdOrDefault, userAddress } = useWalletConnection()
   // Get all the tokens for the current network
-  const tokenList = useTokenList({ networkId: networkIdOrDefault })
+  const { tokens: tokenList } = useTokenList({ networkId: networkIdOrDefault })
 
   const tokens = useMemo(() => {
     return (

--- a/src/hooks/useManageTokens.tsx
+++ b/src/hooks/useManageTokens.tsx
@@ -148,7 +148,7 @@ const SearchInput: React.FC<SearchInputProps> = (props) => {
 const ManageTokensContainer: React.FC = () => {
   const { networkId, networkIdOrDefault } = useWalletConnection()
   // get all tokens
-  const tokens = useTokenList({ networkId })
+  const { tokens } = useTokenList({ networkId })
 
   const [search, setSearch] = useState('')
   const { value: debouncedSearch, setImmediate: setDebouncedSearch } = useDebounce(search, 500)

--- a/src/hooks/useOrders.ts
+++ b/src/hooks/useOrders.ts
@@ -37,7 +37,8 @@ export function useOrders(): Result {
   // to change in token list to trigger update of orders
   // and the incorrect state shown sometimes when loading app from
   // fresh state and seeing incorrect token list Issue #1486
-  const tokens = useTokenList({ networkId })
+  const { tokens, isListReady } = useTokenList({ networkId })
+
   // Pending Orders
   const pendingOrders = usePendingOrders()
 
@@ -57,7 +58,7 @@ export function useOrders(): Result {
     const fetchOrders = async (offset: number): Promise<void> => {
       // isLoading is the important one
       // controls ongoing fetching chain
-      if (!userAddress || !networkId || !isLoading) {
+      if (!userAddress || !networkId || !isLoading || !isListReady) {
         // next isLoading = true will be when userAddress and networkId are valid
         setIsLoading(false)
         return
@@ -121,7 +122,7 @@ export function useOrders(): Result {
       cancelled = true
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [offset, isLoading])
+  }, [offset, isLoading, isListReady])
 
   // allow to fresh start/refresh on demand
   const forceOrdersRefresh = useCallback((): void => {

--- a/src/hooks/useTokenBalances.ts
+++ b/src/hooks/useTokenBalances.ts
@@ -114,7 +114,7 @@ export const useTokenBalances = (passOnParams: Partial<UseTokenListParams> = {})
   const [error, setError] = useSafeState(false)
 
   // get all tokens, maybe without deprecated
-  const tokens = useTokenList({ networkId: walletInfo.networkId, ...passOnParams })
+  const { tokens } = useTokenList({ networkId: walletInfo.networkId, ...passOnParams })
 
   // Get token balances
   useEffect(() => {

--- a/src/hooks/useTokenList.ts
+++ b/src/hooks/useTokenList.ts
@@ -3,20 +3,25 @@ import { TokenDetails } from 'types'
 import useSafeState from './useSafeState'
 import { getTokens, subscribeToTokenList } from 'services'
 import { EMPTY_ARRAY } from 'const'
+import { tokenListApi } from 'api'
 
 export interface UseTokenListParams {
   networkId?: number
   excludeDeprecated?: boolean
 }
 
-export const useTokenList = ({ networkId, excludeDeprecated }: UseTokenListParams = {}): TokenDetails[] => {
+export const useTokenList = ({ networkId, excludeDeprecated }: UseTokenListParams = {}): {
+  tokens: TokenDetails[]
+  isListReady: boolean
+} => {
   // sync get tokenList
   const unfilteredTokens = networkId === undefined ? EMPTY_ARRAY : getTokens(networkId)
 
   const tokens = useMemo(() => {
     if (!excludeDeprecated) return unfilteredTokens
+    const filteredList = unfilteredTokens.filter((token) => !token.disabled)
 
-    return unfilteredTokens.filter((token) => !token.disabled)
+    return filteredList
   }, [excludeDeprecated, unfilteredTokens])
 
   // force update with a new value each time
@@ -26,5 +31,5 @@ export const useTokenList = ({ networkId, excludeDeprecated }: UseTokenListParam
     return subscribeToTokenList(() => forceUpdate({}))
   }, [forceUpdate])
 
-  return tokens
+  return { tokens, isListReady: tokenListApi.isListReady }
 }

--- a/src/pages/OrderBook.tsx
+++ b/src/pages/OrderBook.tsx
@@ -81,7 +81,7 @@ const OrderBookWrapper = styled.div`
 const OrderBook: React.FC = () => {
   const { networkIdOrDefault } = useWalletConnection()
   // get all tokens
-  const tokenList = useTokenList({ networkId: networkIdOrDefault })
+  const { tokens: tokenList } = useTokenList({ networkId: networkIdOrDefault })
   const [baseToken, setBaseToken] = useSafeState<TokenDetails | null>(null)
   const [quoteToken, setQuoteToken] = useSafeState<TokenDetails | null>(null)
   const [hops, setHops] = useSafeState(ORDER_BOOK_HOPS_DEFAULT)

--- a/src/services/factories/getTokenFromExchange.ts
+++ b/src/services/factories/getTokenFromExchange.ts
@@ -120,7 +120,14 @@ function getTokenFromExchangeByIdFactory(
   const { tokenListApi, exchangeApi, getTokenFromErc20 } = factoryParams
 
   return async ({ tokenId, networkId }: GetByIdParams): Promise<TokenDetails | null> => {
+    // Grab token list: either TCR or default token list
+    // if default token list is used, IDs need to be updated first
+    // or app will see strange data as wrong token IDs from config token list will be used
     const tokens = tokenListApi.getTokens(networkId)
+    // this will always return the initial config list first as it is injected
+    // early in the TokenListAPI constructor
+    // render 1: config list with incorrect IDs
+    // render 2: updated token list with correct IDs
 
     // Try from our current list of tokens, by id
     let token = getToken('id', tokenId, tokens)

--- a/src/services/factories/tokenList.ts
+++ b/src/services/factories/tokenList.ts
@@ -282,6 +282,10 @@ export function getTokensFactory(factoryParams: {
     areTokensUpdated.add(networkId)
 
     try {
+      // Set token list readiness to false
+      // and prevent stale data being presented in app
+      tokenListApi.setListReady(false)
+
       const numTokens = await retry(() => exchangeApi.getNumTokens(networkId))
       const tokens = tokenListApi.getTokens(networkId)
 
@@ -297,11 +301,14 @@ export function getTokensFactory(factoryParams: {
         // Otherwise, only update the ids
         await updateTokenIds(networkId, tokens)
       }
+
+      tokenListApi.setListReady(true)
     } catch (e) {
       // Failed to update after retries.
       logDebug(`[tokenListFactory][${networkId}] Failed to update tokens: ${e.message}`)
       // Clear flag so on next query we try again.
       areTokensUpdated.delete(networkId)
+      tokenListApi.setListReady(true)
     }
   }
 

--- a/src/services/factories/tokenList.ts
+++ b/src/services/factories/tokenList.ts
@@ -301,13 +301,12 @@ export function getTokensFactory(factoryParams: {
         // Otherwise, only update the ids
         await updateTokenIds(networkId, tokens)
       }
-
-      tokenListApi.setListReady(true)
     } catch (e) {
       // Failed to update after retries.
       logDebug(`[tokenListFactory][${networkId}] Failed to update tokens: ${e.message}`)
       // Clear flag so on next query we try again.
       areTokensUpdated.delete(networkId)
+    } finally {
       tokenListApi.setListReady(true)
     }
   }


### PR DESCRIPTION
Updates logic to avoid the flash of bad data

Still re-mounts data but at least doesn't show wrong numbers. Though I think the flag is probably a bad idea, it looks better. Maybe in the future we move everything to global state and use a flag `isDefault` list or something to let `useOrders` know not to render anything first time.

Thoughts @Velenir ?