### PR TITLE
Fix search by address in /wallet

### DIFF
--- a/src/components/DepositWidget/index.tsx
+++ b/src/components/DepositWidget/index.tsx
@@ -32,6 +32,7 @@ import useDataFilter from 'hooks/useDataFilter'
 // Reducer/Actions
 import { TokenLocalState } from 'reducers-actions'
 import { useWalletConnection } from 'hooks/useWalletConnection'
+import { web3 } from 'api'
 
 interface WithdrawState {
   amount: BN
@@ -227,7 +228,9 @@ interface BalanceDisplayProps extends TokenLocalState {
 const customFilterFnFactory = (searchTxt: string) => (token: TokenBalanceDetails): boolean => {
   if (searchTxt === '') return true
 
-  return checkTokenAgainstSearch(token, searchTxt)
+  const searchIsAddress = web3.utils.isAddress(searchTxt)
+
+  return checkTokenAgainstSearch(token, searchTxt, searchIsAddress)
 }
 
 const customHideZeroFilterFn = ({


### PR DESCRIPTION
While fixing `TokenAdder` I noticed you can't search by address in `/wallet` page

Try to input `0xdAC17F958D2ee523a2206206994597C13D831ec7` at https://dex.dev.gnosisdev.com/wallet
You should get `USDT` but get nothing

![dex dev gnosisdev com_wallet](https://user-images.githubusercontent.com/5121491/99983787-58fd5b80-2dbd-11eb-969c-5332e4fc1fe9.png)
