### PR TITLE
Fix issue approving tokens

### DIFF
--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -201,10 +201,16 @@ export const composeProvider = <T extends Provider>(
         if (!txConfig) return false
 
         if (!txConfig.gas) {
-          const gasLimit = await web3.eth.estimateGas(txConfig).catch((error) => {
-            console.error('[composeProvider] Error estimating gas, probably failing transaction', txConfig)
-            throw error
-          })
+          const gasLimit = await web3.eth
+            .estimateGas({
+              from: txConfig.from,
+              gas: txConfig.gas,
+              value: txConfig.value,
+            })
+            .catch((error) => {
+              console.error('[composeProvider] Error estimating gas, probably failing transaction', txConfig)
+              throw error
+            })
           logDebug('[composeProvider] No gas Limit. Using estimation ' + gasLimit)
           txConfig.gas = numberToHex(gasLimit)
         } else {


### PR DESCRIPTION
This solves Anna's issue with approving tokens using Wallet Connect.

> TLDR: The issue, is that the estimation is failing if we provide a `gasPrice`

yes, really. I'm betting this has to do with yesterday hardfork in some way. https://www.coindesk.com/ethereums-hard-fork-disruption

So this is how we estimate. We just send the same params we would use in the tx, to the `estimateGas` function:
```js
web3.eth.estimateGas({data: "0x095ea7b30000000000000000000000006f400810b62df8e13fded51be75ff5393eaa841fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdec0de02120132", from: "0xd5cbc5e664813c7f1ce0a136aa154ce525e97e21", to: "0x6810e776880c02933d47db1b9fc05908e5386b96", gasPrice: "0xcce416bb4"}, console.log)
```

> Throws error: `react_devtools_backend.js:2450 MetaMask - RPC Error: gas required exceeds allowance (160) {code: -32000, message: "gas required exceeds allowance (160)"}`


The original params has a `priceEstimation`, so it goes with the data of the estimation too.
You would think that if the estimation don't need that info, they would ignore it. It seems is not the case! at least now, I bet it used to be and not anymore!

https://web3js.readthedocs.io/en/v1.2.0/web3-eth-contract.html#methods-mymethod-estimategas

```js
web3.eth.estimateGas({data: "0x095ea7b30000000000000000000000006f400810b62df8e13fded51be75ff5393eaa841fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdec0de02120132", from: "0xd5cbc5e664813c7f1ce0a136aa154ce525e97e21", to: "0x6810e776880c02933d47db1b9fc05908e5386b96"}, console.log)
```

> Returns: `44374`

Only difference, I removed the price estimation