### PR TITLE
Fix orderbook tokens reset

### DIFF
--- a/src/components/OrderBookBtn.tsx
+++ b/src/components/OrderBookBtn.tsx
@@ -120,14 +120,13 @@ export const OrderBookBtn: React.FC<OrderBookBtnProps> = (props: OrderBookBtnPro
   const [quoteToken, setQuoteToken] = useSafeState<TokenDetails>(quoteTokenDefault)
   const networkDescription = networkId !== Network.Mainnet ? ` (${getNetworkFromId(networkId)})` : ''
 
-  // Update if any of the base tokens change
-  useEffect(() => {
-    setBaseToken(baseTokenDefault)
-    setQuoteToken(quoteTokenDefault)
-  }, [baseTokenDefault, quoteTokenDefault, setBaseToken, setQuoteToken])
-
   const [modalHook, toggleModal] = useModal({
     ...DEFAULT_MODAL_OPTIONS,
+    onShow: () => {
+      // Update if any of the base tokens change
+      setBaseToken(baseTokenDefault)
+      setQuoteToken(quoteTokenDefault)
+    },
     onHide: () => {
       // Reset the selection on close
       setBaseToken(baseTokenDefault)

--- a/src/components/OrderBookBtn.tsx
+++ b/src/components/OrderBookBtn.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import Modal, { useModal } from 'components/common/Modal'
 


### PR DESCRIPTION
`useEffect` was triggered when unnecessary
Because tokens were recreated somewhere when they shouldn't have, which is a separate problem.