### PR TITLE
Remove push hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ storybook-static
 .jest-cache
 .eslint-cache
 .stylelint-cache
+tsconfig.tsbuildinfo
 
 cypress/videos
 cypress/screenshots

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
     - .eslint-cache
     - .jest-cache
 script:
+  - yarn check-types
   - yarn test-coverage
   - yarn build
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache:
     - .eslint-cache
     - .jest-cache
 script:
-  - yarn check-types
   - yarn test-coverage
   - yarn build
 before_install:

--- a/package.json
+++ b/package.json
@@ -26,12 +26,13 @@
     "build-storybook": "build-storybook",
     "docs": "start-storybook --docs",
     "build-docs": "build-storybook --docs",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit --incremental",
     "cypress": "cypress open"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run verify"
+      "pre-commit": "npm run verify",
+      "pre-push": "npm run check-types"
     }
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run verify",
-      "pre-push": "npm run check-types"
+      "pre-commit": "npm run verify"
     }
   },
   "author": "",


### PR DESCRIPTION
Now commiting is again super fast!
The problem is pushing is SLOW. I personally prefer to let travis fail, we already work in branches, and it saves so much time.

The linter already caches most of the issues, all the other should be catched in the "build" of travis.

I wouldn't add `yarn check-types` at all, I did it here in this PR, just for experimenting. We can leave it if our concern is we want to FAIL asap. But, I think it's better to leave that out

EDIT: Following @Velenir tip, I'll try with https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#faster-subsequent-builds-with-the---incremental-flag