### PR TITLE
Add timeout for fetching tokens

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -21,6 +21,7 @@ import { Network } from 'types'
 import { DisabledTokensMaps, TokenOverride, AddressToOverrideMap } from 'types/config'
 
 export const BATCH_TIME_IN_MS = BATCH_TIME * 1000
+export const DEFAULT_TIMEOUT = 5000
 
 export const ZERO_BIG_NUMBER = new BigNumber(0)
 export const ONE_BIG_NUMBER = new BigNumber(1)

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -72,7 +72,8 @@ export function getToken<T extends TokenDetails, K extends keyof T>(
   return token
 }
 
-export const delay = <T>(ms = 100, result?: T): Promise<T> => new Promise((resolve) => setTimeout(resolve, ms, result))
+export const delay = <T = void>(ms = 100, result?: T): Promise<T> =>
+  new Promise((resolve) => setTimeout(resolve, ms, result))
 
 /**
  * Uses images from https://github.com/trustwallet/tokens
@@ -217,15 +218,14 @@ export interface TimeoutParams<T> {
   timeoutErrorMsg?: string
 }
 
-export function timeout<T>(params: TimeoutParams<T>): Promise<T> {
+export function timeout(params: TimeoutParams<undefined>): Promise<never> // never means function throws
+export function timeout<T>(params: TimeoutParams<T extends undefined ? never : T>): Promise<T>
+export async function timeout<T>(params: TimeoutParams<T>): Promise<T | never> {
   const { time = DEFAULT_TIMEOUT, result, timeoutErrorMsg: timeoutMsg = 'Timeout' } = params
-  return new Promise((resolve, rejects) =>
-    setTimeout(() => {
-      if (result) {
-        resolve(result)
-      } else {
-        rejects(new Error(timeoutMsg))
-      }
-    }, time),
-  )
+
+  await delay(time)
+  // provided defined result -- return it
+  if (result !== undefined) return result
+  // no defined result -- throw message
+  throw new Error(timeoutMsg)
 }

--- a/src/utils/miscellaneous.ts
+++ b/src/utils/miscellaneous.ts
@@ -5,7 +5,7 @@ import { TokenDetails, Unpromise } from 'types'
 import { AssertionError } from 'assert'
 import { AuctionElement, Trade, Order } from 'api/exchange/ExchangeApi'
 import { batchIdToDate } from './time'
-import { ORDER_FILLED_FACTOR, MINIMUM_ALLOWANCE_DECIMALS } from 'const'
+import { ORDER_FILLED_FACTOR, MINIMUM_ALLOWANCE_DECIMALS, DEFAULT_TIMEOUT } from 'const'
 import { TEN, ZERO } from '@gnosis.pm/dex-js'
 
 export function assertNonNull<T>(val: T, message: string): asserts val is NonNullable<T> {
@@ -210,3 +210,22 @@ export function notEmpty<TValue>(value: TValue | null | undefined): value is TVa
 }
 
 export const isNonZeroNumber = (value?: string | number): boolean => !!value && !!+value
+
+export interface TimeoutParams<T> {
+  time?: number
+  result?: T
+  timeoutErrorMsg?: string
+}
+
+export function timeout<T>(params: TimeoutParams<T>): Promise<T> {
+  const { time = DEFAULT_TIMEOUT, result, timeoutErrorMsg: timeoutMsg = 'Timeout' } = params
+  return new Promise((resolve, rejects) =>
+    setTimeout(() => {
+      if (result) {
+        resolve(result)
+      } else {
+        rejects(new Error(timeoutMsg))
+      }
+    }, time),
+  )
+}


### PR DESCRIPTION
We've observed in two occasions now that some Metamask fails to resolve some promise for contract calls. First with the issue of SNX/sUSD proxy deprecation, yesterday with Ledger MM (not it seems it doesn't do that anymore).

When this happens, we neither get a success or an error.

Currently, if for one token, the promise is not resolved, the overall "fetch all balances" promise don't resolve either (uses `Promise.all`)

This PR introduces a timeout for fetching individual tokens for this extreme cases. It uses 10s, maybe it could be less. But theoretically promises should resolve one way or the other! 