### PR TITLE
Cache coverage tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
     - .eslint-cache
     - .jest-cache
 script:
-  - yarn test-coverage
+  - yarn test:coverage
   - yarn build
 before_install:
   # Needed to deploy pull request and releases

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "stats": "rimraf ./dist && NODE_ENV=production webpack --mode production --env.stats --profile --json > stats.json && webpack-bundle-analyzer ./stats.json ./dist",
     "test": "MOCK=true jest --cacheDirectory .jest-cache -o",
     "test:integration": "CYPRESS_BASE_URL=http://localhost:8081 start-server-and-test 'serve dist -s -l 8081' http://localhost:8081 'cypress run'",
-    "test-coverage": "MOCK=true jest --coverage && cat ./coverage/lcov.info | coveralls",
+    "test:coverage": "MOCK=true jest --coverage --cache --cacheDirectory .jest-cache && cat ./coverage/lcov.info | coveralls",
     "verify": "npm-run-all --parallel lint:* test",
     "format": "prettier --write \"src/**/*.ts?(x)\" \"src/**/*.js?(x)\"",
     "storybook": "BROWSER=NONE start-storybook -p 6006",


### PR DESCRIPTION
Adds coverage cache

I was unsure if it was safe to cache the coverage, but it looks like it works!
Same report, and the time goes does from 38s to 8s in my machine. Travis will be happy about this.

Try to run:

```bash
yarn test:coverage

# now again
yarn test:coverage

# now change any test

# now test again
yarn test:coverage
```