### PR TITLE
[smart quote] Orders: rearrange data presentation like Trades

### DIFF
--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -73,22 +73,25 @@ interface MarketProps {
 }
 
 const Market: React.FC<MarketProps> = ({ sellToken, buyToken, onCellClick }) => {
-  const market = useMemo(() => `${displayTokenSymbolOrLink(buyToken)}/${displayTokenSymbolOrLink(sellToken)}`, [
-    buyToken,
-    sellToken,
-  ])
+  const labels = useMemo(
+    () => ({
+      label: `Swap ${displayTokenSymbolOrLink(buyToken)} for ${displayTokenSymbolOrLink(sellToken)}`,
+      market: `${displayTokenSymbolOrLink(buyToken)}/${displayTokenSymbolOrLink(sellToken)}`,
+    }),
+    [buyToken, sellToken],
+  )
   return (
     <td
       data-label="Market"
       onClick={(): void =>
         onCellClick({
           target: {
-            value: market,
+            value: labels.market,
           },
         })
       }
     >
-      {market}
+      {labels.label}
     </td>
   )
 }
@@ -125,20 +128,23 @@ const Amounts: React.FC<AmountsProps> = ({ sellToken, order }) => {
     sellToken.decimals,
   ])
 
+  let filledCellContent = 'no limit'
+  let totalCellContent = 'no limit'
+
+  if (!order.isUnlimited) {
+    filledCellContent = `${filledAmount} ${displayTokenSymbolOrLink(sellToken)}`
+    totalCellContent = `${totalAmount} ${displayTokenSymbolOrLink(sellToken)}`
+  }
+
   return (
-    <td data-label="Unfilled Amount">
-      {order.isUnlimited ? (
-        <span>no limit</span>
-      ) : (
-        <>
-          <div className="amounts">
-            {filledAmount} {displayTokenSymbolOrLink(sellToken)}
-            <br />
-            {totalAmount} {displayTokenSymbolOrLink(sellToken)}
-          </div>
-        </>
-      )}
-    </td>
+    <>
+      <td className="amounts" data-label="Filled Amount">
+        {filledCellContent}
+      </td>
+      <td className="amounts" data-label="Total Amount">
+        {totalCellContent}
+      </td>
+    </>
   )
 }
 
@@ -352,11 +358,11 @@ const OrderRow: React.FC<Props> = (props) => {
           pending={pending}
           disabled={disabled || isPendingOrder || pending}
         />
-        <OrderID orderId={order.id} isPendingOrder={!!isPendingOrder} onCellClick={onCellClick} />
         <Market sellToken={sellToken} buyToken={buyToken} onCellClick={onCellClick} />
         <OrderDetails price={price} sellToken={sellToken} buyToken={buyToken} />
         <Amounts order={order} sellToken={sellToken} />
         <Expires order={order} pending={pending} isPendingOrder={isPendingOrder} />
+        <OrderID orderId={order.id} isPendingOrder={!!isPendingOrder} onCellClick={onCellClick} />
         <Status
           order={order}
           isOverBalance={isOverBalance}

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -419,7 +419,7 @@ const OrdersWidget: React.FC<Props> = ({ displayOnly }) => {
               <div className="ordersContainer">
                 <CardWidgetWrapper className="widgetCardWrapper">
                   <CardTable
-                    $columns="3.2rem 5.5rem minmax(8.6rem, 0.3fr) repeat(2,1fr) minmax(5.2rem,0.6fr) minmax(8.6rem, 0.3fr)"
+                    $columns="3.2rem minmax(12.8rem,1fr) minmax(11rem,1fr) repeat(2, minmax(8rem, 0.5fr)) minmax(7.2rem,0.4fr) 5.5rem minmax(8.6rem,0.4fr)"
                     $gap="0 0.6rem"
                     $rowSeparation="0"
                   >
@@ -433,16 +433,18 @@ const OrdersWidget: React.FC<Props> = ({ displayOnly }) => {
                             disabled={deleting}
                           />
                         </th>
-                        <th>Order ID</th>
-                        <th>Market</th>
+                        {/* Token Pair Header (blank) */}
+                        <th />
                         <th>Limit price</th>
-                        <th className="filled">Filled / Total</th>
+                        <th className="filled">Filled</th>
+                        <th className="filled">Total</th>
                         <th
                           className="sortable"
                           onClick={(): void => setSortTopic((prev) => ({ ...prev, asc: !prev.asc }))}
                         >
                           Expires <FontAwesomeIcon size="xs" icon={!sortTopic.asc ? faChevronDown : faChevronUp} />
                         </th>
+                        <th>Order ID</th>
                         <th className="status">Status</th>
                       </tr>
                     </thead>


### PR DESCRIPTION
Part of #1476 

Rearranges Orders more like Trades:
1. splits `Filled/Total` columns
2. `Swap TokenA for TokenB` format
3. Horizontal scroll