### PR TITLE
1545 - Show percentage filled & fix incorrect market order in orders

### DIFF
--- a/src/components/OrdersWidget/OrderRow.styled.ts
+++ b/src/components/OrdersWidget/OrderRow.styled.ts
@@ -56,6 +56,11 @@ export const OrderRowWrapper = styled(FoldableRowWrapper)<{ $color?: string }>`
   }
 
   td {
+    &.column {
+      > div {
+        width: 100%;
+      }
+    }
     &[data-label='Order ID'],
     &[data-label='Market'] {
       cursor: pointer;

--- a/src/components/OrdersWidget/OrderRow.styled.ts
+++ b/src/components/OrdersWidget/OrderRow.styled.ts
@@ -5,6 +5,13 @@ import { MEDIA } from 'const'
 export const OrderRowWrapper = styled(FoldableRowWrapper)<{ $color?: string }>`
   color: ${({ $color = '' }): string => $color};
 
+  div.surplusHighlight {
+    color: var(--color-button-success);
+    font-size: smaller;
+    font-weight: bolder;
+    margin: 0.2rem 0;
+  }
+
   &.pending {
     background: rgba(33, 141, 255, 0.1);
   }

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -76,7 +76,7 @@ interface MarketProps {
 const Market: React.FC<MarketProps> = ({ sellToken, buyToken, onCellClick }) => {
   const labels = useMemo(
     () => ({
-      label: `Swap ${displayTokenSymbolOrLink(buyToken)} for ${displayTokenSymbolOrLink(sellToken)}`,
+      label: `Swap ${displayTokenSymbolOrLink(sellToken)} for ${displayTokenSymbolOrLink(buyToken)}`,
       market: `${displayTokenSymbolOrLink(buyToken)}/${displayTokenSymbolOrLink(sellToken)}`,
     }),
     [buyToken, sellToken],

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -148,8 +148,8 @@ const Amounts: React.FC<AmountsProps> = ({ sellToken, order }) => {
 
   return (
     <>
-      <td className="amounts" data-label="Filled Amount">
-        {filledCellContent}
+      <td className="amounts column" data-label="Filled Amount">
+        <div>{filledCellContent}</div>
         {amountFilled && <div className="surplusHighlight">{amountFilled}% filled</div>}
       </td>
       <td className="amounts" data-label="Total Amount">

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -141,10 +141,9 @@ const Amounts: React.FC<AmountsProps> = ({ sellToken, order }) => {
     // need to convert BN values to Bignumber for decimals math...
     const filledAmt = parseBigNumber(filledAmountBN.toString())
     const totalAmt = parseBigNumber(order.priceDenominator.toString())
-    const calculatable = filledAmt && totalAmt && !filledAmt.isZero()
-    // TS hates the above conditional statements, filledAmt and totalAmt are not NULL when calculatable passed ternary!
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    amountFilled = calculatable ? filledAmt!.div(totalAmt!).times('100').toFixed(2) : null
+    if (filledAmt && totalAmt && !filledAmt.isZero()) {
+      amountFilled = filledAmt.div(totalAmt).times('100').toFixed(2)
+    }
   }
 
   return (

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -18,7 +18,7 @@ import { SwapIcon } from 'components/TradeWidget/SwapIcon'
 import BigNumber from 'bignumber.js'
 
 // minimum floor amount surplus must be greater than for it to display on frontend
-const SURPLUS_THRESHOLD = 0.1
+const SURPLUS_THRESHOLD = 0.01
 
 const TradeRowFoldableWrapper = styled(FoldableRowWrapper)`
   td {

--- a/src/components/UserWallet/UserWallet.styled.ts
+++ b/src/components/UserWallet/UserWallet.styled.ts
@@ -54,12 +54,8 @@ const WalletButton = styled.button`
   font-size: 1.5rem;
   margin: 1.2rem 0;
   padding: 1rem 2rem;
-  width: calc(100% - 4rem);
   white-space: nowrap;
-
-  @media ${MEDIA.mobile} {
-    width: auto;
-  }
+  width: auto;
 `
 
 export const BlockExplorerButton = styled(WalletButton)`

--- a/src/components/common/SmartPrice.tsx
+++ b/src/components/common/SmartPrice.tsx
@@ -13,7 +13,10 @@ interface Props {
 
 export const SmartPrice: React.FC<Props> = ({ buyToken, sellToken, price: priceFraction }) => {
   const [isPriceInverted, setIsPriceInverted] = useState(false)
-  const { baseToken, quoteToken } = getMarket({ sellToken, receiveToken: buyToken })
+  const { baseToken, quoteToken } = useMemo(() => getMarket({ sellToken, receiveToken: buyToken }), [
+    buyToken,
+    sellToken,
+  ])
 
   const [price, priceInverse] = useMemo((): string[] => {
     const buyOrderPrice = calculatePrice({

--- a/src/components/layout/SwapLayout/Card/Card.tsx
+++ b/src/components/layout/SwapLayout/Card/Card.tsx
@@ -390,6 +390,10 @@ export const CardWidgetWrapper = styled(Widget)<{ $columns?: string }>`
           word-break: break-word;
           white-space: normal;
 
+          &.column {
+            flex-flow: column nowrap;
+          }
+
           @media ${MEDIA.mobile} {
             width: 100%;
             border-bottom: 0.1rem solid rgba(0, 0, 0, 0.14);


### PR DESCRIPTION
Closes #1545 

Shows percentage filled in orders like in trades

Also fixes the Swap TokenSell for TokenBuy bug as it was previously inverted 