### PR TITLE
Simplify text selectors

### DIFF
--- a/playwright/integration/about.test.ts
+++ b/playwright/integration/about.test.ts
@@ -15,7 +15,7 @@ describe('About', () => {
 
     // WHEN: Click on the "About" link in the footer
     // can use css-selector + xpath syntax, with >> in-between
-    await page.click('footer >> text=About') // inside footer element with textContent='About'
+    await page.click('footer >> "About"') // inside footer element with textContent='About'
 
     // THEN: We navigate to the about page
     expect(page.url()).toContain('/about')

--- a/playwright/integration/connect_wallet.test.ts
+++ b/playwright/integration/connect_wallet.test.ts
@@ -7,13 +7,11 @@ describe('Connect Wallet', () => {
     await page.goto(baseURL)
 
     // WHEN: connected a Wallet
-    // Click text=/.*Connect Wallet.*/
-    await page.click('text=/.*Connect Wallet.*/')
-
-    await page.click('text=Web3')
+    await page.click('"Connect Wallet"')
+    await page.click('"Web3"')
 
     // WHEN: Wallet popup is open
-    await page.click('header >> text=Web3')
+    await page.click('header >> "Web3"')
 
     // THEN: wallet connected & address available
     // XPATH: closest ancestor with 0x* text of element with text "Copy address to clipboard"


### PR DESCRIPTION
I just wanted to try out what I wrote in one comment of #1625 

> Why do you use a "pattern", is not needed right? (since text selector already searches for partial text matching)
> Also, I think it's more readable the short-form

My understanding is this PR has equivalent selectors