### PR TITLE
[Smart Quote] TradesRow data rearrangement - swap Limit/Fill price and Sell/Bought column split

### DIFF
--- a/src/components/OrdersWidget/OrdersWidget.styled.ts
+++ b/src/components/OrdersWidget/OrdersWidget.styled.ts
@@ -95,6 +95,7 @@ export const OrdersForm = styled.div`
     display: flex;
     flex-flow: column nowrap;
     height: 100%;
+    width: 100%;
 
     @media ${MEDIA.tablet} {
       height: inherit;

--- a/src/components/TradeWidget/SwapIcon.tsx
+++ b/src/components/TradeWidget/SwapIcon.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 export const SwapIcon: React.FC<Props> = ({ swap = (): null => null }) => {
   return (
-    <Wrapper onClick={swap}>
+    <Wrapper className="swapIcon" onClick={swap}>
       <FontAwesomeIcon icon={faRetweet} />
     </Wrapper>
   )

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -23,6 +23,10 @@ const TradeRowFoldableWrapper = styled(FoldableRowWrapper)`
     &[data-label='Market'] {
       cursor: pointer;
     }
+
+    span.swapIcon {
+      margin-left: 0.4rem;
+    }
   }
 
   @media ${MEDIA.mobile} {
@@ -83,7 +87,6 @@ interface MarketAndPricesParams extends Pick<Trade, 'buyToken' | 'sellToken' | '
 }
 
 interface MarketAndPrices {
-  side: string
   quoteTokenLabel: React.ReactNode
   sellTokenLabel: React.ReactNode
   buyTokenLabel: React.ReactNode
@@ -104,14 +107,12 @@ function getMarketAndPrices(params: MarketAndPricesParams): MarketAndPrices {
   const buyTokenLabel = displayTokenSymbolOrLink(buyToken)
 
   const market = `${buyTokenLabel}/${sellTokenLabel}`
-  let side: string, quoteTokenLabel: React.ReactNode, limitPriceBN: BigNumber | undefined, fillPriceBN: BigNumber
+  let quoteTokenLabel: React.ReactNode, limitPriceBN: BigNumber | undefined, fillPriceBN: BigNumber
   if (sellToken === baseToken) {
-    side = 'Sell'
     quoteTokenLabel = buyTokenLabel
     limitPriceBN = limitPrice
     fillPriceBN = fillPrice
   } else {
-    side = 'Buy'
     quoteTokenLabel = sellTokenLabel
     limitPriceBN = (limitPrice && !limitPrice.isZero() && invertPrice(limitPrice)) || undefined
     fillPriceBN = invertPrice(fillPrice)
@@ -119,7 +120,6 @@ function getMarketAndPrices(params: MarketAndPricesParams): MarketAndPrices {
 
   return {
     market,
-    side,
     quoteTokenLabel,
     sellTokenLabel,
     buyTokenLabel,
@@ -214,10 +214,10 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
           decimals: 8,
         })}`}
       >
-        <SwapIcon swap={(): void => setIsPriceInverted(!isPriceInverted)} />{' '}
         {marketLimitPrice ? formatPrice(marketLimitPrice) : 'N/A'} {quoteTokenLabel}
         <br />
         {formatPrice(marketFillPrice)} {quoteTokenLabel}
+        <SwapIcon swap={(): void => setIsPriceInverted(!isPriceInverted)} />{' '}
       </td>
       <td
         data-label="Sold"

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -202,9 +202,6 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
   // Do not display trades that are not settled
   return !isTradeSettled(trade) ? null : (
     <TradeRowFoldableWrapper data-order-id={orderId} data-batch-id={batchId}>
-      <td data-label="Date" className="showResponsive" title={date.toLocaleString()}>
-        {formatDistanceStrict(date, new Date(), { addSuffix: true })}
-      </td>
       <td data-label="Market" className="showResponsive">
         <SwapIcon swap={(): void => setIsPriceInverted(!isPriceInverted)} />{' '}
         <span
@@ -230,14 +227,20 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
         {formatPrice(marketFillPrice)} {quoteTokenLabel}
       </td>
       <td
-        data-label="Sold / Bought"
+        data-label="Sold"
         className="showResponsive"
         title={`${formatAmountFull({
           amount: sellAmount,
           precision: sellTokenDecimals,
-        })} / ${formatAmountFull({ amount: buyAmount, precision: buyTokenDecimals })}`}
+        })}`}
       >
-        {formatSmart({ amount: sellAmount, precision: sellTokenDecimals })} {sellTokenLabel} <br />
+        {formatSmart({ amount: sellAmount, precision: sellTokenDecimals })} {sellTokenLabel}
+      </td>
+      <td
+        data-label="Bought"
+        className="showResponsive"
+        title={`${formatAmountFull({ amount: buyAmount, precision: buyTokenDecimals })}`}
+      >
         {formatSmart({ amount: buyAmount, precision: buyTokenDecimals })} {buyTokenLabel}
       </td>
       <td data-label="Type" title={typeColumnTitle}>
@@ -245,6 +248,9 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
       </td>
       <td data-label="Order ID" onClick={(): void => onCellClick({ target: { value: orderId } })}>
         <EllipsisText title={orderId}>{orderId}</EllipsisText>
+      </td>
+      <td data-label="Date" className="showResponsive" title={date.toLocaleString()}>
+        {formatDistanceStrict(date, new Date(), { addSuffix: true })}
       </td>
       <td data-label="View on Etherscan">
         <BlockExplorerLink type="event" identifier={txHash} networkId={networkId} />

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -13,9 +13,12 @@ import { FoldableRowWrapper } from 'components/layout/SwapLayout/Card'
 
 import { isTradeSettled, divideBN, formatPercentage, getMarket } from 'utils'
 import { displayTokenSymbolOrLink } from 'utils/display'
-import { MEDIA } from 'const'
+import { MEDIA, ONE_BIG_NUMBER, ONE_HUNDRED_BIG_NUMBER } from 'const'
 import { SwapIcon } from 'components/TradeWidget/SwapIcon'
 import BigNumber from 'bignumber.js'
+
+// minimum floor amount surplus must be greater than for it to display on frontend
+const SURPLUS_THRESHOLD = 0.1
 
 const TradeRowFoldableWrapper = styled(FoldableRowWrapper)`
   td {
@@ -26,6 +29,13 @@ const TradeRowFoldableWrapper = styled(FoldableRowWrapper)`
 
     span.swapIcon {
       margin-left: 0.4rem;
+    }
+
+    div.surplusHighlight {
+      color: var(--color-button-success);
+      font-size: smaller;
+      font-weight: bolder;
+      margin: 0.2rem 0;
     }
   }
 
@@ -47,6 +57,11 @@ const TradeRowFoldableWrapper = styled(FoldableRowWrapper)`
       }
     }
   }
+`
+
+const SplitHeaderTitle = styled.div`
+  display: flex;
+  flex-flow: column;
 `
 
 interface TradeRowProps {
@@ -91,9 +106,13 @@ interface MarketAndPrices {
   sellTokenLabel: React.ReactNode
   buyTokenLabel: React.ReactNode
   market: string
-  limitPrice: BigNumber | undefined
+  limitPrice?: BigNumber
   fillPrice: BigNumber
+  surplus?: number
 }
+
+const calcPercentage = (amount: BigNumber, divisor: BigNumber): BigNumber =>
+  ONE_HUNDRED_BIG_NUMBER.times(ONE_BIG_NUMBER.minus(amount.div(divisor)))
 
 function getMarketAndPrices(params: MarketAndPricesParams): MarketAndPrices {
   const { sellToken, buyToken, isPriceInverted, fillPrice, limitPrice } = params
@@ -105,6 +124,7 @@ function getMarketAndPrices(params: MarketAndPricesParams): MarketAndPrices {
 
   const sellTokenLabel = displayTokenSymbolOrLink(sellToken)
   const buyTokenLabel = displayTokenSymbolOrLink(buyToken)
+  const surplus = limitPrice && Math.abs(calcPercentage(limitPrice, fillPrice).toNumber())
 
   const market = `${buyTokenLabel}/${sellTokenLabel}`
   let quoteTokenLabel: React.ReactNode, limitPriceBN: BigNumber | undefined, fillPriceBN: BigNumber
@@ -125,6 +145,7 @@ function getMarketAndPrices(params: MarketAndPricesParams): MarketAndPrices {
     buyTokenLabel,
     limitPrice: limitPriceBN,
     fillPrice: fillPriceBN,
+    surplus,
   }
 }
 
@@ -181,6 +202,7 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
     buyTokenLabel,
     fillPrice: marketFillPrice,
     limitPrice: marketLimitPrice,
+    surplus,
   } = useMemo(
     () =>
       getMarketAndPrices({
@@ -208,15 +230,20 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
         </span>
       </td>
       <td
-        data-label="Limit Price / Fill Price"
-        title={`${marketLimitPrice ? formatPrice({ price: marketLimitPrice, decimals: 8 }) : 'N/A'} / ${formatPrice({
+        data-label="Fill Price"
+        title={formatPrice({
           price: marketFillPrice,
           decimals: 8,
-        })}`}
+        })}
       >
-        {marketLimitPrice ? formatPrice(marketLimitPrice) : 'N/A'} {quoteTokenLabel}
-        <br />
-        {formatPrice(marketFillPrice)} {quoteTokenLabel}
+        <SplitHeaderTitle>
+          <div>
+            {formatPrice(marketFillPrice)} {quoteTokenLabel}
+          </div>
+          {surplus && surplus > SURPLUS_THRESHOLD && (
+            <div className="surplusHighlight">+{surplus.toFixed(2)}% surplus</div>
+          )}
+        </SplitHeaderTitle>
         <SwapIcon swap={(): void => setIsPriceInverted(!isPriceInverted)} />{' '}
       </td>
       <td
@@ -241,6 +268,13 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
       </td>
       <td data-label="Order ID" onClick={(): void => onCellClick({ target: { value: orderId } })}>
         <EllipsisText title={orderId}>{orderId}</EllipsisText>
+      </td>
+      <td
+        data-label="Limit Price"
+        title={marketLimitPrice ? formatPrice({ price: marketLimitPrice, decimals: 8 }) : 'N/A'}
+      >
+        {marketLimitPrice ? formatPrice(marketLimitPrice) : 'N/A'} {quoteTokenLabel}
+        <SwapIcon swap={(): void => setIsPriceInverted(!isPriceInverted)} />{' '}
       </td>
       <td data-label="Date" className="showResponsive" title={date.toLocaleString()}>
         {formatDistanceStrict(date, new Date(), { addSuffix: true })}

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -103,21 +103,16 @@ function getMarketAndPrices(params: MarketAndPricesParams): MarketAndPrices {
   const sellTokenLabel = displayTokenSymbolOrLink(sellToken)
   const buyTokenLabel = displayTokenSymbolOrLink(buyToken)
 
-  let side: string,
-    quoteTokenLabel: React.ReactNode,
-    market: string,
-    limitPriceBN: BigNumber | undefined,
-    fillPriceBN: BigNumber
+  const market = `${buyTokenLabel}/${sellTokenLabel}`
+  let side: string, quoteTokenLabel: React.ReactNode, limitPriceBN: BigNumber | undefined, fillPriceBN: BigNumber
   if (sellToken === baseToken) {
     side = 'Sell'
     quoteTokenLabel = buyTokenLabel
-    market = `${sellTokenLabel}/${buyTokenLabel}`
     limitPriceBN = limitPrice
     fillPriceBN = fillPrice
   } else {
     side = 'Buy'
     quoteTokenLabel = sellTokenLabel
-    market = `${buyTokenLabel}/${sellTokenLabel}`
     limitPriceBN = (limitPrice && !limitPrice.isZero() && invertPrice(limitPrice)) || undefined
     fillPriceBN = invertPrice(fillPrice)
   }
@@ -180,7 +175,6 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
   const [isPriceInverted, setIsPriceInverted] = useState(false)
 
   const {
-    side,
     market,
     quoteTokenLabel,
     sellTokenLabel,
@@ -203,7 +197,6 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
   return !isTradeSettled(trade) ? null : (
     <TradeRowFoldableWrapper data-order-id={orderId} data-batch-id={batchId}>
       <td data-label="Market" className="showResponsive">
-        <SwapIcon swap={(): void => setIsPriceInverted(!isPriceInverted)} />{' '}
         <span
           onClick={(): void =>
             onCellClick({
@@ -211,9 +204,8 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
             })
           }
         >
-          {market}
-        </span>{' '}
-        ➡ {side}
+          Swap {sellTokenLabel} for {buyTokenLabel}
+        </span>
       </td>
       <td
         data-label="Limit Price / Fill Price"
@@ -222,6 +214,7 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
           decimals: 8,
         })}`}
       >
+        <SwapIcon swap={(): void => setIsPriceInverted(!isPriceInverted)} />{' '}
         {marketLimitPrice ? formatPrice(marketLimitPrice) : 'N/A'} {quoteTokenLabel}
         <br />
         {formatPrice(marketFillPrice)} {quoteTokenLabel}

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -171,11 +171,10 @@ export const InnerTradesWidget: React.FC<InnerTradesWidgetProps> = (props) => {
     <CardTable
       $rowSeparation="0"
       $gap="0 0.6rem"
-      $columns={`1fr 0.8fr minmax(6.6rem, 1fr) 1.2fr 6.5rem 5.5rem ${isTab ? 'minmax(9.3rem, 0.6fr)' : '0.74fr'}`}
+      $columns={`0.8fr minmax(6.6rem, 1fr) 1.2fr 1.2fr 6.5rem 5.5rem 1fr ${isTab ? 'minmax(9.3rem, 0.6fr)' : '0.74fr'}`}
     >
       <thead>
         <tr>
-          <th>Date</th>
           <th>Market</th>
           <th>
             <SplitHeaderTitle>
@@ -183,14 +182,11 @@ export const InnerTradesWidget: React.FC<InnerTradesWidgetProps> = (props) => {
               <span>Fill Price</span>
             </SplitHeaderTitle>
           </th>
-          <th>
-            <SplitHeaderTitle>
-              <span>Sold /</span>
-              <span>Bought</span>
-            </SplitHeaderTitle>
-          </th>
+          <th>Sold</th>
+          <th>Bought</th>
           <th>Type</th>
           <th>Order ID</th>
+          <th>Date</th>
           <th>
             <CsvButtonContainer>
               <span>Tx</span>

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -55,11 +55,6 @@ const CsvButtonContainer = styled.div`
   width: 75%;
 `
 
-const SplitHeaderTitle = styled.div`
-  display: flex;
-  flex-flow: column;
-`
-
 function csvTransformer(trade: Trade): CsvColumns {
   const {
     buyToken,
@@ -171,23 +166,19 @@ export const InnerTradesWidget: React.FC<InnerTradesWidgetProps> = (props) => {
     <CardTable
       $rowSeparation="0"
       $gap="0 0.6rem"
-      $columns={`minmax(11rem, 1fr) minmax(10rem, 1fr) 0.8fr 0.8fr 6.5rem 5.5rem 1fr ${
+      $columns={`minmax(12.8rem,1fr) minmax(12.3rem,1fr) repeat(2, minmax(7.8rem, 0.8fr)) 6.5rem 5.5rem minmax(12.3rem,1fr) minmax(5.1rem, 1fr) ${
         isTab ? 'minmax(9.3rem, 0.6fr)' : '0.74fr'
       }`}
     >
       <thead>
         <tr>
           <th></th>
-          <th>
-            <SplitHeaderTitle>
-              <span>Limit Price /</span>
-              <span>Fill Price</span>
-            </SplitHeaderTitle>
-          </th>
+          <th>Fill Price</th>
           <th>Sold</th>
           <th>Bought</th>
           <th>Type</th>
           <th>Order ID</th>
+          <th>Limit Price</th>
           <th>Date</th>
           <th>
             <CsvButtonContainer>

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -177,7 +177,7 @@ export const InnerTradesWidget: React.FC<InnerTradesWidgetProps> = (props) => {
     >
       <thead>
         <tr>
-          <th>Pair</th>
+          <th></th>
           <th>
             <SplitHeaderTitle>
               <span>Limit Price /</span>

--- a/src/components/TradesWidget/index.tsx
+++ b/src/components/TradesWidget/index.tsx
@@ -171,11 +171,13 @@ export const InnerTradesWidget: React.FC<InnerTradesWidgetProps> = (props) => {
     <CardTable
       $rowSeparation="0"
       $gap="0 0.6rem"
-      $columns={`0.8fr minmax(6.6rem, 1fr) 1.2fr 1.2fr 6.5rem 5.5rem 1fr ${isTab ? 'minmax(9.3rem, 0.6fr)' : '0.74fr'}`}
+      $columns={`minmax(11rem, 1fr) minmax(10rem, 1fr) 0.8fr 0.8fr 6.5rem 5.5rem 1fr ${
+        isTab ? 'minmax(9.3rem, 0.6fr)' : '0.74fr'
+      }`}
     >
       <thead>
         <tr>
-          <th>Market</th>
+          <th>Pair</th>
           <th>
             <SplitHeaderTitle>
               <span>Limit Price /</span>

--- a/src/components/layout/PageWrappers.tsx
+++ b/src/components/layout/PageWrappers.tsx
@@ -63,7 +63,6 @@ export const StandaloneCardWrapper = styled.div`
 `
 export const PageWrapper = styled.section`
   height: 75rem;
-  min-width: 85rem;
   max-width: 100%;
 
   background: var(--color-background-pageWrapper);
@@ -73,10 +72,6 @@ export const PageWrapper = styled.section`
   @media ${MEDIA.tablet}, ${MEDIA.mobile} {
     min-height: 35rem;
     height: auto;
-  }
-
-  @media ${MEDIA.tablet} {
-    min-width: 72.7rem;
   }
 
   @media ${MEDIA.mobile} {

--- a/src/components/layout/SwapLayout/index.tsx
+++ b/src/components/layout/SwapLayout/index.tsx
@@ -22,13 +22,21 @@ const Wrapper = styled.div`
   main {
     flex: 0 1 auto;
     margin: 2.4rem auto 5rem;
-    width: auto;
+    width: 100%;
     display: flex;
     flex-flow: row wrap;
     align-items: flex-start;
     justify-content: flex-start;
     font-size: 1.3rem;
     line-height: 1.2;
+
+    @media ${MEDIA.desktop} {
+      padding: 0 2%;
+    }
+
+    @media ${MEDIA.desktopLarge} {
+      padding: 0 10%;
+    }
 
     @media ${MEDIA.mobile} {
       width: 100%;

--- a/src/const.ts
+++ b/src/const.ts
@@ -79,6 +79,7 @@ export const MEDIA = {
   mediumScreenSmall: '850px',
   mediumEnd: '1024px',
   desktopScreen: '1025px',
+  desktopScreenLarge: '1366px',
   get tinyDown(): string {
     return `only screen and (max-width : ${this.tinyScreen})`
   },
@@ -99,6 +100,9 @@ export const MEDIA = {
   },
   get desktop(): string {
     return `only screen and (min-width : ${this.desktopScreen})`
+  },
+  get desktopLarge(): string {
+    return `only screen and (min-width: ${this.desktopScreenLarge})`
   },
   get tabletPortrait(): string {
     return `(min-device-width: ${this.smallScreenUp}) and (max-device-width: ${this.mediumEnd}) and (orientation: portrait)`

--- a/src/styles/variables.ts
+++ b/src/styles/variables.ts
@@ -109,7 +109,7 @@ const DarkColors = `
 
   /* Buttons */
   --color-button-primary: #e8e6e3;
-  --color-button-success: #91c591;
+  --color-button-success: #00BE2E;
   --color-button-disabled: #3d4043;
   --color-button-danger: #9c1818;
   --color-button-secondary: #696969;


### PR DESCRIPTION
Part of #1476 

Inside Orders > Trades

Splits `Sell/Bought` column into two separate columns
Changes `Market` with `WETH/DAI` to `Pair` with `Swap DAI for WETH`

SwapPrice comp on `Limit/Fill Price` column