### PR TITLE
[V2] Button sizes

### DIFF
--- a/src/components/common/Button/index.stories.tsx
+++ b/src/components/common/Button/index.stories.tsx
@@ -13,10 +13,8 @@ export default {
   decorators: [ThemeToggler],
   argTypes: {
     label: { control: 'text' },
-    kind: {
-      control: 'inline-radio',
-      options: ButtonVariations,
-    },
+    kind: { control: 'radio' },
+    size: { control: 'inline-radio' },
     as: { control: null },
     theme: { control: null },
     forwardedAs: { control: null },
@@ -68,4 +66,18 @@ DisabledButton.args = {
   label: 'Disabled Button',
   kind: ButtonVariations.disabled,
   disabled: true,
+}
+
+export const BigButton = Template.bind({})
+BigButton.args = {
+  label: 'Big Button',
+  kind: ButtonVariations.primary,
+  size: 'big',
+}
+
+export const SmolButton = Template.bind({})
+SmolButton.args = {
+  label: 'Smol Button',
+  kind: ButtonVariations.primary,
+  size: 'small',
 }

--- a/src/components/common/Button/index.stories.tsx
+++ b/src/components/common/Button/index.stories.tsx
@@ -12,8 +12,8 @@ export default {
   decorators: [ThemeToggler],
   argTypes: {
     label: { control: 'text' },
-    kind: { control: 'radio' },
-    size: { control: 'inline-radio' },
+    $type: { control: 'radio' },
+    $size: { control: 'inline-radio' },
     as: { control: null },
     theme: { control: null },
     forwardedAs: { control: null },
@@ -27,56 +27,56 @@ const Template: Story<ButtonBaseProps & { label?: string | React.ReactNode }> = 
 export const PrimaryButton = Template.bind({})
 PrimaryButton.args = {
   label: 'Main Button',
-  kind: 'default',
+  $type: 'default',
 }
 
 export const SecondaryButton = Template.bind({})
 SecondaryButton.args = {
   label: 'Secondary Button',
-  kind: 'secondary',
+  $type: 'secondary',
 }
 
 export const SuccessButton = Template.bind({})
 SuccessButton.args = {
   label: 'Success Button',
-  kind: 'success',
+  $type: 'success',
 }
 
 export const WarningButton = Template.bind({})
 WarningButton.args = {
   label: 'Warning Button',
-  kind: 'warning',
+  $type: 'warning',
 }
 
 export const DangerButton = Template.bind({})
 DangerButton.args = {
   label: 'Danger Button',
-  kind: 'danger',
+  $type: 'danger',
 }
 
 export const CancelButton = Template.bind({})
 CancelButton.args = {
   label: 'Cancel Button',
-  kind: 'cancel',
+  $type: 'cancel',
 }
 
 export const DisabledButton = Template.bind({})
 DisabledButton.args = {
   label: 'Disabled Button',
-  kind: 'disabled',
+  $type: 'disabled',
   disabled: true,
 }
 
 export const BigButton = Template.bind({})
 BigButton.args = {
   label: 'Big Button',
-  kind: 'primary',
-  size: 'big',
+  $type: 'primary',
+  $size: 'big',
 }
 
 export const SmolButton = Template.bind({})
 SmolButton.args = {
   label: 'Smol Button',
-  kind: 'primary',
-  size: 'small',
+  $type: 'primary',
+  $size: 'small',
 }

--- a/src/components/common/Button/index.stories.tsx
+++ b/src/components/common/Button/index.stories.tsx
@@ -5,7 +5,6 @@ import { Story, Meta } from '@storybook/react/types-6-0'
 import { ThemeToggler } from 'storybook/decorators'
 
 import { ButtonBase, ButtonBaseProps } from './'
-import { ButtonVariations } from 'styles/common/StyledButton'
 
 export default {
   title: 'Common/Button',
@@ -28,56 +27,56 @@ const Template: Story<ButtonBaseProps & { label?: string | React.ReactNode }> = 
 export const PrimaryButton = Template.bind({})
 PrimaryButton.args = {
   label: 'Main Button',
-  kind: ButtonVariations.default,
+  kind: 'default',
 }
 
 export const SecondaryButton = Template.bind({})
 SecondaryButton.args = {
   label: 'Secondary Button',
-  kind: ButtonVariations.secondary,
+  kind: 'secondary',
 }
 
 export const SuccessButton = Template.bind({})
 SuccessButton.args = {
   label: 'Success Button',
-  kind: ButtonVariations.success,
+  kind: 'success',
 }
 
 export const WarningButton = Template.bind({})
 WarningButton.args = {
   label: 'Warning Button',
-  kind: ButtonVariations.warning,
+  kind: 'warning',
 }
 
 export const DangerButton = Template.bind({})
 DangerButton.args = {
   label: 'Danger Button',
-  kind: ButtonVariations.danger,
+  kind: 'danger',
 }
 
 export const CancelButton = Template.bind({})
 CancelButton.args = {
   label: 'Cancel Button',
-  kind: ButtonVariations.cancel,
+  kind: 'cancel',
 }
 
 export const DisabledButton = Template.bind({})
 DisabledButton.args = {
   label: 'Disabled Button',
-  kind: ButtonVariations.disabled,
+  kind: 'disabled',
   disabled: true,
 }
 
 export const BigButton = Template.bind({})
 BigButton.args = {
   label: 'Big Button',
-  kind: ButtonVariations.primary,
+  kind: 'primary',
   size: 'big',
 }
 
 export const SmolButton = Template.bind({})
 SmolButton.args = {
   label: 'Smol Button',
-  kind: ButtonVariations.primary,
+  kind: 'primary',
   size: 'small',
 }

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 
 import styled from 'styled-components'
-import StyledButton, { ButtonVariations } from 'styles/common/StyledButton'
+import StyledButton, { ButtonVariations, ButtonSizeVariations } from 'styles/common/StyledButton'
 import styles from 'styles/styles'
 
 export interface ButtonBaseProps extends React.ButtonHTMLAttributes<Element> {
   kind?: keyof typeof ButtonVariations
+  size?: ButtonSizeVariations
 }
 
 export const ButtonBase = styled(StyledButton)<ButtonBaseProps>`

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -5,8 +5,8 @@ import StyledButton, { ButtonVariations, ButtonSizeVariations } from 'styles/com
 import styles from 'styles/styles'
 
 export interface ButtonBaseProps extends React.ButtonHTMLAttributes<Element> {
-  kind?: ButtonVariations
-  size?: ButtonSizeVariations
+  $type?: ButtonVariations
+  $size?: ButtonSizeVariations
 }
 
 export const ButtonBase = styled(StyledButton)<ButtonBaseProps>`
@@ -40,11 +40,11 @@ const ThemeButtonToggleWrapper = styled.div<{ $mode: boolean }>`
 
 export const ThemeButton: React.FC<
   ButtonBaseProps & {
-    mode: boolean
+    $mode: boolean
   }
 > = (props) => {
   return (
-    <ThemeButtonToggleWrapper $mode={props.mode}>
+    <ThemeButtonToggleWrapper $mode={props.$mode}>
       <ButtonBase {...props} />
     </ThemeButtonToggleWrapper>
   )

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -5,7 +5,7 @@ import StyledButton, { ButtonVariations, ButtonSizeVariations } from 'styles/com
 import styles from 'styles/styles'
 
 export interface ButtonBaseProps extends React.ButtonHTMLAttributes<Element> {
-  kind?: keyof typeof ButtonVariations
+  kind?: ButtonVariations
   size?: ButtonSizeVariations
 }
 

--- a/src/storybook/decorators.tsx
+++ b/src/storybook/decorators.tsx
@@ -30,7 +30,7 @@ export const ThemeToggler = (DecoratedStory: () => JSX.Element): JSX.Element => 
       <ThemeProvider theme={theme}>
         <Frame style={{ background: darkMode ? COLOURS.bgDark : COLOURS.bgLight }}>{DecoratedStory()}</Frame>
         {/* Cheeky use of ButtonBase here :P */}
-        <ThemeButton kind={ButtonVariations.theme} onClick={handleDarkMode} mode={darkMode}>
+        <ThemeButton size="small" kind={ButtonVariations.theme} onClick={handleDarkMode} mode={darkMode}>
           <FontAwesomeIcon icon={darkMode ? faSun : faMoon} />
         </ThemeButton>
         <br />

--- a/src/storybook/decorators.tsx
+++ b/src/storybook/decorators.tsx
@@ -30,7 +30,7 @@ export const ThemeToggler = (DecoratedStory: () => JSX.Element): JSX.Element => 
         <Frame style={{ background: darkMode ? COLOURS.bgDark : COLOURS.bgLight }}>{DecoratedStory()}</Frame>
         {/* Cheeky use of ButtonBase here :P */}
         <ThemeButton size="small" kind="theme" onClick={handleDarkMode} mode={darkMode}>
-          <FontAwesomeIcon icon={darkMode ? faSun : faMoon} />
+          <FontAwesomeIcon icon={darkMode ? faMoon : faSun} />
         </ThemeButton>
         <br />
         <br />

--- a/src/storybook/decorators.tsx
+++ b/src/storybook/decorators.tsx
@@ -29,7 +29,7 @@ export const ThemeToggler = (DecoratedStory: () => JSX.Element): JSX.Element => 
       <ThemeProvider theme={theme}>
         <Frame style={{ background: darkMode ? COLOURS.bgDark : COLOURS.bgLight }}>{DecoratedStory()}</Frame>
         {/* Cheeky use of ButtonBase here :P */}
-        <ThemeButton size="small" kind="theme" onClick={handleDarkMode} mode={darkMode}>
+        <ThemeButton $size="small" $type="theme" onClick={handleDarkMode} $mode={darkMode}>
           <FontAwesomeIcon icon={darkMode ? faMoon : faSun} />
         </ThemeButton>
         <br />

--- a/src/storybook/decorators.tsx
+++ b/src/storybook/decorators.tsx
@@ -15,7 +15,6 @@ import { ThemeButton } from 'components/common/Button'
 
 import COLOURS from 'styles/colours'
 import { ThemeProvider } from 'styled-components'
-import { ButtonVariations } from 'styles/common/StyledButton'
 
 export const ThemeToggler = (DecoratedStory: () => JSX.Element): JSX.Element => {
   const [darkMode, setDarkMode] = React.useState(true)
@@ -30,7 +29,7 @@ export const ThemeToggler = (DecoratedStory: () => JSX.Element): JSX.Element => 
       <ThemeProvider theme={theme}>
         <Frame style={{ background: darkMode ? COLOURS.bgDark : COLOURS.bgLight }}>{DecoratedStory()}</Frame>
         {/* Cheeky use of ButtonBase here :P */}
-        <ThemeButton size="small" kind={ButtonVariations.theme} onClick={handleDarkMode} mode={darkMode}>
+        <ThemeButton size="small" kind="theme" onClick={handleDarkMode} mode={darkMode}>
           <FontAwesomeIcon icon={darkMode ? faSun : faMoon} />
         </ThemeButton>
         <br />

--- a/src/styles/common/StyledButton.tsx
+++ b/src/styles/common/StyledButton.tsx
@@ -1,5 +1,7 @@
-import styled, { css } from 'styled-components'
-import { ThemeValue, variants } from 'styled-theming'
+import React from 'react'
+
+import styled, { css, ThemeProvider } from 'styled-components'
+import { ThemeMap, ThemeValue, variants } from 'styled-theming'
 
 import ColourSheet from '../colours'
 import StyleSheet from '../styles'
@@ -23,7 +25,12 @@ const {
   disabledLightOpaque,
 } = ColourSheet
 
-const { buttonBorder } = StyleSheet
+const { buttonBorder, buttonFontSize } = StyleSheet
+
+type AppThemes = 'dark' | 'light'
+interface ThemeMode {
+  mode: AppThemes
+}
 
 // Used in stories
 // Good to keep around altough not required
@@ -195,22 +202,41 @@ export const ButtonTheme = variants<'kind', keyof typeof ButtonVariations>('mode
   },
 })
 
-/*
-TODO: consider adding:
-  &.small {
-    font-size: 0.6rem;
-    padding: 0.3rem 0.5rem;
-  }
+// Created a 'size' prop on buttons, default | small | big
+const ButtonSizes = variants('component', 'size', {
+  default: {
+    buttons: '',
+  },
+  small: {
+    buttons: css`
+      font-size: 0.6rem;
+      padding: 0.3rem 0.5rem;
+    `,
+  },
+  big: {
+    buttons: css`
+      font-size: 1.4rem;
+      padding: 0.65rem 1rem;
+    `,
+  },
+})
 
-  &.big {
-    font-size: 1.2rem;
-    padding: 0.65rem 1rem;
-  }
-*/
-
-export default styled.button`
+const ColouredButtonBase = styled.button`
   border: ${buttonBorder};
-
   /* Fold in theme css above */
   ${ButtonTheme}
 `
+
+const ColouredAndSizedButtonBase = styled(ColouredButtonBase)`
+  font-size: ${buttonFontSize};
+  ${ButtonSizes}
+`
+// Wrap ColouredAndSizedButtonsBase in it's own ThemeProvider which takes the toplevel app theme
+// ThemeProvider and interpolate over it's props
+const ThemedButtonBase: React.FC<React.ButtonHTMLAttributes<Element>> = (props) => (
+  <ThemeProvider theme={({ mode }: ThemeMode): ThemeMap => ({ mode, component: 'buttons' })}>
+    <ColouredAndSizedButtonBase {...props} />
+  </ThemeProvider>
+)
+
+export default ThemedButtonBase

--- a/src/styles/common/StyledButton.tsx
+++ b/src/styles/common/StyledButton.tsx
@@ -46,6 +46,8 @@ export enum ButtonVariations {
   theme = 'theme',
 }
 
+export type ButtonSizeVariations = 'default' | 'small' | 'big'
+
 // Create our variated Button Theme
 // 'kind' refers to a prop on button
 // <ButtonBase kind="danger" />

--- a/src/styles/common/StyledButton.tsx
+++ b/src/styles/common/StyledButton.tsx
@@ -50,7 +50,7 @@ export type ButtonSizeVariations = 'default' | 'small' | 'big'
 // Create our variated Button Theme
 // 'kind' refers to a prop on button
 // <ButtonBase kind="danger" />
-export const ButtonTheme = variants<'kind', ButtonVariations>('mode', 'kind', {
+export const ButtonTheme = variants<'$type', ButtonVariations>('mode', '$type', {
   default: {
     light: css`
       color: ${white};
@@ -204,7 +204,7 @@ export const ButtonTheme = variants<'kind', ButtonVariations>('mode', 'kind', {
 })
 
 // Created a 'size' prop on buttons, default | small | big
-const ButtonSizes = variants('component', 'size', {
+const ButtonSizes = variants('component', '$size', {
   default: {
     buttons: '',
   },

--- a/src/styles/common/StyledButton.tsx
+++ b/src/styles/common/StyledButton.tsx
@@ -34,24 +34,23 @@ interface ThemeMode {
 
 // Used in stories
 // Good to keep around altough not required
-export enum ButtonVariations {
-  default = 'default',
-  primary = 'primary',
-  secondary = 'secondary',
-  danger = 'danger',
-  success = 'success',
-  warning = 'warning',
-  cancel = 'cancel',
-  disabled = 'disabled',
-  theme = 'theme',
-}
+export type ButtonVariations =
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'danger'
+  | 'success'
+  | 'warning'
+  | 'cancel'
+  | 'disabled'
+  | 'theme'
 
 export type ButtonSizeVariations = 'default' | 'small' | 'big'
 
 // Create our variated Button Theme
 // 'kind' refers to a prop on button
 // <ButtonBase kind="danger" />
-export const ButtonTheme = variants<'kind', keyof typeof ButtonVariations>('mode', 'kind', {
+export const ButtonTheme = variants<'kind', ButtonVariations>('mode', 'kind', {
   default: {
     light: css`
       color: ${white};

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -1,4 +1,5 @@
 export default {
   buttonBorder: '0.1rem solid transparent',
   borderRadius: '1.6rem',
+  buttonFontSize: '1rem',
 }


### PR DESCRIPTION
:droplet: into #1632

Adds theme capabilities for creating sized versions of buttons and creates a `ThemeProvider` wrapped Button default export

See stories BIG and SMOL to test