### PR TITLE
Fix issue gas estimation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     'react/prop-types': [1, { skipUndeclared: true }],
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
+    '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
   },
   overrides: [
     {

--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -201,9 +201,11 @@ export const composeProvider = <T extends Provider>(
         if (!txConfig) return false
 
         if (!txConfig.gas) {
+          // Remove gasPrice from the estimation props, since they broke after last hardfork
+          //  https://github.com/gnosis/dex-react/pull/1618
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { gasPrice, ...otherProps } = txConfig
-          const gasLimit = await web3.eth.estimateGas(otherProps).catch((error) => {
+          const { gasPrice, ...txConfigEstimation } = txConfig
+          const gasLimit = await web3.eth.estimateGas(txConfigEstimation).catch((error) => {
             console.error('[composeProvider] Error estimating gas, probably failing transaction', txConfig)
             throw error
           })

--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -204,8 +204,10 @@ export const composeProvider = <T extends Provider>(
           const gasLimit = await web3.eth
             .estimateGas({
               from: txConfig.from,
+              to: txConfig.to,
               gas: txConfig.gas,
               value: txConfig.value,
+              data: txConfig.data,
             })
             .catch((error) => {
               console.error('[composeProvider] Error estimating gas, probably failing transaction', txConfig)

--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -203,7 +203,6 @@ export const composeProvider = <T extends Provider>(
         if (!txConfig.gas) {
           // Remove gasPrice from the estimation props, since they broke after last hardfork
           //  https://github.com/gnosis/dex-react/pull/1618
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { gasPrice, ...txConfigEstimation } = txConfig
           const gasLimit = await web3.eth.estimateGas(txConfigEstimation).catch((error) => {
             console.error('[composeProvider] Error estimating gas, probably failing transaction', txConfig)

--- a/src/api/wallet/composeProvider.ts
+++ b/src/api/wallet/composeProvider.ts
@@ -201,18 +201,12 @@ export const composeProvider = <T extends Provider>(
         if (!txConfig) return false
 
         if (!txConfig.gas) {
-          const gasLimit = await web3.eth
-            .estimateGas({
-              from: txConfig.from,
-              to: txConfig.to,
-              gas: txConfig.gas,
-              value: txConfig.value,
-              data: txConfig.data,
-            })
-            .catch((error) => {
-              console.error('[composeProvider] Error estimating gas, probably failing transaction', txConfig)
-              throw error
-            })
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { gasPrice, ...otherProps } = txConfig
+          const gasLimit = await web3.eth.estimateGas(otherProps).catch((error) => {
+            console.error('[composeProvider] Error estimating gas, probably failing transaction', txConfig)
+            throw error
+          })
           logDebug('[composeProvider] No gas Limit. Using estimation ' + gasLimit)
           txConfig.gas = numberToHex(gasLimit)
         } else {


### PR DESCRIPTION
Correcting what was obvious an issue, since in PR hotfix #1618 the `data` was ignored to solve an issue with the hardfork last week.  Only the fields from this method were added https://web3js.readthedocs.io/en/v1.2.0/web3-eth-contract.html#methods-mymethod-estimategas, we should have used https://web3js.readthedocs.io/en/v1.2.0/web3-eth.html?highlight=estimateGas#estimategas

Actually, the fix removes the `gasPrice` that breaks the estimation for approving tokens for Anna after last hardfork, although my understanding it should be fine to add them according to JSON-rpc spec

https://eth.wiki/json-rpc/API

![image](https://user-images.githubusercontent.com/2352112/99523850-ea249a80-2997-11eb-8cba-2fc287d0d4ce.png)

![image](https://user-images.githubusercontent.com/2352112/99523881-f4df2f80-2997-11eb-9430-3ad08c333c61.png)
