### PR TITLE
[Smart Quote] Fix broken **limitPrice** amount

### DIFF
--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -674,14 +674,23 @@ const TradeWidget: React.FC<TradeWidgetProps> = ({
             isPriceInverted={isPriceInverted}
           />
           <PriceSuggestions
+            // Network
             networkId={networkIdOrDefault}
+            // Tokens
+            // Canonical market
             baseToken={baseToken}
             quoteToken={quoteToken}
+            // Keep original selling pair
+            receiveToken={receiveToken}
+            sellToken={sellToken}
+            // Amount
             amount={debouncedSellValue}
+            // Price inversion
             isPriceInverted={isPriceInverted}
+            onSwapPrices={swapPrices}
+            // Form inputIDs
             priceInputId={priceInputId}
             priceInverseInputId={priceInverseInputId}
-            onSwapPrices={swapPrices}
           />
           <OrderValidity
             validFromInputId={validFromId}


### PR DESCRIPTION
`usePriceEstimationWithSlippage` returns price in `quote` token (as it should) but the app wasn't inverting the price when `smart-quote` logic was running thus showing incorrect prices in FE

This fixes that.