### PR TITLE
Use develop price estimator URL for develop branch and PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,7 @@ before_install:
   - sudo apt-get -y install python-pip python-dev
   - pip install awscli --upgrade --user
   # use production url for price estimator on master or tagged
-  - export PRICE_ESTIMATOR_URL=$([[
-    $TRAVIS_BRANCH = master || \
-    $TRAVIS_BRANCH = release/* || \
-    $TRAVIS_BRANCH = hotfix/* || \
-    $TRAVIS_TAG != "" ]] && echo "production" || echo "develop")
+  - export PRICE_ESTIMATOR_URL=$([[ $TRAVIS_BRANCH = master || $TRAVIS_BRANCH = release/* || $TRAVIS_BRANCH = hotfix/* || $TRAVIS_TAG != "" ]] && echo "production" || echo "develop")
   - echo "PRICE_ESTIMATOR_URL=$PRICE_ESTIMATOR_URL"
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
   - echo "TRAVIS_TAG=$TRAVIS_TAG"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ before_install:
   - pip install awscli --upgrade --user
   # use production url for price estimator on master or tagged
   - export PRICE_ESTIMATOR_URL=$([[ $TRAVIS_BRANCH = master || $TRAVIS_BRANCH = release/* || $TRAVIS_BRANCH = hotfix/* || $TRAVIS_TAG != "" ]] && echo "production" || echo "develop")
-  - echo "PRICE_ESTIMATOR_URL=$PRICE_ESTIMATOR_URL"
-  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
-  - echo "TRAVIS_TAG=$TRAVIS_TAG"
 before_deploy:
   # zip ./dist folder if tag IS present
   - if [[ $TRAVIS_TAG != "" && $IPFS_HASH = "" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ before_install:
     $TRAVIS_BRANCH = release/* || \
     $TRAVIS_BRANCH = hotfix/* || \
     $TRAVIS_TAG != "" ]] && echo "production" || echo "develop")
+  - echo "PRICE_ESTIMATOR_URL=$PRICE_ESTIMATOR_URL"
+  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
+  - echo "TRAVIS_TAG=$TRAVIS_TAG"
 before_deploy:
   # zip ./dist folder if tag IS present
   - if [[ $TRAVIS_TAG != "" && $IPFS_HASH = "" ]]; then


### PR DESCRIPTION
Address issue regarding the URL being used for the price estimator:
* Use develop price estimator URL for develop branch and PRs
* Use production only for master, hotfixes, releases and tags

The issue was, that the backslashes in a TRAVIS script expression were causing the URL to be set to `production` always.

Not it should be working as intended
