### PR TITLE
[CSS Fixes] PoolingWidget smushed content on resize

### DIFF
--- a/src/components/PoolingWidget/PoolingWidget.styled.ts
+++ b/src/components/PoolingWidget/PoolingWidget.styled.ts
@@ -9,7 +9,7 @@ import { WrappedWidget } from 'components/TradeWidget/TradeWidget.styled'
 
 export const StepDescriptionWrapper = styled.div`
   width: 50%;
-  padding: 0 2.4rem 0 0;
+  padding: 0 1rem 0 0;
   box-sizing: border-box;
 
   .liqContent {
@@ -42,7 +42,6 @@ export const PoolingInterfaceWrapper = styled(WrappedWidget)`
     display: flex;
     flex-flow: column nowrap;
     padding: 2rem;
-    min-width: 51.4rem;
     max-width: 75rem;
 
     > h2 {

--- a/src/components/layout/SwapLayout/index.tsx
+++ b/src/components/layout/SwapLayout/index.tsx
@@ -35,7 +35,7 @@ const Wrapper = styled.div`
     }
 
     @media ${MEDIA.desktopLarge} {
-      padding: 0 10%;
+      padding: 0 7%;
     }
 
     @media ${MEDIA.mobile} {


### PR DESCRIPTION
Fixes several CSS fixes found on testing with help from @biocom 

PoolingWidget:
<img width="1230" alt="Screen Shot 2020-11-02 at 13 44 03" src="https://user-images.githubusercontent.com/21335563/97871982-910d0380-1d15-11eb-9d36-91673521d862.png">

TODO:

- [ ] test in browserstack safari