### PR TITLE
Sanitize error data

### DIFF
--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -12,14 +12,6 @@ import { isWalletConnectProvider, Provider } from './providerUtils'
 import { logDebug } from 'utils'
 import { web3 } from 'api'
 
-import {
-  addTxPendingApproval,
-  areTxsPendingApproval,
-  openWaitForTxApprovalModal,
-  removeAllTxsPendingApproval,
-  removeTxPendingApproval,
-} from 'components/OuterModal'
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const sanitizeErrorData = (jsonRpcError?: JsonRpcError<any>): void => {
   if (!jsonRpcError) return

--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -12,6 +12,23 @@ import { isWalletConnectProvider, Provider } from './providerUtils'
 import { logDebug } from 'utils'
 import { web3 } from 'api'
 
+import {
+  addTxPendingApproval,
+  areTxsPendingApproval,
+  openWaitForTxApprovalModal,
+  removeAllTxsPendingApproval,
+  removeTxPendingApproval,
+} from 'components/OuterModal'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sanitizeErrorData = (jsonRpcError?: JsonRpcError<any>): void => {
+  if (!jsonRpcError) return
+
+  if (jsonRpcError.data?.originalError) {
+    jsonRpcError.data = jsonRpcError.data.originalError.data
+  }
+}
+
 // custom providerAsMiddleware
 function providerAsMiddleware(provider: Provider): JsonRpcMiddleware {
   // WalletConnectProvider.sendAsync is web3-provider-engine.sendAsync
@@ -38,10 +55,17 @@ function providerAsMiddleware(provider: Provider): JsonRpcMiddleware {
         return
       }
 
-      provider.request(req).then((providerRes) => {
-        Object.assign(res, providerRes)
-        end()
-      }, end)
+      provider.request(req).then(
+        (providerRes) => {
+          Object.assign(res, providerRes)
+          sanitizeErrorData(res.error)
+          end()
+        },
+        (error) => {
+          sanitizeErrorData(error)
+          end(error)
+        },
+      )
     }
   }
 
@@ -54,7 +78,11 @@ function providerAsMiddleware(provider: Provider): JsonRpcMiddleware {
 
     provider[sendFName](req, (err: JsonRpcError<unknown>, providerRes: JsonRpcResponse<unknown>) => {
       // forward any error
-      if (err) return end(err)
+      if (err) {
+        sanitizeErrorData(err)
+        return end(err)
+      }
+      sanitizeErrorData(providerRes.error)
       // copy provider response onto original response
       Object.assign(res, providerRes)
       end()


### PR DESCRIPTION
Cherry-picked solution from #1614 

Intercepts the error handling, making sure the `data` field is present.

This solves an issue with web3 failing in their error handling, leaving the promises unfulfilled. 