### PR TITLE
[1.6] Use limitPrice.eq(fillPrice) instead of string comparison in warning logic

### DIFF
--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -34,7 +34,7 @@ import { DetailedAuctionElement } from 'api/exchange/ExchangeApi'
 import { OrderRowWrapper } from 'components/OrdersWidget/OrderRow.styled'
 import { displayTokenSymbolOrLink } from 'utils/display'
 import { SmartPrice } from 'components/common/SmartPrice'
-import { DEFAULT_DECIMAL_PLACES } from 'const'
+import { DEFAULT_DECIMALS } from 'const'
 
 const PendingLink: React.FC<Pick<Props, 'transactionHash'>> = (props) => {
   const { transactionHash } = props
@@ -124,7 +124,7 @@ const Amounts: React.FC<AmountsProps> = ({ sellToken, order }) => {
 
     return {
       filledAmount:
-        formatSmart({ amount: filledAmount, precision: sellToken.decimals, decimals: DEFAULT_DECIMAL_PLACES }) || '0',
+        formatSmart({ amount: filledAmount, precision: sellToken.decimals, decimals: DEFAULT_DECIMALS }) || '0',
       filledAmountBN: filledAmount,
     }
   }, [order.priceDenominator, order.remainingAmount, sellToken.decimals])
@@ -133,7 +133,7 @@ const Amounts: React.FC<AmountsProps> = ({ sellToken, order }) => {
     () =>
       formatSmart({
         amount: order.priceDenominator,
-        decimals: DEFAULT_DECIMAL_PLACES,
+        decimals: DEFAULT_DECIMALS,
         precision: sellToken.decimals,
       }) || '0',
     [order.priceDenominator, sellToken.decimals],

--- a/src/components/OrdersWidget/OrderRow.tsx
+++ b/src/components/OrdersWidget/OrderRow.tsx
@@ -34,6 +34,7 @@ import { DetailedAuctionElement } from 'api/exchange/ExchangeApi'
 import { OrderRowWrapper } from 'components/OrdersWidget/OrderRow.styled'
 import { displayTokenSymbolOrLink } from 'utils/display'
 import { SmartPrice } from 'components/common/SmartPrice'
+import { DEFAULT_DECIMAL_PLACES } from 'const'
 
 const PendingLink: React.FC<Pick<Props, 'transactionHash'>> = (props) => {
   const { transactionHash } = props
@@ -121,13 +122,22 @@ const Amounts: React.FC<AmountsProps> = ({ sellToken, order }) => {
   const { filledAmount, filledAmountBN } = useMemo(() => {
     const filledAmount = order.priceDenominator.sub(order.remainingAmount)
 
-    return { filledAmount: formatSmart(filledAmount, sellToken.decimals) || '0', filledAmountBN: filledAmount }
+    return {
+      filledAmount:
+        formatSmart({ amount: filledAmount, precision: sellToken.decimals, decimals: DEFAULT_DECIMAL_PLACES }) || '0',
+      filledAmountBN: filledAmount,
+    }
   }, [order.priceDenominator, order.remainingAmount, sellToken.decimals])
 
-  const totalAmount = useMemo(() => formatSmart(order.priceDenominator, sellToken.decimals) || '0', [
-    order.priceDenominator,
-    sellToken.decimals,
-  ])
+  const totalAmount = useMemo(
+    () =>
+      formatSmart({
+        amount: order.priceDenominator,
+        decimals: DEFAULT_DECIMAL_PLACES,
+        precision: sellToken.decimals,
+      }) || '0',
+    [order.priceDenominator, sellToken.decimals],
+  )
 
   let filledCellContent = 'no limit'
   let totalCellContent = 'no limit'

--- a/src/components/OrdersWidget/index.tsx
+++ b/src/components/OrdersWidget/index.tsx
@@ -419,7 +419,7 @@ const OrdersWidget: React.FC<Props> = ({ displayOnly }) => {
               <div className="ordersContainer">
                 <CardWidgetWrapper className="widgetCardWrapper">
                   <CardTable
-                    $columns="3.2rem minmax(12.8rem,1fr) minmax(11rem,1fr) repeat(2, minmax(8rem, 0.5fr)) minmax(7.2rem,0.4fr) 5.5rem minmax(8.6rem,0.4fr)"
+                    $columns="3.2rem minmax(12.8rem,1fr) minmax(11rem,1fr) repeat(2, minmax(8rem, 0.5fr)) minmax(7.2rem,0.4fr) 5.5rem minmax(10.6rem,0.4fr)"
                     $gap="0 0.6rem"
                     $rowSeparation="0"
                   >

--- a/src/components/TradeWidget/TxMessage.tsx
+++ b/src/components/TradeWidget/TxMessage.tsx
@@ -282,6 +282,8 @@ export const TxMessage: React.FC<TxMessageProps> = ({ sellToken, receiveToken, n
     ...baseProps,
     limitPrice: sellToken === quoteToken ? price : priceInverse,
     fillPrice,
+    baseToken,
+    quoteToken,
   })
 
   const renderWarnings = React.useCallback(() => {

--- a/src/components/TradeWidget/TxMessage.tsx
+++ b/src/components/TradeWidget/TxMessage.tsx
@@ -265,25 +265,21 @@ export const TxMessage: React.FC<TxMessageProps> = ({ sellToken, receiveToken, n
   // Get canonical market
   const { baseToken, quoteToken } = useMemo(() => getMarket({ receiveToken, sellToken }), [receiveToken, sellToken])
 
-  const baseProps = {
+  const { priceEstimation: fillPrice } = usePriceEstimationWithSlippage({
     baseTokenId: receiveToken.id,
     baseTokenDecimals: receiveToken.decimals,
     quoteTokenId: sellToken.id,
     quoteTokenDecimals: sellToken.decimals,
-    networkId,
-  }
-
-  const { priceEstimation: fillPrice } = usePriceEstimationWithSlippage({
-    ...baseProps,
     amount: sellTokenAmount,
+    networkId,
   })
 
   const { priceImpactSmart, priceImpactClassName, priceImpactWarning } = usePriceImpact({
-    ...baseProps,
+    networkId,
     limitPrice: sellToken === quoteToken ? price : priceInverse,
     fillPrice,
-    baseToken,
-    quoteToken,
+    baseToken: receiveToken,
+    quoteToken: sellToken,
   })
 
   const renderWarnings = React.useCallback(() => {

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -301,7 +301,7 @@ const TradeWidget: React.FC<TradeWidgetProps> = ({
   useEffect(() => {
     if (priceValue && sellValue) {
       // If price is quoted in sell tokens, we use it, otherwise we use the inverse
-      const priceUsedForReceiveAmount = sellToken.address === quoteToken.address ? priceInverseValue : priceValue
+      const priceUsedForReceiveAmount = sellToken.address === quoteToken.address ? priceValue : priceInverseValue
       setValue(receiveInputId, calculateReceiveAmount(priceUsedForReceiveAmount, sellValue, receiveToken.decimals))
     }
   }, [
@@ -697,7 +697,7 @@ const TradeWidget: React.FC<TradeWidgetProps> = ({
             // SellAmount // Limit Price
             amount={debouncedSellValue}
             // Limit price needs to be shown as correct quote token
-            limitPrice={sellToken === quoteToken ? priceValue : priceInverseValue}
+            limitPrice={sellToken.address === quoteToken.address ? priceValue : priceInverseValue}
             // Price inversion
             isPriceInverted={isPriceInverted}
             onSwapPrices={swapPrices}

--- a/src/components/TradeWidget/index.tsx
+++ b/src/components/TradeWidget/index.tsx
@@ -301,10 +301,21 @@ const TradeWidget: React.FC<TradeWidgetProps> = ({
   useEffect(() => {
     if (priceValue && sellValue) {
       // If price is quoted in sell tokens, we use it, otherwise we use the inverse
-      const priceUsedForReceiveAmount = sellToken.address === quoteToken.address ? priceValue : priceInverseValue
-      setValue(receiveInputId, calculateReceiveAmount(priceUsedForReceiveAmount, sellValue))
+      const priceUsedForReceiveAmount = sellToken.address === quoteToken.address ? priceInverseValue : priceValue
+      setValue(receiveInputId, calculateReceiveAmount(priceUsedForReceiveAmount, sellValue, receiveToken.decimals))
     }
-  }, [isPriceInverted, quoteToken.address, sellToken.address, priceValue, priceInverseValue, setValue, sellValue])
+  }, [
+    isPriceInverted,
+    quoteToken.address,
+    sellToken.address,
+    priceValue,
+    priceInverseValue,
+    setValue,
+    sellValue,
+    quoteToken.decimals,
+    baseToken.decimals,
+    receiveToken.decimals,
+  ])
 
   const url = buildUrl({
     sell: sellValue,

--- a/src/components/TradeWidget/utils.ts
+++ b/src/components/TradeWidget/utils.ts
@@ -2,26 +2,26 @@ import { tokenListApi } from 'api'
 import { isAddress } from 'web3-utils'
 import { parseBigNumber, getToken } from 'utils'
 import { buildSearchQuery } from 'hooks/useQuery'
-import { encodeTokenSymbol } from '@gnosis.pm/dex-js'
+import { encodeTokenSymbol, formatAmount, parseAmount } from '@gnosis.pm/dex-js'
 
 import { BATCH_START_THRESHOLD } from './validationSchema'
 import { BATCH_TIME_IN_MS } from 'const'
 import { TokenDetails } from 'types'
-import { formatPriceWithFloor } from 'components/trade/PriceSuggestions/PriceSuggestionItem'
 
-export function calculateReceiveAmount(priceValue: string, sellValue: string): string {
+export function calculateReceiveAmount(priceValue: string, sellValue: string, precision: number): string {
   let receiveAmount = ''
   if (priceValue && sellValue) {
     const sellAmount = parseBigNumber(sellValue)
     const price = parseBigNumber(priceValue)
 
     if (sellAmount && price) {
-      const receiveBigNumber = sellAmount.dividedBy(price)
+      const receiveBigNumber = sellAmount.times(price)
+      const receiveAsBN = parseAmount(receiveBigNumber.toString(10), precision)
       // Format the "Receive at least" input amount same as PriceSuggestions price
       receiveAmount =
-        receiveBigNumber.isNaN() || !receiveBigNumber.isFinite()
+        !receiveAsBN || receiveBigNumber.isNaN() || !receiveBigNumber.isFinite()
           ? '0'
-          : formatPriceWithFloor(receiveBigNumber, { decimals: 18 })
+          : formatAmount({ amount: receiveAsBN, precision, decimals: precision, thousandSeparator: false })
     }
   }
 

--- a/src/components/TradeWidget/utils.ts
+++ b/src/components/TradeWidget/utils.ts
@@ -1,6 +1,6 @@
 import { tokenListApi } from 'api'
 import { isAddress } from 'web3-utils'
-import { parseBigNumber, getToken } from 'utils'
+import { parseBigNumber, getToken, amountToPrecisionDown } from 'utils'
 import { buildSearchQuery } from 'hooks/useQuery'
 import { encodeTokenSymbol } from '@gnosis.pm/dex-js'
 
@@ -16,12 +16,12 @@ export function calculateReceiveAmount(priceValue: string, sellValue: string, re
 
     if (sellAmount && price) {
       const receiveBigNumber = sellAmount.times(price)
-      const receiveAmountFormatted = receiveBigNumber.decimalPlaces(receiveTokenPrecision, 1)
+      const receiveAmountToPrecision = amountToPrecisionDown(receiveBigNumber, receiveTokenPrecision)
       // Format the "Receive at least" input amount same as PriceSuggestions price
       receiveAmount =
-        !receiveAmountFormatted || receiveAmountFormatted.isNaN() || !receiveAmountFormatted.isFinite()
+        receiveAmountToPrecision?.isNaN() || !receiveAmountToPrecision?.isFinite()
           ? '0'
-          : receiveAmountFormatted.toString(10)
+          : receiveAmountToPrecision.toString(10)
     }
   }
 

--- a/src/components/TradeWidget/utils.ts
+++ b/src/components/TradeWidget/utils.ts
@@ -2,13 +2,13 @@ import { tokenListApi } from 'api'
 import { isAddress } from 'web3-utils'
 import { parseBigNumber, getToken } from 'utils'
 import { buildSearchQuery } from 'hooks/useQuery'
-import { encodeTokenSymbol, formatAmount, parseAmount } from '@gnosis.pm/dex-js'
+import { encodeTokenSymbol } from '@gnosis.pm/dex-js'
 
 import { BATCH_START_THRESHOLD } from './validationSchema'
 import { BATCH_TIME_IN_MS } from 'const'
 import { TokenDetails } from 'types'
 
-export function calculateReceiveAmount(priceValue: string, sellValue: string, precision: number): string {
+export function calculateReceiveAmount(priceValue: string, sellValue: string, receiveTokenPrecision: number): string {
   let receiveAmount = ''
   if (priceValue && sellValue) {
     const sellAmount = parseBigNumber(sellValue)
@@ -16,12 +16,12 @@ export function calculateReceiveAmount(priceValue: string, sellValue: string, pr
 
     if (sellAmount && price) {
       const receiveBigNumber = sellAmount.times(price)
-      const receiveAsBN = parseAmount(receiveBigNumber.toString(10), precision)
+      const receiveAmountFormatted = receiveBigNumber.decimalPlaces(receiveTokenPrecision, 1)
       // Format the "Receive at least" input amount same as PriceSuggestions price
       receiveAmount =
-        !receiveAsBN || receiveBigNumber.isNaN() || !receiveBigNumber.isFinite()
+        !receiveAmountFormatted || receiveAmountFormatted.isNaN() || !receiveAmountFormatted.isFinite()
           ? '0'
-          : formatAmount({ amount: receiveAsBN, precision, decimals: precision, thousandSeparator: false })
+          : receiveAmountFormatted.toString(10)
     }
   }
 

--- a/src/components/TradeWidget/utils.ts
+++ b/src/components/TradeWidget/utils.ts
@@ -15,7 +15,7 @@ export function calculateReceiveAmount(priceValue: string, sellValue: string, re
     const price = parseBigNumber(priceValue)
 
     if (sellAmount && price) {
-      const receiveBigNumber = sellAmount.times(price)
+      const receiveBigNumber = sellAmount.div(price)
       const receiveAmountToPrecision = amountToPrecisionDown(receiveBigNumber, receiveTokenPrecision)
       // Format the "Receive at least" input amount same as PriceSuggestions price
       receiveAmount =

--- a/src/components/TradeWidget/utils.ts
+++ b/src/components/TradeWidget/utils.ts
@@ -7,7 +7,7 @@ import { encodeTokenSymbol } from '@gnosis.pm/dex-js'
 import { BATCH_START_THRESHOLD } from './validationSchema'
 import { BATCH_TIME_IN_MS } from 'const'
 import { TokenDetails } from 'types'
-import { formatPriceToPrecision } from 'components/trade/PriceSuggestions/PriceSuggestionItem'
+import { formatPriceWithFloor } from 'components/trade/PriceSuggestions/PriceSuggestionItem'
 
 export function calculateReceiveAmount(priceValue: string, sellValue: string): string {
   let receiveAmount = ''
@@ -19,7 +19,9 @@ export function calculateReceiveAmount(priceValue: string, sellValue: string): s
       const receiveBigNumber = sellAmount.dividedBy(price)
       // Format the "Receive at least" input amount same as PriceSuggestions price
       receiveAmount =
-        receiveBigNumber.isNaN() || !receiveBigNumber.isFinite() ? '0' : formatPriceToPrecision(receiveBigNumber)
+        receiveBigNumber.isNaN() || !receiveBigNumber.isFinite()
+          ? '0'
+          : formatPriceWithFloor(receiveBigNumber, { decimals: 18 })
     }
   }
 

--- a/src/components/TradeWidget/validationSchema.ts
+++ b/src/components/TradeWidget/validationSchema.ts
@@ -55,7 +55,15 @@ const schema = Joi.object({
       [REQUIRED]: 'Invalid sell amount',
       [GREATER]: 'Invalid sell amount',
     }),
-  receiveToken: Joi.number().unsafe().required(),
+  receiveToken: Joi.number()
+    .unsafe()
+    .greater(0)
+    .required()
+    .messages({
+      [BASE]: 'Invalid receive amount',
+      [REQUIRED]: 'Invalid receive amount',
+      [GREATER]: 'Invalid receive amount: adjust order parameters',
+    }),
   price: Joi.number()
     // allow unsafe JS numbers
     .unsafe()

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -14,7 +14,7 @@ import { FoldableRowWrapper } from 'components/layout/SwapLayout/Card'
 
 import { isTradeSettled, divideBN, formatPercentage, getMarket } from 'utils'
 import { displayTokenSymbolOrLink } from 'utils/display'
-import { DEFAULT_DECIMAL_PLACES, MEDIA, ONE_BIG_NUMBER, ONE_HUNDRED_BIG_NUMBER } from 'const'
+import { DEFAULT_DECIMALS, MEDIA, ONE_BIG_NUMBER, ONE_HUNDRED_BIG_NUMBER } from 'const'
 import { SwapIcon } from 'components/TradeWidget/SwapIcon'
 
 // minimum floor amount surplus must be greater than for it to display on frontend
@@ -238,7 +238,7 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
       >
         <SplitHeaderTitle>
           <div>
-            {formatPrice({ price: marketFillPrice, decimals: DEFAULT_DECIMAL_PLACES })} {quoteTokenLabel}
+            {formatPrice({ price: marketFillPrice, decimals: DEFAULT_DECIMALS })} {quoteTokenLabel}
           </div>
           {surplus && surplus > SURPLUS_THRESHOLD && (
             <div className="surplusHighlight">+{surplus.toFixed(2)}% surplus</div>
@@ -254,16 +254,14 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
           precision: sellTokenDecimals,
         })}`}
       >
-        {formatSmart({ amount: sellAmount, decimals: DEFAULT_DECIMAL_PLACES, precision: sellTokenDecimals })}{' '}
-        {sellTokenLabel}
+        {formatSmart({ amount: sellAmount, decimals: DEFAULT_DECIMALS, precision: sellTokenDecimals })} {sellTokenLabel}
       </td>
       <td
         data-label="Bought"
         className="showResponsive"
         title={`${formatAmountFull({ amount: buyAmount, precision: buyTokenDecimals })}`}
       >
-        {formatSmart({ amount: buyAmount, decimals: DEFAULT_DECIMAL_PLACES, precision: buyTokenDecimals })}{' '}
-        {buyTokenLabel}
+        {formatSmart({ amount: buyAmount, decimals: DEFAULT_DECIMALS, precision: buyTokenDecimals })} {buyTokenLabel}
       </td>
       <td data-label="Type" title={typeColumnTitle}>
         <TypePill tradeType={type}>{type}</TypePill>
@@ -275,7 +273,7 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
         data-label="Limit Price"
         title={marketLimitPrice ? formatPrice({ price: marketLimitPrice, decimals: 8 }) : 'N/A'}
       >
-        {marketLimitPrice ? formatPrice({ price: marketLimitPrice, decimals: DEFAULT_DECIMAL_PLACES }) : 'N/A'}{' '}
+        {marketLimitPrice ? formatPrice({ price: marketLimitPrice, decimals: DEFAULT_DECIMALS }) : 'N/A'}{' '}
         {quoteTokenLabel}
         <SwapIcon swap={(): void => setIsPriceInverted(!isPriceInverted)} />{' '}
       </td>

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { formatDistanceStrict } from 'date-fns'
+import BigNumber from 'bignumber.js'
 
 import { formatPrice, formatSmart, formatAmountFull, invertPrice, DEFAULT_PRECISION } from '@gnosis.pm/dex-js'
 
@@ -13,9 +14,8 @@ import { FoldableRowWrapper } from 'components/layout/SwapLayout/Card'
 
 import { isTradeSettled, divideBN, formatPercentage, getMarket } from 'utils'
 import { displayTokenSymbolOrLink } from 'utils/display'
-import { MEDIA, ONE_BIG_NUMBER, ONE_HUNDRED_BIG_NUMBER } from 'const'
+import { DEFAULT_DECIMAL_PLACES, MEDIA, ONE_BIG_NUMBER, ONE_HUNDRED_BIG_NUMBER } from 'const'
 import { SwapIcon } from 'components/TradeWidget/SwapIcon'
-import BigNumber from 'bignumber.js'
 
 // minimum floor amount surplus must be greater than for it to display on frontend
 const SURPLUS_THRESHOLD = 0.01
@@ -238,7 +238,7 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
       >
         <SplitHeaderTitle>
           <div>
-            {formatPrice(marketFillPrice)} {quoteTokenLabel}
+            {formatPrice({ price: marketFillPrice, decimals: DEFAULT_DECIMAL_PLACES })} {quoteTokenLabel}
           </div>
           {surplus && surplus > SURPLUS_THRESHOLD && (
             <div className="surplusHighlight">+{surplus.toFixed(2)}% surplus</div>
@@ -273,7 +273,8 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
         data-label="Limit Price"
         title={marketLimitPrice ? formatPrice({ price: marketLimitPrice, decimals: 8 }) : 'N/A'}
       >
-        {marketLimitPrice ? formatPrice(marketLimitPrice) : 'N/A'} {quoteTokenLabel}
+        {marketLimitPrice ? formatPrice({ price: marketLimitPrice, decimals: DEFAULT_DECIMAL_PLACES }) : 'N/A'}{' '}
+        {quoteTokenLabel}
         <SwapIcon swap={(): void => setIsPriceInverted(!isPriceInverted)} />{' '}
       </td>
       <td data-label="Date" className="showResponsive" title={date.toLocaleString()}>

--- a/src/components/TradesWidget/TradeRow.tsx
+++ b/src/components/TradesWidget/TradeRow.tsx
@@ -254,14 +254,16 @@ export const TradeRow: React.FC<TradeRowProps> = (params) => {
           precision: sellTokenDecimals,
         })}`}
       >
-        {formatSmart({ amount: sellAmount, precision: sellTokenDecimals })} {sellTokenLabel}
+        {formatSmart({ amount: sellAmount, decimals: DEFAULT_DECIMAL_PLACES, precision: sellTokenDecimals })}{' '}
+        {sellTokenLabel}
       </td>
       <td
         data-label="Bought"
         className="showResponsive"
         title={`${formatAmountFull({ amount: buyAmount, precision: buyTokenDecimals })}`}
       >
-        {formatSmart({ amount: buyAmount, precision: buyTokenDecimals })} {buyTokenLabel}
+        {formatSmart({ amount: buyAmount, decimals: DEFAULT_DECIMAL_PLACES, precision: buyTokenDecimals })}{' '}
+        {buyTokenLabel}
       </td>
       <td data-label="Type" title={typeColumnTitle}>
         <TypePill tradeType={type}>{type}</TypePill>

--- a/src/components/common/SmartPrice.tsx
+++ b/src/components/common/SmartPrice.tsx
@@ -5,7 +5,7 @@ import { Fraction, TokenDetails } from 'types'
 
 import { SwapPrice } from 'components/common/SwapPrice'
 import { amountToPrecisionUp, getMarket } from 'utils'
-import { DEFAULT_DECIMAL_PLACES } from 'const'
+import { DEFAULT_DECIMALS } from 'const'
 
 interface Props {
   buyToken: TokenDetails
@@ -53,7 +53,7 @@ export const SmartPrice: React.FC<Props> = ({ buyToken, sellToken, price: priceF
   const [priceDisplay, priceDisplayFull] = useMemo(
     // Decimals here refers to decimal places to show. Not a precision issue
     () => [
-      formatPrice({ price: priceDisplayed, decimals: DEFAULT_DECIMAL_PLACES }),
+      formatPrice({ price: priceDisplayed, decimals: DEFAULT_DECIMALS }),
       amountToPrecisionUp(priceDisplayed, (isPriceInverted ? baseToken : quoteToken).decimals).toString(10),
     ],
     [priceDisplayed, isPriceInverted, quoteToken, baseToken],

--- a/src/components/common/SmartPrice.tsx
+++ b/src/components/common/SmartPrice.tsx
@@ -33,7 +33,10 @@ export const SmartPrice: React.FC<Props> = ({ buyToken, sellToken, price: priceF
       price = buyOrderPriceInverse
       priceInverse = buyOrderPrice
     }
-    return [formatPrice(price), formatPrice(priceInverse)]
+
+    // set decimals to 5 places - default is 4 from @dex-js
+    // TODO: consider changing dex-js default to 5
+    return [formatPrice({ price, decimals: 5 }), formatPrice({ price: priceInverse, decimals: 5 })]
   }, [buyToken, sellToken, quoteToken, priceFraction])
 
   let priceDisplayed: string, quoteDisplayed: TokenDetails, baseDisplayed: TokenDetails

--- a/src/components/common/SmartPrice.tsx
+++ b/src/components/common/SmartPrice.tsx
@@ -4,7 +4,8 @@ import BigNumber from 'bignumber.js'
 import { Fraction, TokenDetails } from 'types'
 
 import { SwapPrice } from 'components/common/SwapPrice'
-import { getMarket } from 'utils'
+import { amountToPrecisionUp, getMarket } from 'utils'
+import { DEFAULT_DECIMAL_PLACES } from 'const'
 
 interface Props {
   buyToken: TokenDetails
@@ -51,8 +52,11 @@ export const SmartPrice: React.FC<Props> = ({ buyToken, sellToken, price: priceF
 
   const [priceDisplay, priceDisplayFull] = useMemo(
     // Decimals here refers to decimal places to show. Not a precision issue
-    () => [formatPrice({ price: priceDisplayed, decimals: 5 }), formatPrice({ price: priceDisplayed, decimals: 18 })],
-    [priceDisplayed],
+    () => [
+      formatPrice({ price: priceDisplayed, decimals: DEFAULT_DECIMAL_PLACES }),
+      amountToPrecisionUp(priceDisplayed, (isPriceInverted ? baseToken : quoteToken).decimals).toString(10),
+    ],
+    [priceDisplayed, isPriceInverted, quoteToken, baseToken],
   )
 
   return (

--- a/src/components/common/SmartPrice.tsx
+++ b/src/components/common/SmartPrice.tsx
@@ -1,5 +1,6 @@
 import { calculatePrice, formatPrice, invertPrice, safeTokenName } from '@gnosis.pm/dex-js'
 import React, { useMemo, useState } from 'react'
+import BigNumber from 'bignumber.js'
 import { Fraction, TokenDetails } from 'types'
 
 import { SwapPrice } from 'components/common/SwapPrice'
@@ -18,7 +19,7 @@ export const SmartPrice: React.FC<Props> = ({ buyToken, sellToken, price: priceF
     sellToken,
   ])
 
-  const [price, priceInverse] = useMemo((): string[] => {
+  const [price, priceInverse] = useMemo((): BigNumber[] => {
     const buyOrderPrice = calculatePrice({
       numerator: { amount: priceFraction.numerator, decimals: buyToken.decimals },
       denominator: { amount: priceFraction.denominator, decimals: sellToken.decimals },
@@ -34,12 +35,10 @@ export const SmartPrice: React.FC<Props> = ({ buyToken, sellToken, price: priceF
       priceInverse = buyOrderPrice
     }
 
-    // set decimals to 5 places - default is 4 from @dex-js
-    // TODO: consider changing dex-js default to 5
-    return [formatPrice({ price, decimals: 5 }), formatPrice({ price: priceInverse, decimals: 5 })]
+    return [price, priceInverse]
   }, [buyToken, sellToken, quoteToken, priceFraction])
 
-  let priceDisplayed: string, quoteDisplayed: TokenDetails, baseDisplayed: TokenDetails
+  let priceDisplayed: BigNumber, quoteDisplayed: TokenDetails, baseDisplayed: TokenDetails
   if (isPriceInverted) {
     priceDisplayed = priceInverse
     quoteDisplayed = baseToken
@@ -50,9 +49,15 @@ export const SmartPrice: React.FC<Props> = ({ buyToken, sellToken, price: priceF
     baseDisplayed = baseToken
   }
 
+  const [priceDisplay, priceDisplayFull] = useMemo(
+    // Decimals here refers to decimal places to show. Not a precision issue
+    () => [formatPrice({ price: priceDisplayed, decimals: 5 }), formatPrice({ price: priceDisplayed, decimals: 18 })],
+    [priceDisplayed],
+  )
+
   return (
-    <span title={`${priceDisplayed} ${safeTokenName(quoteDisplayed)} per ${safeTokenName(baseDisplayed)}`}>
-      {priceDisplayed}
+    <span title={`${priceDisplayFull} ${safeTokenName(quoteDisplayed)} per ${safeTokenName(baseDisplayed)}`}>
+      {priceDisplay}
       &nbsp;
       <SwapPrice
         baseToken={baseToken}

--- a/src/components/trade/PriceImpact/index.tsx
+++ b/src/components/trade/PriceImpact/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import BigNumber from 'bignumber.js'
 
 import { FormMessage } from 'components/common/FormMessage'
 import { HelpTooltip, HelpTooltipContainer } from 'components/Tooltip'
@@ -26,20 +25,15 @@ export const SimplePriceImpact: React.FC<SimplePriceImpactProps> = ({ className,
 )
 
 function PriceImpact(params: PriceImpactProps): React.ReactElement | null {
-  const {
-    baseToken: { id: baseTokenId },
-    quoteToken: { id: quoteTokenId, decimals },
-    fillPrice,
-    ...rest
-  } = params
+  const { baseToken, quoteToken, fillPrice, ...rest } = params
 
   const { priceImpactSmart, priceImpactWarning, priceImpactClassName } = usePriceImpact({
     ...rest,
     // Match limitPrice and fillPrice precision + force round down last digit
-    // Necessary for value comparison when calcilating warnings
-    fillPrice: fillPrice?.decimalPlaces(decimals, BigNumber.ROUND_DOWN) || null,
-    baseTokenId,
-    quoteTokenId,
+    // Necessary for value comparison when reunnint determinePriceWarnings function
+    fillPrice,
+    baseToken,
+    quoteToken,
   })
 
   return (

--- a/src/components/trade/PriceImpact/index.tsx
+++ b/src/components/trade/PriceImpact/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import BigNumber from 'bignumber.js'
 
 import { FormMessage } from 'components/common/FormMessage'
 import { HelpTooltip, HelpTooltipContainer } from 'components/Tooltip'
@@ -27,12 +28,16 @@ export const SimplePriceImpact: React.FC<SimplePriceImpactProps> = ({ className,
 function PriceImpact(params: PriceImpactProps): React.ReactElement | null {
   const {
     baseToken: { id: baseTokenId },
-    quoteToken: { id: quoteTokenId },
+    quoteToken: { id: quoteTokenId, decimals },
+    fillPrice,
     ...rest
   } = params
 
   const { priceImpactSmart, priceImpactWarning, priceImpactClassName } = usePriceImpact({
     ...rest,
+    // Match limitPrice and fillPrice precision + force round down last digit
+    // Necessary for value comparison when calcilating warnings
+    fillPrice: fillPrice?.decimalPlaces(decimals, BigNumber.ROUND_DOWN) || null,
     baseTokenId,
     quoteTokenId,
   })

--- a/src/components/trade/PriceImpact/index.tsx
+++ b/src/components/trade/PriceImpact/index.tsx
@@ -20,7 +20,7 @@ const PriceImpactTooltip: React.FC = () => (
 
 export const SimplePriceImpact: React.FC<SimplePriceImpactProps> = ({ className, impactAmount }) => (
   <BoldColourTag className={className}>
-    <HelpTooltip tooltip={<PriceImpactTooltip />} /> {impactAmount}%
+    <HelpTooltip tooltip={<PriceImpactTooltip />} /> {impactAmount}
   </BoldColourTag>
 )
 

--- a/src/components/trade/PriceImpact/index.tsx
+++ b/src/components/trade/PriceImpact/index.tsx
@@ -29,8 +29,6 @@ function PriceImpact(params: PriceImpactProps): React.ReactElement | null {
 
   const { priceImpactSmart, priceImpactWarning, priceImpactClassName } = usePriceImpact({
     ...rest,
-    // Match limitPrice and fillPrice precision + force round down last digit
-    // Necessary for value comparison when reunnint determinePriceWarnings function
     fillPrice,
     baseToken,
     quoteToken,

--- a/src/components/trade/PriceImpact/types.ts
+++ b/src/components/trade/PriceImpact/types.ts
@@ -1,6 +1,5 @@
 import BigNumber from 'bignumber.js'
 import { TokenDex } from '@gnosis.pm/dex-js'
-import { BestAskParams } from 'hooks/useBestAsk'
 
 export interface PriceImpactArgsBase {
   limitPrice?: string | null
@@ -9,6 +8,8 @@ export interface PriceImpactArgsBase {
 
 export interface PriceImpactArgs extends PriceImpactArgsBase {
   fillPrice: BigNumber | null
+  baseTokenDecimals: number
+  quoteTokenDecimals: number
 }
 
 export interface PriceImpactProps {
@@ -30,4 +31,4 @@ export interface UsePriceImpactReturn {
   priceImpactWarning: string | null
 }
 
-export type UsePriceImpactParams = BestAskParams & Pick<PriceImpactProps, 'limitPrice' | 'fillPrice'>
+export type UsePriceImpactParams = PriceImpactProps

--- a/src/components/trade/PriceImpact/types.ts
+++ b/src/components/trade/PriceImpact/types.ts
@@ -6,10 +6,8 @@ export interface PriceImpactArgsBase {
   bestAskPrice: BigNumber | null
 }
 
-export interface PriceImpactArgs extends PriceImpactArgsBase {
+export type PriceImpactArgs = PriceImpactArgsBase & {
   fillPrice: BigNumber | null
-  baseTokenDecimals: number
-  quoteTokenDecimals: number
 }
 
 export interface PriceImpactProps {

--- a/src/components/trade/PriceImpact/usePriceImpact.ts
+++ b/src/components/trade/PriceImpact/usePriceImpact.ts
@@ -6,6 +6,7 @@ import useBestAsk from 'hooks/useBestAsk'
 
 import { calculatePriceImpact, determinePriceWarning, getImpactColourClass } from './utils'
 import { UsePriceImpactParams, UsePriceImpactReturn } from './types'
+import { amountToPrecisionDown } from 'utils'
 
 function usePriceImpact(params: UsePriceImpactParams): UsePriceImpactReturn {
   const {
@@ -18,7 +19,7 @@ function usePriceImpact(params: UsePriceImpactParams): UsePriceImpactReturn {
 
   // Format fill price to quoteToken decimals
   // Facilitates comparing limit/fill price
-  const fillPrice = preFillPrice?.decimalPlaces(quoteTokenDecimals, 1) || null
+  const fillPrice = preFillPrice ? amountToPrecisionDown(preFillPrice, quoteTokenDecimals) : null
 
   const { bestAskPrice } = useBestAsk({
     networkId,

--- a/src/components/trade/PriceImpact/usePriceImpact.ts
+++ b/src/components/trade/PriceImpact/usePriceImpact.ts
@@ -11,7 +11,7 @@ import { amountToPrecisionDown } from 'utils'
 function usePriceImpact(params: UsePriceImpactParams): UsePriceImpactReturn {
   const {
     networkId,
-    baseToken: { id: baseTokenId, decimals: baseTokenDecimals },
+    baseToken: { id: baseTokenId },
     quoteToken: { id: quoteTokenId, decimals: quoteTokenDecimals },
     limitPrice,
     fillPrice: preFillPrice,
@@ -43,10 +43,7 @@ function usePriceImpact(params: UsePriceImpactParams): UsePriceImpactReturn {
     }
 
     // Calculate any applicable trade warnings
-    const priceImpactWarning = determinePriceWarning(
-      { limitPrice, fillPrice, bestAskPrice, baseTokenDecimals, quoteTokenDecimals },
-      priceImpact,
-    )
+    const priceImpactWarning = determinePriceWarning({ limitPrice, fillPrice, bestAskPrice }, priceImpact)
     // Dynamic class for styling
     const priceImpactClassName = getImpactColourClass(priceImpact)
 
@@ -55,7 +52,7 @@ function usePriceImpact(params: UsePriceImpactParams): UsePriceImpactReturn {
       priceImpactClassName,
       priceImpactWarning,
     }
-  }, [baseTokenDecimals, bestAskPrice, fillPrice, limitPrice, quoteTokenDecimals])
+  }, [bestAskPrice, fillPrice, limitPrice])
 }
 
 export default usePriceImpact

--- a/src/components/trade/PriceImpact/usePriceImpact.ts
+++ b/src/components/trade/PriceImpact/usePriceImpact.ts
@@ -1,12 +1,9 @@
-import BN from 'bn.js'
 import { useMemo } from 'react'
-import { formatSmart, parseAmount } from '@gnosis.pm/dex-js'
-
 import useBestAsk from 'hooks/useBestAsk'
 
 import { calculatePriceImpact, determinePriceWarning, getImpactColourClass } from './utils'
 import { UsePriceImpactParams, UsePriceImpactReturn } from './types'
-import { amountToPrecisionDown } from 'utils'
+import { amountToPrecisionDown, formatPercentage } from 'utils'
 
 function usePriceImpact(params: UsePriceImpactParams): UsePriceImpactReturn {
   const {
@@ -29,17 +26,13 @@ function usePriceImpact(params: UsePriceImpactParams): UsePriceImpactReturn {
 
   return useMemo(() => {
     const priceImpact = calculatePriceImpact({ bestAskPrice, limitPrice })
-    const priceImpactBN = priceImpact && (parseAmount(priceImpact.toString(), 4) as BN)
+
     // Smart format, if possible
     let priceImpactSmart: string
-    if (priceImpactBN && !priceImpactBN.isZero()) {
-      priceImpactSmart = formatSmart({
-        amount: priceImpactBN,
-        precision: 4,
-        smallLimit: '0.01',
-      })
+    if (priceImpact && !priceImpact.isZero()) {
+      priceImpactSmart = formatPercentage(priceImpact)
     } else {
-      priceImpactSmart = '0'
+      priceImpactSmart = '0%'
     }
 
     // Calculate any applicable trade warnings

--- a/src/components/trade/PriceImpact/usePriceImpact.ts
+++ b/src/components/trade/PriceImpact/usePriceImpact.ts
@@ -8,7 +8,17 @@ import { calculatePriceImpact, determinePriceWarning, getImpactColourClass } fro
 import { UsePriceImpactParams, UsePriceImpactReturn } from './types'
 
 function usePriceImpact(params: UsePriceImpactParams): UsePriceImpactReturn {
-  const { networkId, baseTokenId, quoteTokenId, limitPrice, fillPrice } = params
+  const {
+    networkId,
+    baseToken: { id: baseTokenId, decimals: baseTokenDecimals },
+    quoteToken: { id: quoteTokenId, decimals: quoteTokenDecimals },
+    limitPrice,
+    fillPrice: preFillPrice,
+  } = params
+
+  // Format fill price to quoteToken decimals
+  // Facilitates comparing limit/fill price
+  const fillPrice = preFillPrice?.decimalPlaces(quoteTokenDecimals, 1) || null
 
   const { bestAskPrice } = useBestAsk({
     networkId,
@@ -32,7 +42,10 @@ function usePriceImpact(params: UsePriceImpactParams): UsePriceImpactReturn {
     }
 
     // Calculate any applicable trade warnings
-    const priceImpactWarning = determinePriceWarning({ limitPrice, fillPrice, bestAskPrice }, priceImpact)
+    const priceImpactWarning = determinePriceWarning(
+      { limitPrice, fillPrice, bestAskPrice, baseTokenDecimals, quoteTokenDecimals },
+      priceImpact,
+    )
     // Dynamic class for styling
     const priceImpactClassName = getImpactColourClass(priceImpact)
 
@@ -41,7 +54,7 @@ function usePriceImpact(params: UsePriceImpactParams): UsePriceImpactReturn {
       priceImpactClassName,
       priceImpactWarning,
     }
-  }, [bestAskPrice, fillPrice, limitPrice])
+  }, [baseTokenDecimals, bestAskPrice, fillPrice, limitPrice, quoteTokenDecimals])
 }
 
 export default usePriceImpact

--- a/src/components/trade/PriceImpact/utils.ts
+++ b/src/components/trade/PriceImpact/utils.ts
@@ -59,9 +59,10 @@ const getImpactColourClass = (impact: BigNumber | null): string => {
 }
 
 function determinePriceWarning(params: PriceImpactArgs, impact: BigNumber | null): string | null {
-  const { limitPrice: limitPriceString, fillPrice, bestAskPrice } = params
+  const { limitPrice: limitPriceString, fillPrice, bestAskPrice, baseTokenDecimals, quoteTokenDecimals } = params
 
   const limitPrice = limitPriceString && parseBigNumber(limitPriceString)
+  const lowerPrecision = Math.min(baseTokenDecimals, quoteTokenDecimals)
 
   // No comparable prices, or user opting for suggested fill price
   // round values before comparing
@@ -73,7 +74,7 @@ function determinePriceWarning(params: PriceImpactArgs, impact: BigNumber | null
     !fillPrice ||
     !bestAskPrice ||
     // round to 5 places and check limit = fill
-    fillPrice.toFixed(12) === limitPrice.toFixed(12)
+    fillPrice.toFixed(lowerPrecision) === limitPrice.toFixed(lowerPrecision)
   )
     return null
 

--- a/src/components/trade/PriceImpact/utils.ts
+++ b/src/components/trade/PriceImpact/utils.ts
@@ -1,17 +1,17 @@
 import BigNumber from 'bignumber.js'
 
 import { parseBigNumber } from 'utils'
-import { ONE_HUNDRED_BIG_NUMBER, ONE_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
+import { ONE_BIG_NUMBER, ZERO_BIG_NUMBER } from 'const'
 import { PriceImpactArgs, PriceImpactArgsBase } from './types'
 
 // Limit as to where price colour changes
-const HIGH_PRICE_IMPACT_THRESHOLD = new BigNumber(5) // 5%
-const MID_PRICE_IMPACT_THRESHOLD = new BigNumber(3) // 3%
-const LOW_PRICE_IMPACT_THRESHOLD = ONE_BIG_NUMBER // 1%
+const HIGH_PRICE_IMPACT_THRESHOLD = new BigNumber('0.05') // 5%
+const MID_PRICE_IMPACT_THRESHOLD = new BigNumber('0.03') // 3%
+const LOW_PRICE_IMPACT_THRESHOLD = new BigNumber('0.01') // 1%
 // TODO: remove for slippage toggle
 // 0.5% placeholder slippage
-const HIGH_PLACEHOLDER_SLIPPAGE = new BigNumber(1.05) // 5%
-const MID_PLACEHOLDER_SLIPPAGE = new BigNumber(1.03) // 3%
+const HIGH_PLACEHOLDER_SLIPPAGE = new BigNumber('1.05') // 5%
+const MID_PLACEHOLDER_SLIPPAGE = new BigNumber('1.03') // 3%
 
 enum ImpactLevel {
   NONE,
@@ -115,7 +115,7 @@ function calculatePriceImpact({ limitPrice: limitPriceString, bestAskPrice }: Pr
   if (!bestAskPrice || !limitPrice) return null
 
   // PRICE_IMPACT = 100 - (BEST_ASK / LIMIT_PRICE * 100)
-  const impact = ONE_HUNDRED_BIG_NUMBER.minus(bestAskPrice.div(limitPrice).times(ONE_HUNDRED_BIG_NUMBER))
+  const impact = ONE_BIG_NUMBER.minus(bestAskPrice.div(limitPrice))
   return impact.lt(ZERO_BIG_NUMBER) ? ZERO_BIG_NUMBER : impact
 }
 

--- a/src/components/trade/PriceImpact/utils.ts
+++ b/src/components/trade/PriceImpact/utils.ts
@@ -63,18 +63,13 @@ function determinePriceWarning(params: PriceImpactArgs, impact: BigNumber | null
 
   const limitPrice = limitPriceString && parseBigNumber(limitPriceString)
 
-  // No comparable prices, or user opting for suggested fill price
-  // round values before comparing
-  if (
-    // if any of the limit/fill/bestAsk params are
-    // null or zero, return null
-    !limitPrice ||
-    limitPrice.isZero() ||
-    !fillPrice ||
-    !bestAskPrice
-  )
+  // No calculatable prices: stop early
+  if (!limitPrice || limitPrice.isZero() || !fillPrice || !bestAskPrice) {
     return null
+  }
 
+  // Limit price BigNumber === Fill price BigNumber - order is optimised, no warnings
+  const fillPriceMatchesLimitPrice = limitPrice.eq(fillPrice)
   // Is user's limit price less than the suggested fill price?
   const orderWontBeFullyExecuted = limitPrice.lt(fillPrice)
   // Is user's limit price less than suggested fill price AND best ask?
@@ -93,6 +88,9 @@ function determinePriceWarning(params: PriceImpactArgs, impact: BigNumber | null
     !isPriceAboveDeepMarketThreshold && limitPrice.gte(fillPrice.times(MID_PLACEHOLDER_SLIPPAGE))
 
   switch (true) {
+    // CASE 4 & 3: price matches fill price, orders goes ahead
+    case fillPriceMatchesLimitPrice:
+      return null
     // CASE 6: Limit price is GREATER THAN Fill price AND upper threshold 5%
     case isPriceAboveDeepMarketThreshold:
       return WARNINGS.DEEP_MARKET
@@ -104,7 +102,6 @@ function determinePriceWarning(params: PriceImpactArgs, impact: BigNumber | null
     // CASE 2
     case isPriceMidImpactAndExecutable:
       return WARNINGS.MAYBE_FULLY_EXECUTED
-    // CASE 4 & 3
     default:
       return null
   }

--- a/src/components/trade/PriceImpact/utils.ts
+++ b/src/components/trade/PriceImpact/utils.ts
@@ -59,10 +59,9 @@ const getImpactColourClass = (impact: BigNumber | null): string => {
 }
 
 function determinePriceWarning(params: PriceImpactArgs, impact: BigNumber | null): string | null {
-  const { limitPrice: limitPriceString, fillPrice, bestAskPrice, baseTokenDecimals, quoteTokenDecimals } = params
+  const { limitPrice: limitPriceString, fillPrice, bestAskPrice } = params
 
   const limitPrice = limitPriceString && parseBigNumber(limitPriceString)
-  const lowerPrecision = Math.min(baseTokenDecimals, quoteTokenDecimals)
 
   // No comparable prices, or user opting for suggested fill price
   // round values before comparing
@@ -72,9 +71,7 @@ function determinePriceWarning(params: PriceImpactArgs, impact: BigNumber | null
     !limitPrice ||
     limitPrice.isZero() ||
     !fillPrice ||
-    !bestAskPrice ||
-    // round to 5 places and check limit = fill
-    fillPrice.toFixed(lowerPrecision) === limitPrice.toFixed(lowerPrecision)
+    !bestAskPrice
   )
     return null
 
@@ -109,7 +106,7 @@ function determinePriceWarning(params: PriceImpactArgs, impact: BigNumber | null
       return WARNINGS.MAYBE_FULLY_EXECUTED
     // CASE 4 & 3
     default:
-      return ''
+      return null
   }
 }
 

--- a/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import BigNumber from 'bignumber.js'
 
-import { DEFAULT_DECIMAL_PLACES } from 'const'
+import { DEFAULT_DECIMALS } from 'const'
 import { invertPrice, TokenDex } from '@gnosis.pm/dex-js'
 
 import Spinner from 'components/common/Spinner'
@@ -49,12 +49,12 @@ function getPriceFormatted({
     // See description on amountToPrecisionDown for more details/examples
     const inversePriceValue = amountToPrecisionDown(
       invertPrice(price),
-      // if DEFAULT_DECIMAL_PLACES > someToken.decimals, show higher of the two
+      // if DEFAULT_DECIMALS > someToken.decimals, show higher of the two
       // why? long form is used for calculation so a smaller precision aka less decimals would break math
-      Math.max(baseTokenDecimals, DEFAULT_DECIMAL_PLACES),
+      Math.max(baseTokenDecimals, DEFAULT_DECIMALS),
     ).toString(10)
 
-    const priceValue = amountToPrecisionDown(price, Math.max(quoteTokenDecimals, DEFAULT_DECIMAL_PLACES)).toString(10)
+    const priceValue = amountToPrecisionDown(price, Math.max(quoteTokenDecimals, DEFAULT_DECIMALS)).toString(10)
 
     if (isPriceInverted) {
       // Price is inverted

--- a/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
@@ -44,19 +44,26 @@ interface GetPriceFormatted {
   qtDecimals: number
 }
 
-function getPriceFormatted({ price, isPriceInverted, btDecimals, qtDecimals }: GetPriceFormatted): FormattedPrices {
+function getPriceFormatted({ price, isPriceInverted }: GetPriceFormatted): FormattedPrices {
   if (price) {
     const inversePriceLabel = formatPriceWithFloor(invertPrice(price))
     const priceLabel = formatPriceWithFloor(price)
-    const inversePriceBN = parseAmount(invertPrice(price).toString(10), btDecimals) as BN
-    const priceValueBN = parseAmount(price.toString(10), qtDecimals) as BN
+    // Use full precision for accuracy and tightest price
+    const inversePriceBN = parseAmount(invertPrice(price).toString(10), 18) as BN
+    const priceValueBN = parseAmount(price.toString(10), 18) as BN
 
+    // Have to explicitly pass full precision when using object params
     const inversePriceValue = formatAmountFull({
       amount: inversePriceBN,
-      precision: btDecimals,
+      precision: 18,
       thousandSeparator: false,
     })
-    const priceValue = formatAmountFull({ amount: priceValueBN, precision: qtDecimals, thousandSeparator: false })
+    // Have to explicitly pass full precision when using object params
+    const priceValue = formatAmountFull({
+      amount: priceValueBN,
+      precision: 18,
+      thousandSeparator: false,
+    })
 
     if (isPriceInverted) {
       // Price is inverted

--- a/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
@@ -40,8 +40,6 @@ function formatPriceWithFloor(price: BigNumber): string {
 interface GetPriceFormatted {
   price: BigNumber | null
   isPriceInverted: boolean
-  btDecimals: number
-  qtDecimals: number
 }
 
 function getPriceFormatted({ price, isPriceInverted }: GetPriceFormatted): FormattedPrices {
@@ -99,8 +97,6 @@ export const PriceSuggestionItem: React.FC<Props> = (props) => {
   const { priceValue, inversePriceValue, priceLabel, inversePriceLabel } = getPriceFormatted({
     price,
     isPriceInverted,
-    btDecimals: baseToken.decimals,
-    qtDecimals: quoteToken.decimals,
   })
   const displayPrice = priceLabel === 'Infinity' || inversePriceLabel === 'Infinity' ? 'N/A' : priceLabel
   return (

--- a/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
@@ -6,7 +6,7 @@ import { invertPrice, TokenDex } from '@gnosis.pm/dex-js'
 
 import Spinner from 'components/common/Spinner'
 import { SwapPrice } from 'components/common/SwapPrice'
-import { formatPriceWithFloor } from 'utils'
+import { amountToPrecisionDown, formatPriceWithFloor } from 'utils'
 
 export interface Props {
   label: string
@@ -45,16 +45,16 @@ function getPriceFormatted({
     const priceLabel = formatPriceWithFloor(price)
 
     // Use long precision form for accuracy
-    // Use BigNumber's decimalPlaces(<# of decimal places to show>, ROUNDING_MODE)
     // Rounds away 0's
+    // See description on amountToPrecisionDown for more details/examples
+    const inversePriceValue = amountToPrecisionDown(
+      invertPrice(price),
+      // if DEFAULT_DECIMAL_PLACES > someToken.decimals, show higher of the two
+      // why? long form is used for calculation so a smaller precision aka less decimals would break math
+      Math.max(baseTokenDecimals, DEFAULT_DECIMAL_PLACES),
+    ).toString(10)
 
-    // ROUNDING_MODE [1] => Rounds towards zero
-    // 1. new BigNumber(0.0016600425).decimalPlaces(9,1).toString(10) => "0.001660042"
-    // 2. new BigNumber(0.0016600000).decimalPlaces(9,1).toString(10) => "0.00166"
-    const inversePriceValue = invertPrice(price)
-      .decimalPlaces(Math.max(baseTokenDecimals, DEFAULT_DECIMAL_PLACES), 1)
-      .toString(10)
-    const priceValue = price.decimalPlaces(Math.max(quoteTokenDecimals, DEFAULT_DECIMAL_PLACES), 1).toString(10)
+    const priceValue = amountToPrecisionDown(price, Math.max(quoteTokenDecimals, DEFAULT_DECIMAL_PLACES)).toString(10)
 
     if (isPriceInverted) {
       // Price is inverted

--- a/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestionItem.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import BigNumber from 'bignumber.js'
 
 import { PRICE_ESTIMATION_PRECISION } from 'const'
-import { invertPrice, TokenDex } from '@gnosis.pm/dex-js'
+import { formatAmount, invertPrice, parseAmount, TokenDex } from '@gnosis.pm/dex-js'
 
 import Spinner from 'components/common/Spinner'
 import { SwapPrice } from 'components/common/SwapPrice'
@@ -28,16 +28,26 @@ interface FormattedPrices {
 
 const LOW_PRICE_FLOOR = new BigNumber('0.0001')
 
-export function formatPriceToPrecision(price: BigNumber, useThreshold = false): string {
+interface FormatPriceOptions {
+  useThreshold?: boolean | undefined
+  decimals?: number | undefined
+}
+
+export function formatPriceWithFloor(
+  price: BigNumber,
+  { useThreshold = false, decimals = PRICE_ESTIMATION_PRECISION }: FormatPriceOptions,
+): string {
+  const priceAsBN = parseAmount(price.toString(10), 18)
   return price.gt(LOW_PRICE_FLOOR) || !useThreshold
-    ? price.toFixed(PRICE_ESTIMATION_PRECISION)
+    ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      formatAmount({ amount: priceAsBN!, precision: 18, decimals })
     : '< ' + LOW_PRICE_FLOOR.toString()
 }
 
 function getPriceFormatted(price: BigNumber | null, isPriceInverted: boolean): FormattedPrices {
   if (price) {
-    const inversePriceLabel = formatPriceToPrecision(invertPrice(price), true)
-    const priceLabel = formatPriceToPrecision(price, true)
+    const inversePriceLabel = formatPriceWithFloor(invertPrice(price), { useThreshold: true })
+    const priceLabel = formatPriceWithFloor(price, { useThreshold: true })
     const inversePriceValue = invertPrice(price).toString(10)
     const priceValue = price.toString(10)
 

--- a/src/components/trade/PriceSuggestions/PriceSuggestionWidget.tsx
+++ b/src/components/trade/PriceSuggestions/PriceSuggestionWidget.tsx
@@ -41,7 +41,7 @@ export const PriceSuggestionWidget: React.FC<Props> = (props) => {
   const { setValue, trigger } = useFormContext<TradeFormData>()
 
   const updatePrices = useCallback(
-    (price: string, invertedPrice) => {
+    async (price: string, invertedPrice) => {
       if (isPriceInverted) {
         setValue(priceInverseInputId, price)
         setValue(priceInputId, invertedPrice)
@@ -49,9 +49,12 @@ export const PriceSuggestionWidget: React.FC<Props> = (props) => {
         setValue(priceInputId, price)
         setValue(priceInverseInputId, invertedPrice)
       }
-      trigger()
+      // stupid hack to fix validation
+      // otherwise trigger doesnt validate properly the new values
+      await new Promise((accept) => setTimeout(accept, 0))
+      return trigger()
     },
-    [isPriceInverted, trigger, setValue, priceInputId, priceInverseInputId],
+    [isPriceInverted, trigger, setValue, priceInverseInputId, priceInputId],
   )
 
   const { priceEstimation: fillPrice, isPriceLoading: fillPriceLoading } = usePriceEstimationWithSlippage({

--- a/src/const.ts
+++ b/src/const.ts
@@ -7,7 +7,7 @@ export {
   BATCH_TIME,
   MAX_BATCH_ID,
   FEE_PERCENTAGE,
-  DEFAULT_DECIMALS,
+  DEFAULT_DECIMALS as OLD_DEFAULT_DECIMALS,
   DEFAULT_PRECISION,
   ZERO,
   ONE,
@@ -64,7 +64,7 @@ export const HIGHLIGHT_TIME = 5000
 export const TOAST_NOTIFICATION_DURATION = 10000 // in milliseconds
 
 export const PRICE_ESTIMATION_DEBOUNCE_TIME = 200
-export const DEFAULT_DECIMAL_PLACES = 5
+export const DEFAULT_DECIMALS = 5
 // The prices on the contract will update at max once every batch, which is 5min long
 export const PRICES_CACHE_TIME = 60 // in seconds
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -64,7 +64,7 @@ export const HIGHLIGHT_TIME = 5000
 export const TOAST_NOTIFICATION_DURATION = 10000 // in milliseconds
 
 export const PRICE_ESTIMATION_DEBOUNCE_TIME = 200
-export const PRICE_ESTIMATION_PRECISION = 5
+export const DEFAULT_DECIMAL_PLACES = 5
 // The prices on the contract will update at max once every batch, which is 5min long
 export const PRICES_CACHE_TIME = 60 // in seconds
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { ONE_HUNDRED_BIG_NUMBER, BATCH_TIME_IN_MS } from 'const'
+import { ONE_HUNDRED_BIG_NUMBER, BATCH_TIME_IN_MS, DEFAULT_DECIMAL_PLACES } from 'const'
 import { batchIdToDate } from './time'
 
 export {
@@ -146,4 +146,12 @@ export function formatPercentage(percentage: BigNumber): string {
     result = displayPercentage.decimalPlaces(2, BigNumber.ROUND_FLOOR).toString(10)
   }
   return result + '%'
+}
+
+export function formatPriceWithFloor(price: BigNumber): string {
+  const LOW_PRICE_FLOOR = new BigNumber('0.0001')
+  if (!price || price.isZero()) return 'N/A'
+
+  const displayPrice = price.decimalPlaces(DEFAULT_DECIMAL_PLACES, 1).toString(10)
+  return price.gt(LOW_PRICE_FLOOR) ? displayPrice : '< ' + LOW_PRICE_FLOOR.toString(10)
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -137,13 +137,14 @@ export const formatTimeToFromBatch = (
  */
 export function formatPercentage(percentage: BigNumber): string {
   const displayPercentage = percentage.times(ONE_HUNDRED_BIG_NUMBER)
+
   let result = ''
   if (!displayPercentage.gte('0.01')) {
     result = '<0.01'
   } else if (displayPercentage.gt('99.99')) {
     result = '>99.99'
   } else {
-    result = displayPercentage.decimalPlaces(2, BigNumber.ROUND_FLOOR).toString(10)
+    result = amountToPrecisionDown(displayPercentage, 2).toString(10)
   }
   return result + '%'
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { ONE_HUNDRED_BIG_NUMBER, BATCH_TIME_IN_MS, DEFAULT_DECIMAL_PLACES } from 'const'
+import { ONE_HUNDRED_BIG_NUMBER, BATCH_TIME_IN_MS, DEFAULT_DECIMALS } from 'const'
 import { batchIdToDate } from './time'
 
 export {
@@ -197,6 +197,6 @@ export function formatPriceWithFloor(price: BigNumber): string {
   const LOW_PRICE_FLOOR = new BigNumber('0.0001')
   if (!price || price.isZero()) return 'N/A'
 
-  const displayPrice = amountToPrecisionDown(price, DEFAULT_DECIMAL_PLACES).toString(10)
+  const displayPrice = amountToPrecisionDown(price, DEFAULT_DECIMALS).toString(10)
   return price.gt(LOW_PRICE_FLOOR) ? displayPrice : '< ' + LOW_PRICE_FLOOR.toString(10)
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -148,10 +148,55 @@ export function formatPercentage(percentage: BigNumber): string {
   return result + '%'
 }
 
+/**
+ * @function formatBigNumberToPrecisionAndRoundingFactory
+ *
+ * @description sets decimal places on BigNumber amount using current ROUDING_MODE selected. Removes any extra right padded zeroes.
+ *
+ * @example
+ * // 0.437300089
+ * amountToPrecisionDown(new BigNumber("0.437300089"), 5).toString(10) // => "0.4373" Note: it removes the extra "0" padded right
+ * amountToPrecisionDown(new BigNumber("0.437300089"), 2).toString(10) // => "0.43"   Note: it does NOT round to 0.44!
+ *
+ * @param ROUNDING_MODE BigNumber.RoundingMode
+ */
+export const formatBigNumberToPrecisionAndRoundingFactory = (ROUNDING_MODE: BigNumber.RoundingMode) => (
+  amount: BigNumber,
+  precision: number,
+): BigNumber => amount.decimalPlaces(precision, ROUNDING_MODE)
+
+/**
+ * @function amountToPrecisionDown
+ *
+ * @description Rounds DOWN - see example below
+ * @param amount BigNumber amount
+ * @param precision number of decimal places to show
+ *
+ * @example
+ * // 0.437300089
+ * amountToPrecisionDown(new BigNumber("0.437300089"), 5).toString(10) // => "0.4373" Note: it removes the extra "0" padded right
+ * amountToPrecisionDown(new BigNumber("0.437300089"), 2).toString(10) // => "0.43"   Note: it does NOT round to 0.44!
+ */
+export const amountToPrecisionDown = formatBigNumberToPrecisionAndRoundingFactory(BigNumber.ROUND_DOWN)
+
+/**
+ * @function amountToPrecisionUp
+ *
+ * @description Rounds UP - see example below
+ * @param amount BigNumber amount
+ * @param precision number of decimal places to show
+ *
+ * @example
+ * // 0.437300089
+ * amountToPrecisionUp(new BigNumber("0.437300089"), 5).toString(10) // => "0.4373" Note: it removes the extra "0" padded right
+ * amountToPrecisionUp(new BigNumber("0.437300089"), 3).toString(10) // => "0.44"   Note: it DOES round to 0.44 from 0.437!
+ */
+export const amountToPrecisionUp = formatBigNumberToPrecisionAndRoundingFactory(BigNumber.ROUND_UP)
+
 export function formatPriceWithFloor(price: BigNumber): string {
   const LOW_PRICE_FLOOR = new BigNumber('0.0001')
   if (!price || price.isZero()) return 'N/A'
 
-  const displayPrice = price.decimalPlaces(DEFAULT_DECIMAL_PLACES, 1).toString(10)
+  const displayPrice = amountToPrecisionDown(price, DEFAULT_DECIMAL_PLACES).toString(10)
   return price.gt(LOW_PRICE_FLOOR) ? displayPrice : '< ' + LOW_PRICE_FLOOR.toString(10)
 }


### PR DESCRIPTION
as title states - on small amounts sometimes the warning was showing up when it shouldnt. User selects suggested `fillPrice` and warning still showed. This prevents taht