### PR TITLE
[Fixes] Warning rounding calculation error + remove smart format from receive amount

### DIFF
--- a/src/components/TradeWidget/TxMessage.tsx
+++ b/src/components/TradeWidget/TxMessage.tsx
@@ -267,14 +267,14 @@ export const TxMessage: React.FC<TxMessageProps> = ({ sellToken, receiveToken, n
 
   const baseProps = {
     baseTokenId: receiveToken.id,
+    baseTokenDecimals: receiveToken.decimals,
     quoteTokenId: sellToken.id,
+    quoteTokenDecimals: sellToken.decimals,
     networkId,
   }
 
   const { priceEstimation: fillPrice } = usePriceEstimationWithSlippage({
     ...baseProps,
-    baseTokenDecimals: baseToken.decimals,
-    quoteTokenDecimals: quoteToken.decimals,
     amount: sellTokenAmount,
   })
 

--- a/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
@@ -28,14 +28,16 @@ interface FormattedPrices {
 
 const LOW_PRICE_FLOOR = new BigNumber('0.0001')
 
-export function formatPriceToPrecision(price: BigNumber): string {
-  return price.gt(LOW_PRICE_FLOOR) ? price.toFixed(PRICE_ESTIMATION_PRECISION) : '< ' + LOW_PRICE_FLOOR.toString()
+export function formatPriceToPrecision(price: BigNumber, useThreshold = false): string {
+  return price.gt(LOW_PRICE_FLOOR) || !useThreshold
+    ? price.toFixed(PRICE_ESTIMATION_PRECISION)
+    : '< ' + LOW_PRICE_FLOOR.toString()
 }
 
 function getPriceFormatted(price: BigNumber | null, isPriceInverted: boolean): FormattedPrices {
   if (price) {
-    const inversePriceLabel = formatPriceToPrecision(invertPrice(price))
-    const priceLabel = formatPriceToPrecision(price)
+    const inversePriceLabel = formatPriceToPrecision(invertPrice(price), true)
+    const priceLabel = formatPriceToPrecision(price, true)
     const inversePriceValue = invertPrice(price).toString(10)
     const priceValue = price.toString(10)
 


### PR DESCRIPTION
Fixes calculation issues found in confirmation modal price impact and fixes smart formatting for small amounts in `Receive at least` input when using really low price and/or 0 sell amount