### PR TITLE
fix networkOrDefault type and typo

### DIFF
--- a/src/api/wallet/WalletApi.ts
+++ b/src/api/wallet/WalletApi.ts
@@ -67,7 +67,7 @@ export interface WalletApi {
 export interface WalletInfo {
   isConnected: boolean
   userAddress?: string
-  networkId?: number
+  networkId?: Network
   blockNumber?: number
 }
 

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -152,7 +152,7 @@ const TradeWidgetContainer: React.FC = () => {
   const sellTokenSymbol = decodeSymbol(encodedSellTokenSymbol || '')
   const receiveTokenSymbol = decodeSymbol(decodeReceiveTokenSymbol || '')
 
-  const { sellToken: initialSellTokenDefaultNetwork, buyToken: initialReceiveTokenDefaultNetwork } =
+  const { sellToken: initialSellTokenDefaultNetwork, receiveToken: initialReceiveTokenDefaultNetwork } =
     initialTokenSelection.networks[networkIdOrDefault] || {}
 
   const sellTokenWithFallback = useMemo(

--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -6,7 +6,7 @@ import { BlockchainUpdatePrompt, WalletInfo } from 'api/wallet/WalletApi'
 
 interface PendingStateObject extends WalletInfo {
   pending: true
-  networkIdOrDefault: number
+  networkIdOrDefault: Network
 }
 
 const PendingState: PendingStateObject = {
@@ -33,7 +33,7 @@ const constructPendingState = ({ chainId, account, blockHeader }: BlockchainUpda
 }
 
 export const useWalletConnection = ():
-  | (WalletInfo & { pending: false; networkIdOrDefault: number })
+  | (WalletInfo & { pending: false; networkIdOrDefault: Network })
   | PendingStateObject => {
   const [walletInfo, setWalletInfo] = useSafeState<WalletInfo | null>(null)
 


### PR DESCRIPTION
Fixes broken line using `buyToken` instead of `receiveToken` and assigns `Network` type to `networkIdOrDefault` inside `useWalletConnection`