### PR TITLE
App Error Handling: Incorrect Network

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import { encodeSymbol } from '@gnosis.pm/dex-js'
 import GlobalStyles from 'styles/global'
 import { ToastContainer } from 'setupToastify'
 
+import useNetworkCheck from 'hooks/useNetworkCheck'
+
 import { assertNonNull } from 'utils'
 
 // Main layout
@@ -132,47 +134,52 @@ function getInitialUrl(): string {
 const initialUrl = getInitialUrl()
 
 // App
-const App: React.FC = () => (
-  <>
-    <Router basename={process.env.BASE_URL}>
-      <Switch>
-        <Route path="/v2">
-          <TradingLayout>
-            <React.Suspense fallback={null}>
-              <Switch>
-                <Route path="/v2" exact component={Trading} />
-                <Route component={NotFound2} />
-              </Switch>
-            </React.Suspense>
-          </TradingLayout>
-        </Route>
-        <Route>
-          <SwapLayout>
-            <GlobalStyles />
-            <ToastContainer />
-            <React.Suspense fallback={null}>
-              <Switch>
-                <PrivateRoute path="/orders" exact component={Orders} />
-                <Route path="/trade/:buy-:sell" component={Trade} />
-                <PrivateRoute path="/liquidity" exact component={Strategies} />
-                <PrivateRoute path="/wallet" exact component={Wallet} />
-                <Route path="/about" exact component={About} />
-                <Route path="/faq" exact component={FAQ} />
-                <Route path="/book" exact component={OrderBook} />
-                <Route path="/connect-wallet" exact component={ConnectWallet} />
-                <Route path="/trades" exact component={Trades} />
-                <Route path="/settings" exact component={Settings} />
-                <Redirect from="/" to={initialUrl} />
-                <Route component={NotFound} />
-              </Switch>
-            </React.Suspense>
-          </SwapLayout>
-        </Route>
-      </Switch>
-    </Router>
-    {process.env.NODE_ENV === 'development' && <Console />}
-  </>
-)
+const App: React.FC = () => {
+  // Deal with incorrect network
+  useNetworkCheck()
+
+  return (
+    <>
+      <Router basename={process.env.BASE_URL}>
+        <Switch>
+          <Route path="/v2">
+            <TradingLayout>
+              <React.Suspense fallback={null}>
+                <Switch>
+                  <Route path="/v2" exact component={Trading} />
+                  <Route component={NotFound2} />
+                </Switch>
+              </React.Suspense>
+            </TradingLayout>
+          </Route>
+          <Route>
+            <SwapLayout>
+              <GlobalStyles />
+              <ToastContainer />
+              <React.Suspense fallback={null}>
+                <Switch>
+                  <PrivateRoute path="/orders" exact component={Orders} />
+                  <Route path="/trade/:buy-:sell" component={Trade} />
+                  <PrivateRoute path="/liquidity" exact component={Strategies} />
+                  <PrivateRoute path="/wallet" exact component={Wallet} />
+                  <Route path="/about" exact component={About} />
+                  <Route path="/faq" exact component={FAQ} />
+                  <Route path="/book" exact component={OrderBook} />
+                  <Route path="/connect-wallet" exact component={ConnectWallet} />
+                  <Route path="/trades" exact component={Trades} />
+                  <Route path="/settings" exact component={Settings} />
+                  <Redirect from="/" to={initialUrl} />
+                  <Route component={NotFound} />
+                </Switch>
+              </React.Suspense>
+            </SwapLayout>
+          </Route>
+        </Switch>
+      </Router>
+      {process.env.NODE_ENV === 'development' && <Console />}
+    </>
+  )
+}
 
 export default hot(
   withGlobalContext(

--- a/src/hooks/useNetworkCheck.tsx
+++ b/src/hooks/useNetworkCheck.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { ToastId } from 'react-toastify'
+import { toast } from 'toastify'
+
+import { useWalletConnection } from 'hooks/useWalletConnection'
+import useSafeState from 'hooks/useSafeState'
+
+import { Network } from 'types'
+
+const availableNetworks = CONFIG.exchangeContractConfig.config.map(({ networkId }) => networkId)
+
+const NetworkErrorMessage: React.FC = () => (
+  <div>
+    <div>Please switch to a supported network!</div>
+    <strong>{`${availableNetworks.map(
+      (id, idx, arr) => (idx === arr.length - 1 ? ' or ' : ' ') + Network[id],
+    )}`}</strong>
+    <br />
+    <br />
+    <div>
+      Click{' '}
+      <a href="https://github.com/gnosis/dex-react/wiki#-compatible-networks" target="_blank" rel="noreferrer">
+        here
+      </a>{' '}
+      for more information
+    </div>
+  </div>
+)
+
+function runCheckOnValidNetworks(networkId?: number): boolean {
+  if (!networkId) return true
+
+  return availableNetworks.includes(networkId)
+}
+
+const useNetworkCheck = (): void => {
+  const [currentNetworkId, setCurrentNetworkId] = useSafeState<Network | undefined>(undefined)
+  const [currentNetworkErrorId, setCurrentNetworkErrorId] = useSafeState<ToastId | undefined>(undefined)
+
+  const { networkId } = useWalletConnection()
+
+  const isValidOrNonNetwork = React.useMemo(() => runCheckOnValidNetworks(networkId), [networkId])
+
+  // User switched network, dismiss current error
+  React.useEffect(() => {
+    const isNewNetworkError = !isValidOrNonNetwork && currentNetworkId !== networkId
+
+    async function dealWithNewNetworkError(): Promise<void> {
+      if (isValidOrNonNetwork) {
+        if (currentNetworkErrorId) {
+          await toast.dismiss(currentNetworkErrorId)
+          setCurrentNetworkErrorId(undefined)
+        }
+      }
+
+      // Connected to a network but not one of the accepted ones
+      else if (isNewNetworkError) {
+        currentNetworkErrorId && (await toast.dismiss(currentNetworkErrorId))
+        const toastID = await toast.error(<NetworkErrorMessage />, {
+          autoClose: false,
+        })
+
+        ReactDOM.unstable_batchedUpdates(() => {
+          setCurrentNetworkId(networkId)
+          setCurrentNetworkErrorId(toastID)
+        })
+      }
+    }
+
+    dealWithNewNetworkError()
+  }, [
+    currentNetworkErrorId,
+    currentNetworkId,
+    isValidOrNonNetwork,
+    networkId,
+    setCurrentNetworkErrorId,
+    setCurrentNetworkId,
+  ])
+}
+
+export default useNetworkCheck

--- a/src/hooks/useNetworkCheck.tsx
+++ b/src/hooks/useNetworkCheck.tsx
@@ -19,7 +19,7 @@ const NetworkErrorMessage: React.FC = () => (
     <br />
     <div>
       Click{' '}
-      <a href="https://github.com/gnosis/dex-react/wiki#-compatible-networks" target="_blank" rel="noreferrer">
+      <a href="https://github.com/gnosis/dex-react/wiki#-compatible-networks" target="_blank" rel="noopener noreferrer">
         here
       </a>{' '}
       for more information


### PR DESCRIPTION
Closes #283 

Deals with incorrect network using CONFIG list's default accepted networks and uses `toast.error` pointing users to a our repo's wiki about networks.

**THE URL IN THE TOAST ERROR NEEDS TO POINT ELSEWHERE!! Right now it is pointing to THIS repo.**

Thoughts on toast approach?