### PR TITLE
Add WBTC to xDAI default list

### DIFF
--- a/config-default.yaml
+++ b/config-default.yaml
@@ -250,6 +250,7 @@ initialTokenList:
     decimals: 8
     addressByNetwork:
       '1': '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'
+      '100': '0x8e5bbbb09ed1ebde8674cda39a0c169401db4252'
 
   - id: 13
     name: Compound Dai


### PR DESCRIPTION
Adds WBTC to xDAI default list


TEST: 
* Validate the address is correct
* You can try to make an order for buying or selling WBTC